### PR TITLE
Adjust authentication card layout

### DIFF
--- a/frontend/src/features/auth/LoginPage.jsx
+++ b/frontend/src/features/auth/LoginPage.jsx
@@ -33,50 +33,52 @@ export default function LoginPage() {
   };
 
   return (
-    <div className="auth-card" role="form">
-      <div>
-        <h2>Welcome back to Onkur</h2>
+    <div className="auth-page">
+      <div className="auth-card" role="form">
+        <div>
+          <h2>Welcome back to Onkur</h2>
+          <p style={{ margin: 0, color: 'var(--muted-text)' }}>
+            Reconnect with the community and track the impact you are creating.
+          </p>
+        </div>
+        <form onSubmit={handleSubmit} className="auth-form">
+          <div className="form-field">
+            <label htmlFor="email">Email</label>
+            <input
+              id="email"
+              name="email"
+              type="email"
+              autoComplete="email"
+              required
+              value={values.email}
+              onChange={handleChange}
+              placeholder="you@example.org"
+            />
+          </div>
+          <div className="form-field">
+            <label htmlFor="password">Password</label>
+            <input
+              id="password"
+              name="password"
+              type="password"
+              autoComplete="current-password"
+              required
+              value={values.password}
+              onChange={handleChange}
+              placeholder="••••••••"
+            />
+          </div>
+          <div className="form-actions">
+            {error ? <p className="form-error">{error}</p> : null}
+            <button type="submit" className="btn-primary" disabled={submitting}>
+              {submitting ? 'Signing you in…' : 'Log in'}
+            </button>
+          </div>
+        </form>
         <p style={{ margin: 0, color: 'var(--muted-text)' }}>
-          Reconnect with the community and track the impact you are creating.
+          New to Onkur? <Link to="/signup">Create an account</Link>
         </p>
       </div>
-      <form onSubmit={handleSubmit} className="auth-form">
-        <div className="form-field">
-          <label htmlFor="email">Email</label>
-          <input
-            id="email"
-            name="email"
-            type="email"
-            autoComplete="email"
-            required
-            value={values.email}
-            onChange={handleChange}
-            placeholder="you@example.org"
-          />
-        </div>
-        <div className="form-field">
-          <label htmlFor="password">Password</label>
-          <input
-            id="password"
-            name="password"
-            type="password"
-            autoComplete="current-password"
-            required
-            value={values.password}
-            onChange={handleChange}
-            placeholder="••••••••"
-          />
-        </div>
-        <div className="form-actions">
-          {error ? <p className="form-error">{error}</p> : null}
-          <button type="submit" className="btn-primary" disabled={submitting}>
-            {submitting ? 'Signing you in…' : 'Log in'}
-          </button>
-        </div>
-      </form>
-      <p style={{ margin: 0, color: 'var(--muted-text)' }}>
-        New to Onkur? <Link to="/signup">Create an account</Link>
-      </p>
     </div>
   );
 }

--- a/frontend/src/features/auth/SignupPage.jsx
+++ b/frontend/src/features/auth/SignupPage.jsx
@@ -34,64 +34,66 @@ export default function SignupPage() {
   };
 
   return (
-    <div className="auth-card" role="form">
-      <div>
-        <h2>Join the Onkur movement</h2>
+    <div className="auth-page">
+      <div className="auth-card" role="form">
+        <div>
+          <h2>Join the Onkur movement</h2>
+          <p style={{ margin: 0, color: 'var(--muted-text)' }}>
+            Create an account to discover events, earn eco-badges, and follow your impact story.
+          </p>
+        </div>
+        <form onSubmit={handleSubmit} className="auth-form">
+          <div className="form-field">
+            <label htmlFor="name">Full name</label>
+            <input
+              id="name"
+              name="name"
+              type="text"
+              autoComplete="name"
+              required
+              value={values.name}
+              onChange={handleChange}
+              placeholder="Aanya Patel"
+            />
+          </div>
+          <div className="form-field">
+            <label htmlFor="email">Email</label>
+            <input
+              id="email"
+              name="email"
+              type="email"
+              autoComplete="email"
+              required
+              value={values.email}
+              onChange={handleChange}
+              placeholder="you@example.org"
+            />
+          </div>
+          <div className="form-field">
+            <label htmlFor="password">Password</label>
+            <input
+              id="password"
+              name="password"
+              type="password"
+              autoComplete="new-password"
+              required
+              value={values.password}
+              onChange={handleChange}
+              placeholder="At least 8 characters"
+              minLength={8}
+            />
+          </div>
+          <div className="form-actions">
+            {error ? <p className="form-error">{error}</p> : null}
+            <button type="submit" className="btn-primary" disabled={submitting}>
+              {submitting ? 'Creating your account…' : 'Sign up'}
+            </button>
+          </div>
+        </form>
         <p style={{ margin: 0, color: 'var(--muted-text)' }}>
-          Create an account to discover events, earn eco-badges, and follow your impact story.
+          Already have an account? <Link to="/login">Log in</Link>
         </p>
       </div>
-      <form onSubmit={handleSubmit} className="auth-form">
-        <div className="form-field">
-          <label htmlFor="name">Full name</label>
-          <input
-            id="name"
-            name="name"
-            type="text"
-            autoComplete="name"
-            required
-            value={values.name}
-            onChange={handleChange}
-            placeholder="Aanya Patel"
-          />
-        </div>
-        <div className="form-field">
-          <label htmlFor="email">Email</label>
-          <input
-            id="email"
-            name="email"
-            type="email"
-            autoComplete="email"
-            required
-            value={values.email}
-            onChange={handleChange}
-            placeholder="you@example.org"
-          />
-        </div>
-        <div className="form-field">
-          <label htmlFor="password">Password</label>
-          <input
-            id="password"
-            name="password"
-            type="password"
-            autoComplete="new-password"
-            required
-            value={values.password}
-            onChange={handleChange}
-            placeholder="At least 8 characters"
-            minLength={8}
-          />
-        </div>
-        <div className="form-actions">
-          {error ? <p className="form-error">{error}</p> : null}
-          <button type="submit" className="btn-primary" disabled={submitting}>
-            {submitting ? 'Creating your account…' : 'Sign up'}
-          </button>
-        </div>
-      </form>
-      <p style={{ margin: 0, color: 'var(--muted-text)' }}>
-        Already have an account? <Link to="/login">Log in</Link>
-      </p>
     </div>
   );
 }

--- a/frontend/src/styles/theme.css
+++ b/frontend/src/styles/theme.css
@@ -221,6 +221,16 @@ button {
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
+  width: min(100%, 440px);
+  margin: 2.5rem auto 3rem;
+}
+
+.auth-page {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 0 0.75rem;
 }
 
 .auth-card h2 {
@@ -416,7 +426,12 @@ button {
   }
 
   .auth-card {
-    padding: 2.5rem 2.25rem;
+    padding: 2.75rem 2.5rem;
+    margin: 4rem auto 5rem;
+  }
+
+  .auth-page {
+    padding: 0 1.5rem;
   }
 
   .dashboard-grid {


### PR DESCRIPTION
## Summary
- wrap the login and signup pages with a shared `auth-page` container so the forms stay centered
- constrain the auth card width and adjust responsive spacing to better match the new design guidance

## Testing
- npm run 