### PR TITLE
Add backend Docker ignore to prevent node_modules copy

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+npm-debug.log
+Dockerfile
+.git
+.gitignore


### PR DESCRIPTION
## Summary
- add a backend-specific .dockerignore to prevent local node_modules and git metadata from being copied into the image build context

## Testing
- not run (docker-compose reproducibility fix)
