### PR TITLE
Stop overriding backend app directory in compose

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+npm-debug.log
+Dockerfile
+.git
+.gitignore

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,9 +5,6 @@ services:
       - ./backend/.env
     ports:
       - "1011:5000"
-    volumes:
-      - ./backend:/app
-      - backend_node_modules:/app/node_modules
     restart: unless-stopped
   frontend:
     build: ./frontend
@@ -16,5 +13,3 @@ services:
     ports:
       - "1010:5173"
     restart: unless-stopped
-volumes:
-  backend_node_modules:


### PR DESCRIPTION
## Summary
- update the backend service in docker-compose to rely on the image filesystem instead of bind-mounting the host source directory
- allow the container to keep the dependencies installed during `npm install` so modules like nodemailer remain available at runtime

## Testing
- `docker compose config` *(fails in CI environment: command not found)*
