### PR TITLE
Make header brand link home and adjust nav spacing

### DIFF
--- a/frontend/src/features/layout/AppLayout.jsx
+++ b/frontend/src/features/layout/AppLayout.jsx
@@ -56,10 +56,14 @@ export default function AppLayout({ children }) {
     <div className="app-shell">
       <header className="app-header">
         <div className="app-header__top">
-          <div className="app-header__brand">
-            <h1>Onkur</h1>
-            <p>{headerSubtitle}</p>
-          </div>
+        <div className="app-header__brand">
+          <h1>
+            <Link to="/" className="app-header__brand-link" aria-label="Go to the Onkur home page">
+              Onkur
+            </Link>
+          </h1>
+          <p>{headerSubtitle}</p>
+        </div>
           {user ? (
             <div className="app-header__meta">
               <span>{user.name}</span>

--- a/frontend/src/styles/theme.css
+++ b/frontend/src/styles/theme.css
@@ -78,6 +78,24 @@ button {
   letter-spacing: 0.02em;
 }
 
+.app-header__brand-link {
+  color: inherit;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  text-decoration: none;
+}
+
+.app-header__brand-link:hover {
+  text-decoration: none;
+}
+
+.app-header__brand-link:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.85);
+  outline-offset: 4px;
+  border-radius: var(--radius-sm);
+}
+
 .app-header__brand p {
   margin: 0.25rem 0 0;
   font-size: 0.95rem;
@@ -96,6 +114,7 @@ button {
   display: flex;
   align-items: center;
   gap: 0.75rem;
+  padding-top: 0.5rem;
   margin-left: auto;
 }
 


### PR DESCRIPTION
## Summary
- turn the Onkur header title into an accessible link back to the landing page
- add styling for the header link to keep branding visuals and focus treatment consistent
- provide top padding to the header action buttons so the sign-in and sign-up controls have breathing room

## Testing
- npm run build
