### PR TITLE
Align document titles across pages

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>PERN Frontend</title>
+    <title>Onkur</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/features/auth/LoginPage.jsx
+++ b/frontend/src/features/auth/LoginPage.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
+import useDocumentTitle from '../../lib/useDocumentTitle';
 import { useAuth } from './AuthContext';
 
 const initialState = {
@@ -12,6 +13,7 @@ export default function LoginPage() {
   const [values, setValues] = useState(initialState);
   const [error, setError] = useState('');
   const [submitting, setSubmitting] = useState(false);
+  useDocumentTitle('Onkur | Welcome back to Onkur');
 
   const handleChange = (event) => {
     const { name, value } = event.target;

--- a/frontend/src/features/auth/SignupPage.jsx
+++ b/frontend/src/features/auth/SignupPage.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
+import useDocumentTitle from '../../lib/useDocumentTitle';
 import { useAuth } from './AuthContext';
 
 const initialState = {
@@ -15,6 +16,7 @@ export default function SignupPage() {
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
   const [submitting, setSubmitting] = useState(false);
+  useDocumentTitle('Onkur | Join the Onkur movement');
 
   const handleChange = (event) => {
     const { name, value } = event.target;

--- a/frontend/src/features/auth/VerifyEmailPage.jsx
+++ b/frontend/src/features/auth/VerifyEmailPage.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { apiRequest } from '../../lib/apiClient';
+import useDocumentTitle from '../../lib/useDocumentTitle';
 
 export default function VerifyEmailPage() {
   const [searchParams] = useSearchParams();
@@ -46,6 +47,8 @@ export default function VerifyEmailPage() {
     if (status === 'missing') return 'Verification link missing';
     return 'Verifying your email…';
   }, [status]);
+
+  useDocumentTitle(`Onkur | ${heading}`);
 
   return (
     <div className="flex w-full justify-center px-4 pb-16 pt-10 sm:pt-14">

--- a/frontend/src/features/dashboard/AdminDashboard.jsx
+++ b/frontend/src/features/dashboard/AdminDashboard.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import DashboardCard from './DashboardCard';
 import { useAuth } from '../auth/AuthContext';
+import useDocumentTitle from '../../lib/useDocumentTitle';
 
 function formatRole(role) {
   return role
@@ -17,6 +18,7 @@ export default function AdminDashboard() {
   const [form, setForm] = useState({ userId: '', role: '' });
   const [message, setMessage] = useState('');
   const [error, setError] = useState('');
+  useDocumentTitle('Onkur | Operations center 🌿');
 
   useEffect(() => {
     let active = true;

--- a/frontend/src/features/dashboard/EventManagerDashboard.jsx
+++ b/frontend/src/features/dashboard/EventManagerDashboard.jsx
@@ -1,14 +1,17 @@
 import DashboardCard from './DashboardCard';
 import { useAuth } from '../auth/AuthContext';
+import useDocumentTitle from '../../lib/useDocumentTitle';
 
 export default function EventManagerDashboard() {
   const { user } = useAuth();
+  const firstName = user?.name?.split(' ')[0] || 'manager';
+  useDocumentTitle(`Onkur | Welcome back, ${firstName} 🌱`);
 
   return (
     <div className="grid gap-5 md:[grid-template-columns:repeat(auto-fit,minmax(280px,1fr))]">
       <header className="flex flex-col gap-2 md:col-span-full">
         <h2 className="m-0 font-display text-2xl font-semibold text-brand-forest">
-          Welcome back, {user?.name?.split(' ')[0] || 'manager'} 🌱
+          Welcome back, {firstName} 🌱
         </h2>
         <p className="m-0 text-sm text-brand-muted sm:text-base">
           Plan meaningful experiences, assign volunteer crews, and showcase impact with visual storytelling.

--- a/frontend/src/features/dashboard/SponsorDashboard.jsx
+++ b/frontend/src/features/dashboard/SponsorDashboard.jsx
@@ -1,14 +1,17 @@
 import DashboardCard from './DashboardCard';
 import { useAuth } from '../auth/AuthContext';
+import useDocumentTitle from '../../lib/useDocumentTitle';
 
 export default function SponsorDashboard() {
   const { user } = useAuth();
+  const firstName = user?.name?.split(' ')[0] || 'sponsor';
+  useDocumentTitle(`Onkur | Thank you, ${firstName} 🌍`);
 
   return (
     <div className="grid gap-5 md:[grid-template-columns:repeat(auto-fit,minmax(280px,1fr))]">
       <header className="flex flex-col gap-2 md:col-span-full">
         <h2 className="m-0 font-display text-2xl font-semibold text-brand-forest">
-          Thank you, {user?.name?.split(' ')[0] || 'sponsor'} 🌍
+          Thank you, {firstName} 🌍
         </h2>
         <p className="m-0 text-sm text-brand-muted sm:text-base">
           Track the visibility of your contributions and stay close to the stories your support makes possible.

--- a/frontend/src/features/dashboard/VolunteerDashboard.jsx
+++ b/frontend/src/features/dashboard/VolunteerDashboard.jsx
@@ -1,14 +1,17 @@
 import DashboardCard from './DashboardCard';
 import { useAuth } from '../auth/AuthContext';
+import useDocumentTitle from '../../lib/useDocumentTitle';
 
 export default function VolunteerDashboard() {
   const { user } = useAuth();
+  const firstName = user?.name?.split(' ')[0] || 'volunteer';
+  useDocumentTitle(`Onkur | Hi ${firstName} 👋`);
 
   return (
     <div className="grid gap-5 md:[grid-template-columns:repeat(auto-fit,minmax(280px,1fr))]">
       <header className="flex flex-col gap-2 md:col-span-full">
         <h2 className="m-0 font-display text-2xl font-semibold text-brand-forest">
-          Hi {user?.name?.split(' ')[0] || 'volunteer'} 👋
+          Hi {firstName} 👋
         </h2>
         <p className="m-0 text-sm text-brand-muted sm:text-base">
           Your dashboard keeps track of upcoming events, logged hours, and the eco-badges you earn while supporting community

--- a/frontend/src/features/landing/HomePage.jsx
+++ b/frontend/src/features/landing/HomePage.jsx
@@ -1,4 +1,5 @@
 import { Link, Navigate } from 'react-router-dom';
+import useDocumentTitle from '../../lib/useDocumentTitle';
 import { useAuth } from '../auth/AuthContext';
 
 const HIGHLIGHTS = [
@@ -57,6 +58,7 @@ const IMPACT_STATS = [
 
 export default function HomePage() {
   const { isAuthenticated } = useAuth();
+  useDocumentTitle('Onkur | Nature · Sustainability · Community');
 
   if (isAuthenticated) {
     return <Navigate to="/app" replace />;

--- a/frontend/src/features/layout/AppLayout.jsx
+++ b/frontend/src/features/layout/AppLayout.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react';
+import { useMemo } from 'react';
 
 import { Link, useLocation } from 'react-router-dom';
 import { useAuth } from '../auth/AuthContext';
@@ -23,29 +23,6 @@ export default function AppLayout({ children }) {
     }
     return 'Cultivate impact through every event, pledge, and story.';
   }, [isAuthenticated]);
-
-  useEffect(() => {
-    const path = location.pathname;
-    let title = 'Onkur';
-
-    if (path === '/') {
-      title = 'Onkur | Nature · Sustainability · Community';
-    } else if (path.startsWith('/login')) {
-      title = 'Sign in | Onkur';
-    } else if (path.startsWith('/signup')) {
-      title = 'Join Onkur | Mobile-first volunteering';
-    } else if (path.startsWith('/verify-email')) {
-      title = 'Verify email | Onkur';
-    } else if (path.startsWith('/app')) {
-      if (user?.role) {
-        title = `${formatRole(user.role)} Dashboard | Onkur`;
-      } else {
-        title = 'Onkur Dashboard';
-      }
-    }
-
-    document.title = title;
-  }, [location.pathname, user]);
 
   const activeNav = useMemo(() => {
     if (location.pathname.startsWith('/gallery')) return 'gallery';

--- a/frontend/src/lib/useDocumentTitle.js
+++ b/frontend/src/lib/useDocumentTitle.js
@@ -1,0 +1,31 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * Updates the browser tab title while the component is mounted.
+ *
+ * @param {string} title - The full title to display in the document tab.
+ */
+export default function useDocumentTitle(title) {
+  const previousTitleRef = useRef(typeof document !== 'undefined' ? document.title : undefined);
+
+  useEffect(() => {
+    if (typeof document === 'undefined' || !title) {
+      return undefined;
+    }
+
+    const previous = document.title;
+    document.title = title;
+
+    return () => {
+      document.title = previous;
+    };
+  }, [title]);
+
+  useEffect(() => {
+    return () => {
+      if (typeof document !== 'undefined' && previousTitleRef.current !== undefined) {
+        document.title = previousTitleRef.current;
+      }
+    };
+  }, []);
+}


### PR DESCRIPTION
## Summary
- add a reusable `useDocumentTitle` hook for setting browser tab titles
- update the home, auth, and dashboard views to assign `Onkur | …` titles that match their page headings
- remove the layout-level title switch so each page owns its document title formatting

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb0d684100833384f613685f4548c5