### PR TITLE
Add email verification and transactional email support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Onkur is a mobile-first volunteering platform rooted in sustainability and community. Phase 1 lays the technical backbone: secure authentication, role-aware access, and a responsive shell that welcomes every stakeholder.
 
 ## ✨ Phase 1 highlights
-- Email + password signup/login backed by JWTs and server-side token revocation.
+- Email + password signup/login backed by JWTs, email verification, and server-side token revocation.
 - Role-based dashboards for Volunteers, Event Managers, Sponsors, and Admins.
 - Admin console to assign roles and browse the community directory.
 - Earthy, mobile-first UI with a sticky bottom nav, verdant header, and warm onboarding copy.
@@ -30,6 +30,8 @@ Dive into the [product wiki](docs/wiki/README.md) for full design notes, API det
    - `DATABASE_URL` – Postgres connection string.
    - `JWT_SECRET`, `JWT_EXPIRY`, `JWT_ISSUER` – JWT signing + expiry configuration.
    - `BCRYPT_SALT_ROUNDS` – bcrypt cost factor (defaults to 12).
+   - `APP_BASE_URL` – canonical frontend URL used in transactional emails.
+   - `EMAIL_FROM`, `EMAIL_SMTP_HOST`, `EMAIL_SMTP_PORT`, `EMAIL_SMTP_SECURE`, `EMAIL_SMTP_USER`, `EMAIL_SMTP_PASS` – SMTP settings for outbound email.
    - `CORS_ORIGIN`, `PORT`, `LOG_LEVEL`, `LOG_FILE` – server + logging controls.
    - `MINIO_*` – optional object storage wiring from the base template.
 3. (Optional) verify connectivity

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -4,6 +4,17 @@ CORS_ORIGIN=http://localhost:1010
 LOG_LEVEL=info
 LOG_FILE=logs/onkur.log
 
+# App URLs
+APP_BASE_URL=http://localhost:1010
+
+# Email
+EMAIL_FROM="Onkur <no-reply@onkur.org>"
+EMAIL_SMTP_HOST=smtp.example.com
+EMAIL_SMTP_PORT=587
+EMAIL_SMTP_SECURE=false
+EMAIL_SMTP_USER=onkur
+EMAIL_SMTP_PASS=super-secret
+
 # Database
 DATABASE_URL=postgres://sayabasu:%211Dilbert@192.168.1.3:5432/onkur_db
 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -16,6 +16,7 @@
         "jsonwebtoken": "^9.0.2",
         "minio": "^8.0.6",
         "multer": "^2.0.2",
+        "nodemailer": "^6.10.1",
         "pg": "^8.16.3",
         "winston": "^3.17.0"
       },
@@ -4240,6 +4241,15 @@
       "integrity": "sha512-5b0pgg78U3hwXkCM8Z9b2FJdPZlr9Psr9V2gQPESdGHqbntyFJKFW4r5TeWGFzafGY3hzs1JC62VEQMbl1JFkw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/nodemon": {
       "version": "3.1.10",

--- a/backend/package.json
+++ b/backend/package.json
@@ -23,6 +23,7 @@
     "jsonwebtoken": "^9.0.2",
     "minio": "^8.0.6",
     "multer": "^2.0.2",
+    "nodemailer": "^6.10.1",
     "pg": "^8.16.3",
     "winston": "^3.17.0"
   },

--- a/backend/src/config/index.js
+++ b/backend/src/config/index.js
@@ -9,6 +9,9 @@ const config = {
   logLevel: process.env.LOG_LEVEL || "info",
   logFile: process.env.LOG_FILE || "",
   databaseUrl: process.env.DATABASE_URL,
+  app: {
+    baseUrl: process.env.APP_BASE_URL || process.env.CORS_ORIGIN || "http://localhost:3000",
+  },
   jwt: {
     secret: process.env.JWT_SECRET,
     expiry: process.env.JWT_EXPIRY || "1h",
@@ -16,6 +19,14 @@ const config = {
   },
   bcrypt: {
     saltRounds: parseInt(process.env.BCRYPT_SALT_ROUNDS || "12", 10),
+  },
+  email: {
+    from: process.env.EMAIL_FROM || "Onkur <no-reply@onkur.org>",
+    smtpHost: process.env.EMAIL_SMTP_HOST,
+    smtpPort: process.env.EMAIL_SMTP_PORT ? parseInt(process.env.EMAIL_SMTP_PORT, 10) : 587,
+    smtpSecure: process.env.EMAIL_SMTP_SECURE === "true",
+    smtpUser: process.env.EMAIL_SMTP_USER,
+    smtpPass: process.env.EMAIL_SMTP_PASS,
   },
   minio: {
     endPoint: process.env.MINIO_ENDPOINT,

--- a/backend/src/features/auth/auth.repository.js
+++ b/backend/src/features/auth/auth.repository.js
@@ -14,8 +14,14 @@ const schemaPromise = (async () => {
       email_normalized TEXT NOT NULL UNIQUE,
       password_hash TEXT NOT NULL,
       role TEXT NOT NULL CHECK (role = ANY(ARRAY[${roleCheckArray}]::TEXT[])),
-      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      email_verified_at TIMESTAMPTZ NULL
     )
+  `);
+
+  await pool.query(`
+    ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS email_verified_at TIMESTAMPTZ NULL
   `);
 
   await pool.query(`
@@ -37,6 +43,17 @@ const schemaPromise = (async () => {
   `);
 
   await pool.query(`
+    CREATE TABLE IF NOT EXISTS email_verification_tokens (
+      id UUID PRIMARY KEY,
+      user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      token TEXT NOT NULL UNIQUE,
+      expires_at TIMESTAMPTZ NOT NULL,
+      used_at TIMESTAMPTZ NULL,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `);
+
+  await pool.query(`
     CREATE INDEX IF NOT EXISTS idx_users_email_normalized ON users (email_normalized)
   `);
 
@@ -46,6 +63,10 @@ const schemaPromise = (async () => {
 
   await pool.query(`
     CREATE INDEX IF NOT EXISTS idx_revoked_tokens_expires_at ON revoked_tokens (expires_at)
+  `);
+
+  await pool.query(`
+    CREATE INDEX IF NOT EXISTS idx_email_verification_tokens_user ON email_verification_tokens (user_id)
   `);
 })();
 
@@ -62,7 +83,7 @@ async function createUser({ name, email, passwordHash, role }) {
     `
       INSERT INTO users (id, name, email, email_normalized, password_hash, role)
       VALUES ($1, $2, $3, $4, $5, $6)
-      RETURNING id, name, email, role, created_at
+      RETURNING id, name, email, role, created_at, email_verified_at
     `,
     [id, name, email, normalizedEmail, passwordHash, role]
   );
@@ -74,7 +95,7 @@ async function findUserByEmail(email) {
   await ensureSchema();
   const normalizedEmail = email.toLowerCase();
   const result = await pool.query(
-    `SELECT id, name, email, email_normalized, password_hash, role, created_at FROM users WHERE email_normalized = $1`,
+    `SELECT id, name, email, email_normalized, password_hash, role, created_at, email_verified_at FROM users WHERE email_normalized = $1`,
     [normalizedEmail]
   );
   return result.rows[0] || null;
@@ -83,7 +104,7 @@ async function findUserByEmail(email) {
 async function findUserById(id) {
   await ensureSchema();
   const result = await pool.query(
-    `SELECT id, name, email, email_normalized, password_hash, role, created_at FROM users WHERE id = $1`,
+    `SELECT id, name, email, email_normalized, password_hash, role, created_at, email_verified_at FROM users WHERE id = $1`,
     [id]
   );
   return result.rows[0] || null;
@@ -92,7 +113,7 @@ async function findUserById(id) {
 async function listUsers() {
   await ensureSchema();
   const result = await pool.query(
-    `SELECT id, name, email, role, created_at FROM users ORDER BY created_at DESC`
+    `SELECT id, name, email, role, created_at, email_verified_at FROM users ORDER BY created_at DESC`
   );
   return result.rows;
 }
@@ -104,7 +125,7 @@ async function updateUserRole({ userId, role }) {
       UPDATE users
       SET role = $2
       WHERE id = $1
-      RETURNING id, name, email, role, created_at
+      RETURNING id, name, email, role, created_at, email_verified_at
     `,
     [userId, role]
   );
@@ -155,6 +176,83 @@ async function pruneExpiredTokens() {
   }
 }
 
+async function createEmailVerificationToken({ userId, expiresInMinutes }) {
+  await ensureSchema();
+  const id = randomUUID();
+  const token = randomUUID().replace(/-/g, '');
+  const expiresAt = new Date(Date.now() + expiresInMinutes * 60 * 1000);
+
+  await pool.query(`DELETE FROM email_verification_tokens WHERE user_id = $1 AND used_at IS NULL`, [userId]);
+
+  const result = await pool.query(
+    `
+      INSERT INTO email_verification_tokens (id, user_id, token, expires_at)
+      VALUES ($1, $2, $3, $4)
+      RETURNING id, token, expires_at
+    `,
+    [id, userId, token, expiresAt]
+  );
+
+  return result.rows[0];
+}
+
+async function findEmailVerificationToken(token) {
+  await ensureSchema();
+  const result = await pool.query(
+    `
+      SELECT id, user_id, token, expires_at, used_at
+      FROM email_verification_tokens
+      WHERE token = $1
+    `,
+    [token]
+  );
+  return result.rows[0] || null;
+}
+
+async function markVerificationTokenUsed({ tokenId }) {
+  await ensureSchema();
+  await pool.query(
+    `
+      UPDATE email_verification_tokens
+      SET used_at = NOW()
+      WHERE id = $1
+    `,
+    [tokenId]
+  );
+}
+
+async function deleteVerificationTokensForUser({ userId, exceptTokenId = null }) {
+  await ensureSchema();
+  if (exceptTokenId) {
+    await pool.query(
+      `
+        DELETE FROM email_verification_tokens
+        WHERE user_id = $1 AND id <> $2
+      `,
+      [userId, exceptTokenId]
+    );
+  } else {
+    await pool.query(
+      `DELETE FROM email_verification_tokens WHERE user_id = $1`,
+      [userId]
+    );
+  }
+}
+
+async function markEmailVerified({ userId }) {
+  await ensureSchema();
+  const result = await pool.query(
+    `
+      UPDATE users
+      SET email_verified_at = COALESCE(email_verified_at, NOW())
+      WHERE id = $1
+      RETURNING id, name, email, email_normalized, password_hash, role, created_at, email_verified_at
+    `,
+    [userId]
+  );
+  return result.rows[0] || null;
+}
+
 module.exports = {
   createUser,
   findUserByEmail,
@@ -165,4 +263,9 @@ module.exports = {
   revokeToken,
   isTokenRevoked,
   pruneExpiredTokens,
+  createEmailVerificationToken,
+  findEmailVerificationToken,
+  markVerificationTokenUsed,
+  deleteVerificationTokensForUser,
+  markEmailVerified,
 };

--- a/backend/src/features/auth/auth.route.js
+++ b/backend/src/features/auth/auth.route.js
@@ -1,5 +1,14 @@
 const express = require('express');
-const { signup, login, logout, getProfile, listAllUsers, assignRole, ROLES } = require('./auth.service');
+const {
+  signup,
+  login,
+  logout,
+  getProfile,
+  listAllUsers,
+  assignRole,
+  verifyEmail,
+  ROLES,
+} = require('./auth.service');
 const { authenticate, authorizeRoles } = require('./auth.middleware');
 
 const router = express.Router();
@@ -20,7 +29,18 @@ router.post('/api/auth/signup', async (req, res) => {
   try {
     const { name, email, password } = req.body || {};
     const result = await signup({ name, email, password });
-    res.status(201).json(sanitizeAuthResponse(result));
+    res.status(201).json(result);
+  } catch (error) {
+    const status = error.statusCode || 500;
+    res.status(status).json({ error: error.message });
+  }
+});
+
+router.post('/api/auth/verify-email', async (req, res) => {
+  try {
+    const { token } = req.body || {};
+    const result = await verifyEmail({ token });
+    res.status(200).json(result);
   } catch (error) {
     const status = error.statusCode || 500;
     res.status(status).json({ error: error.message });

--- a/backend/src/features/auth/email.service.js
+++ b/backend/src/features/auth/email.service.js
@@ -1,14 +1,58 @@
-const logger = require('../../utils/logger');
+const { sendTemplatedEmail } = require('../email/email.service');
+const config = require('../../config');
+
+function buildVerifyUrl(token) {
+  const baseUrl = (config.app && config.app.baseUrl) || config.corsOrigin || 'http://localhost:3000';
+  const normalized = baseUrl.replace(/\/$/, '');
+  return `${normalized}/verify-email?token=${encodeURIComponent(token)}`;
+}
+
+async function sendVerificationEmail({ to, name, token, expiresAt }) {
+  const verifyUrl = buildVerifyUrl(token);
+  await sendTemplatedEmail({
+    to,
+    subject: 'Verify your email for Onkur',
+    heading: 'Confirm your Onkur email address',
+    previewText: 'Tap to verify your Onkur account and start creating impact.',
+    bodyLines: [
+      `Hi ${name || 'there'},`,
+      'Thanks for joining Onkur! Please confirm your email so we can keep your impact journey secure.',
+      expiresAt
+        ? `This link will expire on ${new Date(expiresAt).toLocaleString(undefined, {
+            month: 'short',
+            day: 'numeric',
+            year: 'numeric',
+            hour: '2-digit',
+            minute: '2-digit',
+          })}.`
+        : 'This link will expire soon for your security.',
+    ],
+    cta: {
+      label: 'Verify email',
+      url: verifyUrl,
+    },
+  });
+}
 
 async function sendWelcomeEmail({ to, name }) {
-  logger.info('Queued welcome email', {
+  await sendTemplatedEmail({
     to,
     subject: 'Welcome to Onkur',
-    template: 'welcome',
-    name,
+    heading: 'You are all set! 🌿',
+    previewText: 'Thank you for verifying your Onkur account.',
+    bodyLines: [
+      `Hi ${name || 'there'},`,
+      'Your email is verified and you are ready to explore events, earn eco-badges, and track your community impact.',
+      'Log in to find an event that speaks to you and start cultivating change.',
+    ],
+    cta: {
+      label: 'Log in to Onkur',
+      url: `${((config.app && config.app.baseUrl) || config.corsOrigin || 'http://localhost:3000').replace(/\/$/, '')}/login`,
+    },
   });
 }
 
 module.exports = {
+  sendVerificationEmail,
   sendWelcomeEmail,
 };

--- a/backend/src/features/email/email.service.js
+++ b/backend/src/features/email/email.service.js
@@ -1,0 +1,142 @@
+const nodemailer = require('nodemailer');
+const logger = require('../../utils/logger');
+const config = require('../../config');
+
+let transporter;
+let transportInitialized = false;
+
+function resolveTransporter() {
+  if (transportInitialized) {
+    return transporter;
+  }
+
+  transportInitialized = true;
+  const { smtpHost, smtpPort, smtpSecure, smtpUser, smtpPass } = config.email || {};
+
+  if (!smtpHost) {
+    logger.warn('Email transport is not configured. Outbound messages will be skipped.');
+    transporter = null;
+    return transporter;
+  }
+
+  const transportOptions = {
+    host: smtpHost,
+    port: smtpPort,
+    secure: Boolean(smtpSecure),
+  };
+
+  if (smtpUser && smtpPass) {
+    transportOptions.auth = {
+      user: smtpUser,
+      pass: smtpPass,
+    };
+  }
+
+  transporter = nodemailer.createTransport(transportOptions);
+  return transporter;
+}
+
+function renderStandardTemplate({ heading, bodyLines = [], cta, previewText }) {
+  const safeBody = Array.isArray(bodyLines) ? bodyLines : [String(bodyLines || '')];
+  const bodyHtml = safeBody
+    .map((line) => `<p style="margin: 0 0 16px; font-size: 16px; line-height: 24px; color: #1f2937;">${line}</p>`)
+    .join('');
+
+  const ctaHtml = cta && cta.url && cta.label
+    ? `<p style="margin: 24px 0; text-align: center;"><a href="${cta.url}" style="display: inline-block; padding: 12px 24px; background: #2F855A; color: #ffffff; text-decoration: none; border-radius: 9999px; font-weight: 600;">${cta.label}</a></p>`
+    : '';
+
+  const html = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>${heading}</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  </head>
+  <body style="margin: 0; padding: 0; background: #f7faf5; font-family: 'Inter', 'Segoe UI', sans-serif;">
+    <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="background: #f7faf5; padding: 32px 0;">
+      <tr>
+        <td align="center">
+          <table role="presentation" cellpadding="0" cellspacing="0" width="600" style="max-width: 600px; background: #ffffff; border-radius: 16px; box-shadow: 0 18px 40px rgba(47, 133, 90, 0.18); overflow: hidden;">
+            <tr>
+              <td style="background: #2F855A; padding: 28px 32px; color: #ffffff;">
+                <h1 style="margin: 0; font-size: 24px; font-weight: 600; letter-spacing: 0.02em;">Onkur</h1>
+                <p style="margin: 8px 0 0; font-size: 14px; opacity: 0.85;">Rooted in nature. Built for community action.</p>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding: 32px;">
+                <h2 style="margin: 0 0 16px; font-size: 22px; color: #2F855A;">${heading}</h2>
+                ${bodyHtml}
+                ${ctaHtml}
+                <p style="margin: 32px 0 0; font-size: 14px; color: #6b7280;">With gratitude,<br />The Onkur team</p>
+              </td>
+            </tr>
+            <tr>
+              <td style="background: #f7faf5; padding: 20px 32px; text-align: center; font-size: 12px; color: #9ca3af;">
+                You are receiving this email because you created an account on Onkur.
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>`;
+
+  const textParts = [heading, '', ...safeBody];
+  if (cta && cta.url && cta.label) {
+    textParts.push('', `${cta.label}: ${cta.url}`);
+  }
+  textParts.push('', 'With gratitude,', 'The Onkur team');
+  const text = textParts.join('\n');
+
+  return { html, text, previewText: previewText || heading };
+}
+
+async function sendEmail({ to, subject, html, text, headers = {} }) {
+  const transport = resolveTransporter();
+  const from = (config.email && config.email.from) || 'Onkur <no-reply@onkur.org>';
+
+  if (!transport) {
+    logger.info('Email send skipped because transport is not configured', { to, subject });
+    return null;
+  }
+
+  const payload = {
+    from,
+    to,
+    subject,
+    html,
+    text,
+    headers,
+  };
+
+  try {
+    const info = await transport.sendMail(payload);
+    logger.info('Email dispatched', {
+      to,
+      subject,
+      messageId: info.messageId,
+    });
+    return info;
+  } catch (error) {
+    logger.error('Failed to send email', {
+      to,
+      subject,
+      error: error.message,
+    });
+    throw error;
+  }
+}
+
+async function sendTemplatedEmail({ to, subject, heading, bodyLines, cta, previewText, headers }) {
+  const template = renderStandardTemplate({ heading, bodyLines, cta, previewText });
+  return sendEmail({ to, subject, html: template.html, text: template.text, headers });
+}
+
+module.exports = {
+  sendEmail,
+  sendTemplatedEmail,
+  renderStandardTemplate,
+};

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,6 +2,7 @@ import { Navigate, Route, Routes } from 'react-router-dom';
 import AppLayout from './features/layout/AppLayout';
 import LoginPage from './features/auth/LoginPage';
 import SignupPage from './features/auth/SignupPage';
+import VerifyEmailPage from './features/auth/VerifyEmailPage';
 import ProtectedRoute from './features/auth/ProtectedRoute';
 import PublicOnlyRoute from './features/auth/PublicOnlyRoute';
 import DashboardRouter from './features/dashboard/DashboardRouter';
@@ -36,6 +37,7 @@ function App() {
             </PublicOnlyRoute>
           }
         />
+        <Route path="/verify-email" element={<VerifyEmailPage />} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
     </AppLayout>

--- a/frontend/src/features/auth/AuthContext.jsx
+++ b/frontend/src/features/auth/AuthContext.jsx
@@ -111,17 +111,13 @@ export function AuthProvider({ children }) {
     [setAuthenticated]
   );
 
-  const signup = useCallback(
-    async ({ name, email, password }) => {
-      const result = await apiRequest('/api/auth/signup', {
-        method: 'POST',
-        body: { name, email, password },
-      });
-      setAuthenticated(result);
-      return result.user;
-    },
-    [setAuthenticated]
-  );
+  const signup = useCallback(async ({ name, email, password }) => {
+    const result = await apiRequest('/api/auth/signup', {
+      method: 'POST',
+      body: { name, email, password },
+    });
+    return result;
+  }, []);
 
   const logout = useCallback(async () => {
     if (auth.token) {

--- a/frontend/src/features/auth/SignupPage.jsx
+++ b/frontend/src/features/auth/SignupPage.jsx
@@ -6,12 +6,14 @@ const initialState = {
   name: '',
   email: '',
   password: '',
+  confirmPassword: '',
 };
 
 export default function SignupPage() {
   const { signup } = useAuth();
   const [values, setValues] = useState(initialState);
   const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
   const [submitting, setSubmitting] = useState(false);
 
   const handleChange = (event) => {
@@ -23,9 +25,22 @@ export default function SignupPage() {
     event.preventDefault();
     setSubmitting(true);
     setError('');
+    setSuccess('');
+
+    if (values.password !== values.confirmPassword) {
+      setError('Passwords do not match.');
+      setSubmitting(false);
+      return;
+    }
 
     try {
-      await signup(values);
+      const { message } = await signup({
+        name: values.name,
+        email: values.email,
+        password: values.password,
+      });
+      setValues(initialState);
+      setSuccess(message || 'Account created. Check your inbox to verify your email.');
     } catch (err) {
       setError(err.message || 'We could not create your account.');
     } finally {
@@ -95,8 +110,26 @@ export default function SignupPage() {
               className="w-full rounded-md border border-brand-green/40 bg-white/90 px-3 py-3 text-base shadow-sm transition focus:border-brand-green focus:outline-none focus:ring-2 focus:ring-brand-green/40"
             />
           </div>
+          <div className="space-y-2">
+            <label className="text-sm font-semibold text-brand-muted" htmlFor="confirmPassword">
+              Re-enter password
+            </label>
+            <input
+              id="confirmPassword"
+              name="confirmPassword"
+              type="password"
+              autoComplete="new-password"
+              required
+              value={values.confirmPassword}
+              onChange={handleChange}
+              placeholder="Confirm your password"
+              minLength={8}
+              className="w-full rounded-md border border-brand-green/40 bg-white/90 px-3 py-3 text-base shadow-sm transition focus:border-brand-green focus:outline-none focus:ring-2 focus:ring-brand-green/40"
+            />
+          </div>
           <div className="space-y-3 pt-2">
             {error ? <p className="text-sm font-medium text-red-600">{error}</p> : null}
+            {success ? <p className="text-sm font-medium text-brand-green">{success}</p> : null}
             <button
               type="submit"
               className="inline-flex w-full items-center justify-center rounded-md bg-brand-yellow px-4 py-2.5 text-base font-semibold text-brand-brown shadow-[0_6px_12px_rgba(236,201,75,0.3)] transition hover:-translate-y-0.5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-green/50 disabled:cursor-not-allowed disabled:opacity-70"

--- a/frontend/src/features/auth/VerifyEmailPage.jsx
+++ b/frontend/src/features/auth/VerifyEmailPage.jsx
@@ -1,0 +1,79 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
+import { apiRequest } from '../../lib/apiClient';
+
+export default function VerifyEmailPage() {
+  const [searchParams] = useSearchParams();
+  const token = useMemo(() => searchParams.get('token'), [searchParams]);
+  const [status, setStatus] = useState(token ? 'pending' : 'missing');
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    let isMounted = true;
+    if (!token) {
+      setStatus('missing');
+      setMessage('We could not find a verification token. Please use the link from your email.');
+      return () => {
+        isMounted = false;
+      };
+    }
+
+    (async () => {
+      try {
+        setStatus('pending');
+        const response = await apiRequest('/api/auth/verify-email', {
+          method: 'POST',
+          body: { token },
+        });
+        if (!isMounted) return;
+        setStatus('success');
+        setMessage(response.message || 'Your email has been verified. You can now log in.');
+      } catch (error) {
+        if (!isMounted) return;
+        setStatus('error');
+        setMessage(error.message || 'We could not verify your email.');
+      }
+    })();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [token]);
+
+  const heading = useMemo(() => {
+    if (status === 'success') return 'Email verified!';
+    if (status === 'error') return 'Verification failed';
+    if (status === 'missing') return 'Verification link missing';
+    return 'Verifying your email…';
+  }, [status]);
+
+  return (
+    <div className="flex w-full justify-center px-4 pb-16 pt-10 sm:pt-14">
+      <div className="w-full max-w-md rounded-[20px] bg-white p-6 text-center shadow-[0_16px_40px_rgba(47,133,90,0.15)] sm:p-8">
+        <h2 className="font-display text-2xl font-semibold text-brand-green">{heading}</h2>
+        <p className="mt-3 text-sm text-brand-muted sm:text-base">{message}</p>
+        {status === 'success' ? (
+          <div className="mt-6 space-y-3">
+            <Link
+              to="/login"
+              className="inline-flex w-full items-center justify-center rounded-md bg-brand-yellow px-4 py-2.5 text-base font-semibold text-brand-brown shadow-[0_6px_12px_rgba(236,201,75,0.3)] transition hover:-translate-y-0.5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-green/50"
+            >
+              Go to login
+            </Link>
+          </div>
+        ) : null}
+        {status === 'error' || status === 'missing' ? (
+          <div className="mt-6 space-y-2 text-sm text-brand-muted">
+            <p>
+              Need a new link? Try signing in to request another verification email or{' '}
+              <a className="text-brand-green underline" href="mailto:support@onkur.org">
+                contact support
+              </a>
+              .
+            </p>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/layout/AppLayout.jsx
+++ b/frontend/src/features/layout/AppLayout.jsx
@@ -34,6 +34,8 @@ export default function AppLayout({ children }) {
       title = 'Sign in | Onkur';
     } else if (path.startsWith('/signup')) {
       title = 'Join Onkur | Mobile-first volunteering';
+    } else if (path.startsWith('/verify-email')) {
+      title = 'Verify email | Onkur';
     } else if (path.startsWith('/app')) {
       if (user?.role) {
         title = `${formatRole(user.role)} Dashboard | Onkur`;


### PR DESCRIPTION
## Summary
- introduce a reusable email service with a branded HTML template and SMTP configuration knobs
- require email verification during signup, extend auth persistence, and add coverage to the auth service tests
- update the frontend signup experience with confirm-password validation, verification messaging, and a public verify-email route while documenting the new flow

## Testing
- npm test (backend)
- npm run build (frontend)
