### PR TITLE
Implement volunteer journey end-to-end flow

### DIFF
--- a/backend/src/features/volunteer-journey/AGENTS.md
+++ b/backend/src/features/volunteer-journey/AGENTS.md
@@ -1,0 +1,10 @@
+# Volunteer Journey Feature Guidelines
+
+These instructions apply to files within `backend/src/features/volunteer-journey/`.
+
+- Keep data-access logic inside `volunteerJourney.repository.js`; service files should orchestrate validation, domain rules, and messaging.
+- Reuse helpers for array sanitization so profile fields remain lowercase-trimmed without duplicates.
+- When adding new badge thresholds, update both the badge catalogue in the service and the volunteer wiki documentation.
+- Ensure new queries remain friendly to the in-memory `pg-mem` test harness (avoid Postgres-only syntax outside common SQL).
+- Keep reminder scheduler changes behind the `NODE_ENV!=='test'` guard. When adjusting intervals, ensure timers call `unref()` s
+  o background jobs do not block Node process shutdown.

--- a/backend/src/features/volunteer-journey/volunteerJourney.repository.js
+++ b/backend/src/features/volunteer-journey/volunteerJourney.repository.js
@@ -1,0 +1,486 @@
+const { randomUUID } = require('crypto');
+const pool = require('../common/db');
+
+const schemaPromise = (async () => {
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS volunteer_profiles (
+      user_id UUID PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+      skills TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+      interests TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+      availability TEXT NULL,
+      location TEXT NULL,
+      bio TEXT NULL,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `);
+
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS events (
+      id UUID PRIMARY KEY,
+      title TEXT NOT NULL,
+      description TEXT NOT NULL,
+      category TEXT NOT NULL,
+      theme TEXT NULL,
+      date_start TIMESTAMPTZ NOT NULL,
+      date_end TIMESTAMPTZ NOT NULL,
+      location TEXT NOT NULL,
+      capacity INTEGER NOT NULL CHECK (capacity > 0),
+      status TEXT NOT NULL CHECK (status = ANY(ARRAY['draft','published','cancelled']::TEXT[])),
+      created_by UUID NULL REFERENCES users(id) ON DELETE SET NULL,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `);
+
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS event_signups (
+      id UUID PRIMARY KEY,
+      event_id UUID NOT NULL REFERENCES events(id) ON DELETE CASCADE,
+      user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      status TEXT NOT NULL DEFAULT 'CONFIRMED',
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      reminder_sent_at TIMESTAMPTZ NULL,
+      UNIQUE(event_id, user_id)
+    )
+  `);
+
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS volunteer_hours (
+      id UUID PRIMARY KEY,
+      user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      event_id UUID NULL REFERENCES events(id) ON DELETE SET NULL,
+      minutes INTEGER NOT NULL CHECK (minutes > 0),
+      note TEXT NULL,
+      verified_by UUID NULL REFERENCES users(id) ON DELETE SET NULL,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `);
+
+  await pool.query(`
+    CREATE INDEX IF NOT EXISTS idx_events_status_date ON events (status, date_start)
+  `);
+
+  await pool.query(`
+    CREATE INDEX IF NOT EXISTS idx_event_signups_event ON event_signups (event_id)
+  `);
+
+  await pool.query(`
+    CREATE INDEX IF NOT EXISTS idx_event_signups_user ON event_signups (user_id)
+  `);
+
+  await pool.query(`
+    CREATE INDEX IF NOT EXISTS idx_volunteer_hours_user ON volunteer_hours (user_id)
+  `);
+})();
+
+async function ensureSchema() {
+  await schemaPromise;
+}
+
+async function getVolunteerProfile(userId) {
+  await ensureSchema();
+  const result = await pool.query(
+    `
+      SELECT user_id, skills, interests, availability, location, bio, created_at, updated_at
+      FROM volunteer_profiles
+      WHERE user_id = $1
+    `,
+    [userId]
+  );
+  return result.rows[0] || null;
+}
+
+async function upsertVolunteerProfile({ userId, skills, interests, availability, location, bio }) {
+  await ensureSchema();
+  const result = await pool.query(
+    `
+      INSERT INTO volunteer_profiles (user_id, skills, interests, availability, location, bio, updated_at)
+      VALUES ($1, $2, $3, $4, $5, $6, NOW())
+      ON CONFLICT (user_id)
+      DO UPDATE SET
+        skills = EXCLUDED.skills,
+        interests = EXCLUDED.interests,
+        availability = EXCLUDED.availability,
+        location = EXCLUDED.location,
+        bio = EXCLUDED.bio,
+        updated_at = NOW()
+      RETURNING user_id, skills, interests, availability, location, bio, created_at, updated_at
+    `,
+    [userId, skills, interests, availability, location, bio]
+  );
+  return result.rows[0];
+}
+
+async function listPublishedEvents({ category, location, theme, date }, { forUserId = null } = {}) {
+  await ensureSchema();
+  const conditions = ["e.status = 'published'"];
+  const values = [];
+
+  if (category) {
+    values.push(category);
+    conditions.push(`LOWER(e.category) = LOWER($${values.length})`);
+  }
+
+  if (location) {
+    values.push(`%${location.toLowerCase()}%`);
+    conditions.push(`LOWER(e.location) LIKE $${values.length}`);
+  }
+
+  if (theme) {
+    values.push(theme);
+    conditions.push(`LOWER(e.theme) = LOWER($${values.length})`);
+  }
+
+  if (date) {
+    values.push(date);
+    const index = values.length;
+    conditions.push(`DATE(e.date_start) <= $${index}`);
+    conditions.push(`DATE(e.date_end) >= $${index}`);
+  }
+
+  const whereClause = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
+
+  const query = `
+    SELECT
+      e.id,
+      e.title,
+      e.description,
+      e.category,
+      e.theme,
+      e.date_start,
+      e.date_end,
+      e.location,
+      e.capacity,
+      e.status,
+      e.created_at,
+      e.updated_at,
+      COALESCE(sc.signup_count, 0) AS signup_count
+    FROM events e
+    LEFT JOIN (
+      SELECT event_id, COUNT(*)::INT AS signup_count
+      FROM event_signups
+      GROUP BY event_id
+    ) sc ON sc.event_id = e.id
+    ${whereClause}
+    ORDER BY e.date_start ASC
+  `;
+
+  const result = await pool.query(query, values);
+  const events = result.rows;
+
+  let registeredIds = new Set();
+  if (forUserId) {
+    const signupRes = await pool.query(
+      `SELECT event_id FROM event_signups WHERE user_id = $1`,
+      [forUserId]
+    );
+    registeredIds = new Set(signupRes.rows.map((row) => row.event_id));
+  }
+
+  return events.map((event) => ({
+    ...event,
+    signup_count: Number(event.signup_count || 0),
+    available_slots: Math.max(event.capacity - Number(event.signup_count || 0), 0),
+    is_registered: registeredIds.has(event.id),
+  }));
+}
+
+async function findEventById(eventId) {
+  await ensureSchema();
+  const result = await pool.query(
+    `
+      SELECT
+        e.id,
+        e.title,
+        e.description,
+        e.category,
+        e.theme,
+        e.date_start,
+        e.date_end,
+        e.location,
+        e.capacity,
+        e.status,
+        e.created_at,
+        e.updated_at,
+        COALESCE(sc.signup_count, 0) AS signup_count
+      FROM events e
+      LEFT JOIN (
+        SELECT event_id, COUNT(*)::INT AS signup_count
+        FROM event_signups
+        GROUP BY event_id
+      ) sc ON sc.event_id = e.id
+      WHERE e.id = $1
+    `,
+    [eventId]
+  );
+  if (!result.rows[0]) {
+    return null;
+  }
+  const row = result.rows[0];
+  return {
+    ...row,
+    signup_count: Number(row.signup_count || 0),
+    available_slots: Math.max(row.capacity - Number(row.signup_count || 0), 0),
+  };
+}
+
+async function createEventSignup({ eventId, userId }) {
+  await ensureSchema();
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+
+    const eventResult = await client.query(
+      `
+        SELECT id, title, date_start, date_end, location, capacity, status
+        FROM events
+        WHERE id = $1
+        FOR UPDATE
+      `,
+      [eventId]
+    );
+
+    const event = eventResult.rows[0];
+    if (!event) {
+      throw Object.assign(new Error('Event not found'), { statusCode: 404 });
+    }
+
+    if (event.status !== 'published') {
+      throw Object.assign(new Error('Event is not open for registration'), { statusCode: 400 });
+    }
+
+    const existing = await client.query(
+      `SELECT id FROM event_signups WHERE event_id = $1 AND user_id = $2`,
+      [eventId, userId]
+    );
+    if (existing.rows[0]) {
+      throw Object.assign(new Error('You are already registered for this event'), { statusCode: 409 });
+    }
+
+    const countResult = await client.query(
+      `SELECT COUNT(*)::INT AS count FROM event_signups WHERE event_id = $1`,
+      [eventId]
+    );
+    const currentCount = Number(countResult.rows[0]?.count || 0);
+    if (currentCount >= event.capacity) {
+      throw Object.assign(new Error('Event capacity has been reached'), { statusCode: 409 });
+    }
+
+    const signupId = randomUUID();
+    const signupResult = await client.query(
+      `
+        INSERT INTO event_signups (id, event_id, user_id)
+        VALUES ($1, $2, $3)
+        RETURNING id, event_id, user_id, status, created_at
+      `,
+      [signupId, eventId, userId]
+    );
+
+    await client.query('COMMIT');
+    return { event, signup: signupResult.rows[0] };
+  } catch (error) {
+    await client.query('ROLLBACK');
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+async function hasSignup({ userId, eventId }) {
+  await ensureSchema();
+  const result = await pool.query(
+    `SELECT 1 FROM event_signups WHERE user_id = $1 AND event_id = $2`,
+    [userId, eventId]
+  );
+  return Boolean(result.rowCount);
+}
+
+async function listSignupsForUser(userId) {
+  await ensureSchema();
+  const result = await pool.query(
+    `
+      SELECT
+        es.id,
+        es.status,
+        es.created_at,
+        es.event_id,
+        es.reminder_sent_at,
+        e.title,
+        e.description,
+        e.category,
+        e.theme,
+        e.date_start,
+        e.date_end,
+        e.location,
+        e.capacity,
+        COALESCE(sc.signup_count, 0) AS signup_count
+      FROM event_signups es
+      JOIN events e ON e.id = es.event_id
+      LEFT JOIN (
+        SELECT event_id, COUNT(*)::INT AS signup_count
+        FROM event_signups
+        GROUP BY event_id
+      ) sc ON sc.event_id = e.id
+      WHERE es.user_id = $1
+      ORDER BY e.date_start ASC
+    `,
+    [userId]
+  );
+
+  return result.rows.map((row) => ({
+    ...row,
+    signup_count: Number(row.signup_count || 0),
+    available_slots: Math.max(row.capacity - Number(row.signup_count || 0), 0),
+  }));
+}
+
+async function logVolunteerHours({ userId, eventId, minutes, note, verifiedBy = null }) {
+  await ensureSchema();
+  const id = randomUUID();
+  const result = await pool.query(
+    `
+      INSERT INTO volunteer_hours (id, user_id, event_id, minutes, note, verified_by)
+      VALUES ($1, $2, $3, $4, $5, $6)
+      RETURNING id, user_id, event_id, minutes, note, verified_by, created_at
+    `,
+    [id, userId, eventId, minutes, note || null, verifiedBy]
+  );
+  return result.rows[0];
+}
+
+async function listVolunteerHours(userId) {
+  await ensureSchema();
+  const result = await pool.query(
+    `
+      SELECT
+        vh.id,
+        vh.user_id,
+        vh.event_id,
+        vh.minutes,
+        vh.note,
+        vh.verified_by,
+        vh.created_at,
+        e.title AS event_title,
+        e.date_start AS event_date_start,
+        e.date_end AS event_date_end
+      FROM volunteer_hours vh
+      LEFT JOIN events e ON e.id = vh.event_id
+      WHERE vh.user_id = $1
+      ORDER BY vh.created_at DESC
+    `,
+    [userId]
+  );
+  return result.rows;
+}
+
+async function getTotalMinutesForUser(userId) {
+  await ensureSchema();
+  const result = await pool.query(
+    `SELECT COALESCE(SUM(minutes), 0)::INT AS total_minutes FROM volunteer_hours WHERE user_id = $1`,
+    [userId]
+  );
+  return Number(result.rows[0]?.total_minutes || 0);
+}
+
+async function findSignupsNeedingReminder() {
+  await ensureSchema();
+  const result = await pool.query(`
+    SELECT
+      es.id,
+      es.user_id,
+      es.event_id,
+      es.reminder_sent_at,
+      u.email,
+      u.name,
+      e.title,
+      e.date_start,
+      e.date_end,
+      e.location
+    FROM event_signups es
+    JOIN events e ON e.id = es.event_id
+    JOIN users u ON u.id = es.user_id
+    WHERE es.reminder_sent_at IS NULL
+      AND e.status = 'published'
+      AND e.date_start > NOW()
+      AND e.date_start <= NOW() + INTERVAL '24 hours'
+      AND e.date_start - INTERVAL '24 hours' <= NOW()
+  `);
+  return result.rows;
+}
+
+async function markReminderSent(signupId) {
+  await ensureSchema();
+  await pool.query(
+    `UPDATE event_signups SET reminder_sent_at = NOW() WHERE id = $1`,
+    [signupId]
+  );
+}
+
+async function getUpcomingEventsForUser(userId) {
+  await ensureSchema();
+  const result = await pool.query(
+    `
+      SELECT
+        e.id,
+        e.title,
+        e.date_start,
+        e.date_end,
+        e.location,
+        e.theme,
+        e.category,
+        es.created_at AS signup_created_at
+      FROM event_signups es
+      JOIN events e ON e.id = es.event_id
+      WHERE es.user_id = $1
+        AND e.date_end >= NOW()
+      ORDER BY e.date_start ASC
+      LIMIT 10
+    `,
+    [userId]
+  );
+  return result.rows;
+}
+
+async function getPastEventsForUser(userId) {
+  await ensureSchema();
+  const result = await pool.query(
+    `
+      SELECT
+        e.id,
+        e.title,
+        e.date_start,
+        e.date_end,
+        e.location,
+        e.theme,
+        e.category,
+        es.created_at AS signup_created_at
+      FROM event_signups es
+      JOIN events e ON e.id = es.event_id
+      WHERE es.user_id = $1
+        AND e.date_end < NOW()
+      ORDER BY e.date_end DESC
+      LIMIT 10
+    `,
+    [userId]
+  );
+  return result.rows;
+}
+
+module.exports = {
+  ensureSchema,
+  getVolunteerProfile,
+  upsertVolunteerProfile,
+  listPublishedEvents,
+  findEventById,
+  createEventSignup,
+  hasSignup,
+  listSignupsForUser,
+  logVolunteerHours,
+  listVolunteerHours,
+  getTotalMinutesForUser,
+  findSignupsNeedingReminder,
+  markReminderSent,
+  getUpcomingEventsForUser,
+  getPastEventsForUser,
+};

--- a/backend/src/features/volunteer-journey/volunteerJourney.route.js
+++ b/backend/src/features/volunteer-journey/volunteerJourney.route.js
@@ -1,0 +1,156 @@
+const express = require('express');
+const { authenticate } = require('../auth/auth.middleware');
+const {
+  getProfile,
+  updateProfile,
+  browseEvents,
+  signupForEvent,
+  listMySignups,
+  recordVolunteerHours,
+  getVolunteerHours,
+  getVolunteerDashboard,
+  startReminderScheduler,
+} = require('./volunteerJourney.service');
+
+const router = express.Router();
+const authOnly = authenticate();
+const uuidPattern = /^[0-9a-fA-F-]{36}$/;
+
+function parseFilters(query = {}) {
+  const filters = {};
+  const { category, location, theme, date } = query;
+
+  if (category && String(category).trim()) {
+    filters.category = String(category).trim();
+  }
+
+  if (location && String(location).trim()) {
+    filters.location = String(location).trim();
+  }
+
+  if (theme && String(theme).trim()) {
+    filters.theme = String(theme).trim();
+  }
+
+  if (date && String(date).trim()) {
+    const normalized = String(date).trim();
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(normalized)) {
+      throw Object.assign(new Error('Date filter must use YYYY-MM-DD format'), { statusCode: 400 });
+    }
+    filters.date = normalized;
+  }
+
+  return filters;
+}
+
+router.get('/api/me/profile', authOnly, async (req, res) => {
+  try {
+    const profile = await getProfile(req.user.id);
+    res.json(profile);
+  } catch (error) {
+    const status = error.statusCode || 500;
+    res.status(status).json({ error: error.message });
+  }
+});
+
+router.put('/api/me/profile', authOnly, async (req, res) => {
+  try {
+    const { skills, interests, availability, location, bio } = req.body || {};
+    const updated = await updateProfile({
+      userId: req.user.id,
+      skills,
+      interests,
+      availability,
+      location,
+      bio,
+    });
+    res.json(updated);
+  } catch (error) {
+    const status = error.statusCode || 500;
+    res.status(status).json({ error: error.message });
+  }
+});
+
+router.get('/api/events', authOnly, async (req, res) => {
+  try {
+    const filters = parseFilters(req.query || {});
+    const events = await browseEvents(filters, { userId: req.user.id });
+    res.json({ events });
+  } catch (error) {
+    const status = error.statusCode || 500;
+    res.status(status).json({ error: error.message });
+  }
+});
+
+router.post('/api/events/:eventId/signup', authOnly, async (req, res) => {
+  try {
+    const { eventId } = req.params;
+    if (!uuidPattern.test(eventId)) {
+      return res.status(400).json({ error: 'Invalid event identifier' });
+    }
+    const result = await signupForEvent({ eventId, user: req.user });
+    res.status(201).json(result);
+  } catch (error) {
+    const status = error.statusCode || 500;
+    res.status(status).json({ error: error.message });
+  }
+});
+
+router.get('/api/me/signups', authOnly, async (req, res) => {
+  try {
+    const signups = await listMySignups(req.user.id);
+    res.json({ signups });
+  } catch (error) {
+    const status = error.statusCode || 500;
+    res.status(status).json({ error: error.message });
+  }
+});
+
+router.post('/api/events/:eventId/hours', authOnly, async (req, res) => {
+  try {
+    const { eventId } = req.params;
+    if (!uuidPattern.test(eventId)) {
+      return res.status(400).json({ error: 'Invalid event identifier' });
+    }
+    const { minutes, note } = req.body || {};
+    const entry = await recordVolunteerHours({
+      userId: req.user.id,
+      eventId,
+      minutes,
+      note,
+    });
+    res.status(201).json({ entry });
+  } catch (error) {
+    const status = error.statusCode || 500;
+    res.status(status).json({ error: error.message });
+  }
+});
+
+router.get('/api/me/hours', authOnly, async (req, res) => {
+  try {
+    const summary = await getVolunteerHours(req.user.id);
+    res.json(summary);
+  } catch (error) {
+    const status = error.statusCode || 500;
+    res.status(status).json({ error: error.message });
+  }
+});
+
+router.get('/api/me/dashboard', authOnly, async (req, res) => {
+  try {
+    const dashboard = await getVolunteerDashboard(req.user.id);
+    res.json(dashboard);
+  } catch (error) {
+    const status = error.statusCode || 500;
+    res.status(status).json({ error: error.message });
+  }
+});
+
+if (process.env.NODE_ENV !== 'test') {
+  startReminderScheduler();
+}
+
+module.exports = {
+  basePath: '/api',
+  router,
+};

--- a/backend/tests/volunteerJourney.service.test.js
+++ b/backend/tests/volunteerJourney.service.test.js
@@ -1,0 +1,146 @@
+const { newDb } = require('pg-mem');
+const { randomUUID } = require('crypto');
+
+describe('volunteerJourney.service', () => {
+  let pool;
+  let authService;
+  let volunteerService;
+  let emailServiceMock;
+  let repository;
+
+  beforeEach(async () => {
+    jest.resetModules();
+
+    process.env.JWT_SECRET = 'test-secret';
+    process.env.JWT_ISSUER = 'test-suite';
+    process.env.JWT_EXPIRY = '1h';
+    process.env.BCRYPT_SALT_ROUNDS = '1';
+
+    const db = newDb({ autoCreateForeignKeyIndices: true });
+    const pg = db.adapters.createPg();
+    pool = new pg.Pool();
+
+    jest.doMock('../src/features/common/db', () => pool);
+    jest.doMock('../src/utils/logger', () => ({
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    }));
+    emailServiceMock = {
+      sendTemplatedEmail: jest.fn().mockResolvedValue(null),
+    };
+    jest.doMock('../src/features/email/email.service', () => emailServiceMock);
+    jest.doMock('../src/features/auth/email.service', () => ({
+      sendVerificationEmail: jest.fn().mockResolvedValue(null),
+      sendWelcomeEmail: jest.fn().mockResolvedValue(null),
+    }));
+
+    authService = require('../src/features/auth/auth.service');
+    volunteerService = require('../src/features/volunteer-journey/volunteerJourney.service');
+    repository = require('../src/features/volunteer-journey/volunteerJourney.repository');
+  });
+
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  async function createVolunteer({ name = 'Volunteer One', email = 'volunteer1@example.com', password = 'password123' } = {}) {
+    const signup = await authService.signup({ name, email, password });
+    const tokenRow = await pool.query('SELECT token FROM email_verification_tokens WHERE user_id = $1', [
+      signup.user.id,
+    ]);
+    if (tokenRow.rows[0]) {
+      await authService.verifyEmail({ token: tokenRow.rows[0].token });
+    }
+    const login = await authService.login({ email, password });
+    return login.user;
+  }
+
+  async function createPublishedEvent({
+    title = 'Community Clean-up',
+    description = 'Help restore the local park.',
+    category = 'clean-up',
+    theme = 'nature',
+    location = 'Riverfront',
+    capacity = 10,
+    status = 'published',
+    startOffsetHours = 48,
+    durationHours = 2,
+  } = {}) {
+    await repository.ensureSchema();
+    const id = randomUUID();
+    const start = new Date(Date.now() + startOffsetHours * 60 * 60 * 1000);
+    const end = new Date(start.getTime() + durationHours * 60 * 60 * 1000);
+    await pool.query(
+      `
+        INSERT INTO events (id, title, description, category, theme, date_start, date_end, location, capacity, status, created_at, updated_at)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, NOW(), NOW())
+      `,
+      [id, title, description, category, theme, start, end, location, capacity, status]
+    );
+    return { id, title, description, category, theme, location, capacity, status, start, end };
+  }
+
+  test('updates and reads volunteer profile fields with normalization', async () => {
+    const volunteer = await createVolunteer();
+
+    const updated = await volunteerService.updateProfile({
+      userId: volunteer.id,
+      skills: ['Tree Planting', 'tree planting', 'Community Outreach'],
+      interests: ['Forests', 'Education'],
+      availability: 'Weekends',
+      location: ' Pune ',
+      bio: 'Ready to help nurture our urban forests.',
+    });
+
+    expect(updated.skills).toEqual(['tree planting', 'community outreach']);
+    expect(updated.interests).toEqual(['forests', 'education']);
+    expect(updated.availability).toBe('Weekends');
+    expect(updated.location).toBe('Pune');
+
+    const profile = await volunteerService.getProfile(volunteer.id);
+    expect(profile.skills).toEqual(updated.skills);
+    expect(profile.interests).toEqual(updated.interests);
+  });
+
+  test('event signup enforces uniqueness and capacity while sending confirmation email', async () => {
+    const primaryVolunteer = await createVolunteer({ name: 'Primary', email: 'primary@example.com' });
+    const secondaryVolunteer = await createVolunteer({ name: 'Secondary', email: 'secondary@example.com' });
+    const event = await createPublishedEvent({ capacity: 1, location: 'Lakeside' });
+
+    const list = await volunteerService.browseEvents({ location: 'Lakeside' }, { userId: primaryVolunteer.id });
+    expect(list).toHaveLength(1);
+
+    const signup = await volunteerService.signupForEvent({ eventId: event.id, user: primaryVolunteer });
+    expect(signup.event.isRegistered).toBe(true);
+    expect(emailServiceMock.sendTemplatedEmail).toHaveBeenCalledTimes(1);
+
+    await expect(volunteerService.signupForEvent({ eventId: event.id, user: primaryVolunteer })).rejects.toMatchObject({
+      statusCode: 409,
+    });
+
+    await expect(volunteerService.signupForEvent({ eventId: event.id, user: secondaryVolunteer })).rejects.toMatchObject({
+      statusCode: 409,
+    });
+  });
+
+  test('logging hours requires a signup and unlocks badges as thresholds are reached', async () => {
+    const volunteer = await createVolunteer({ name: 'Hours Hero', email: 'hours@example.com' });
+    const event = await createPublishedEvent({ capacity: 5 });
+
+    await expect(
+      volunteerService.recordVolunteerHours({ userId: volunteer.id, eventId: event.id, minutes: 60 })
+    ).rejects.toMatchObject({ statusCode: 400 });
+
+    await volunteerService.signupForEvent({ eventId: event.id, user: volunteer });
+
+    await volunteerService.recordVolunteerHours({ userId: volunteer.id, eventId: event.id, minutes: 300 });
+    await volunteerService.recordVolunteerHours({ userId: volunteer.id, eventId: event.id, minutes: 320 });
+
+    const hours = await volunteerService.getVolunteerHours(volunteer.id);
+    expect(hours.totalMinutes).toBe(620);
+    const seedlingBadge = hours.badges.find((badge) => badge.slug === 'seedling');
+    expect(seedlingBadge.earned).toBe(true);
+    expect(seedlingBadge.thresholdHours).toBe(10);
+  });
+});

--- a/docs/wiki/README.md
+++ b/docs/wiki/README.md
@@ -105,6 +105,13 @@ Onkur is a mobile-first volunteering platform built to inspire environmental and
   - [Frontend experience](#frontend-experience)
   - [Metrics & auditing](#metrics--auditing)
   - [Environment keys](#environment-keys)
+- [Phase 2 – Volunteer Journey](#phase-2--volunteer-journey)
+  - [Highlights](#phase-2-highlights)
+  - [Backend APIs](#backend-apis)
+  - [Data model updates](#data-model-updates)
+  - [Email flows](#email-flows)
+  - [Frontend experience](#phase-2-frontend-experience)
+  - [Testing & observability](#testing--observability)
 - [Project conventions](#project-conventions)
 - [Environment setup](#environment-setup)
 - [Local development workflow](#local-development-workflow)
@@ -320,6 +327,45 @@ VALUES
 ### 4. Production readiness checks
 - Run `npm run build` inside `frontend/` to ensure the new UI compiles.
 - Consider adding automated tests (e.g. Jest for backend, Vitest/React Testing Library for frontend) once the feature grows.
+
+## Phase 2 – Volunteer Journey
+
+### Phase 2 Highlights
+- Volunteers can create and update skill, interest, availability, and location details from the in-app profile editor.
+- Published events can be browsed with filters for category, location, theme, and date while respecting capacity and duplicate signup rules.
+- Signups trigger templated confirmation emails and schedule a 24-hour reminder as events approach.
+- Volunteers log minutes per event, unlocking Seedling (10h), Grove Guardian (50h), and Forest Champion (100h) eco badges.
+- The refreshed dashboard surfaces upcoming activities, recent participation, and impact metrics in a mobile-first layout.
+
+### Backend APIs
+- `GET /api/me/profile` and `PUT /api/me/profile` manage volunteer profile data.
+- `GET /api/events` lists published events with filter support and registration status.
+- `POST /api/events/:id/signup` enforces capacity, prevents duplicates, and records participation.
+- `GET /api/me/signups` returns the volunteer’s event commitments.
+- `POST /api/events/:id/hours` logs minutes against an event signup.
+- `GET /api/me/hours` aggregates totals, entries, and badge progress.
+- `GET /api/me/dashboard` combines profile, activity, and achievement data for the volunteer home view.
+
+### Data model updates
+- `volunteer_profiles` stores normalized arrays for skills and interests plus availability, location, and bio metadata.
+- `events` gains support for themes, status management, and timestamp columns to drive discovery and reminders.
+- `event_signups` tracks reminder delivery times alongside capacity-safe registration rows.
+- `volunteer_hours` records minutes, notes, and optional verification metadata per volunteer/event pairing.
+
+### Email flows
+- Signup confirmations use the shared Nodemailer transport; the scheduler (15-minute interval) sends reminders exactly 24 hours before event start.
+- Reminder dispatch respects `NODE_ENV=test` to remain inert inside Jest.
+
+### Phase 2 Frontend Experience
+- The volunteer dashboard now loads profile, signups, hours, badges, and events in one pass with optimistic refresh helpers.
+- Profile editing, event discovery, and hours logging components surface inline success/error states and mobile-first forms.
+- Badges and recent hour entries visualize progress using the earthy Onkur palette.
+
+### Testing & observability
+- Added `volunteerJourney.service.test.js` powered by `pg-mem` to cover profile updates, event signup constraints, and badge unlock logic.
+- Reminder scheduling and email dispatch leverage shared logger hooks for auditing outcomes.
+- Run `npm test` inside `backend/` and `npm run build` inside `frontend/` to confirm volunteer flows and UI bundles stay health
+  y after changes.
 
 ## Docker usage
 You can spin up both servers with Docker once your `.env` files are configured:

--- a/frontend/src/features/volunteer/AGENTS.md
+++ b/frontend/src/features/volunteer/AGENTS.md
@@ -1,0 +1,9 @@
+# Volunteer Frontend Guidelines
+
+These notes apply to files under `frontend/src/features/volunteer/`.
+
+- Keep components mobile-first: stack sections vertically and rely on responsive utilities for wider breakpoints.
+- Prefer colocated hooks/helpers in the same folder rather than reaching into shared libs unless the logic is reused elsewhere.
+- Surfaces that mutate backend data should display inline success and error states rather than relying on alerts.
+- When wiring new flows into the dashboard, reuse the shared refresh helpers so profile, signup, and hours panels stay in sync a
+  fter mutations.

--- a/frontend/src/features/volunteer/EventDiscovery.jsx
+++ b/frontend/src/features/volunteer/EventDiscovery.jsx
@@ -1,0 +1,219 @@
+import { useEffect, useMemo, useState } from 'react';
+
+function formatDateRange(event) {
+  if (!event?.dateStart) return 'Date TBA';
+  const start = new Date(event.dateStart);
+  const end = event.dateEnd ? new Date(event.dateEnd) : null;
+  const dateFormatter = new Intl.DateTimeFormat('en-US', { dateStyle: 'medium' });
+  const timeFormatter = new Intl.DateTimeFormat('en-US', { timeStyle: 'short' });
+
+  if (end && start.toDateString() === end.toDateString()) {
+    return `${dateFormatter.format(start)} · ${timeFormatter.format(start)} – ${timeFormatter.format(end)}`;
+  }
+  if (end) {
+    return `${dateFormatter.format(start)} ${timeFormatter.format(start)} → ${dateFormatter.format(end)} ${timeFormatter.format(end)}`;
+  }
+  return `${dateFormatter.format(start)} ${timeFormatter.format(start)}`;
+}
+
+function summarize(event) {
+  if (!event?.description) return '';
+  if (event.description.length <= 140) return event.description;
+  return `${event.description.slice(0, 137)}…`;
+}
+
+export default function EventDiscovery({ events, filters, onFilterChange, onSignup, isLoading }) {
+  const [form, setForm] = useState({ category: '', location: '', theme: '', date: '' });
+  const [actionStates, setActionStates] = useState({});
+
+  useEffect(() => {
+    setForm({
+      category: filters?.category || '',
+      location: filters?.location || '',
+      theme: filters?.theme || '',
+      date: filters?.date || '',
+    });
+  }, [filters]);
+
+  const totalAvailable = useMemo(
+    () => events.reduce((count, event) => (event.availableSlots > 0 ? count + 1 : count), 0),
+    [events]
+  );
+
+  const handleChange = (event) => {
+    const { name, value } = event.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    onFilterChange?.({ ...form });
+  };
+
+  const handleReset = () => {
+    const cleared = { category: '', location: '', theme: '', date: '' };
+    setForm(cleared);
+    onFilterChange?.(cleared);
+  };
+
+  const handleSignup = async (eventId) => {
+    if (!onSignup) return;
+    setActionStates((prev) => ({ ...prev, [eventId]: { status: 'loading' } }));
+    try {
+      await onSignup(eventId);
+      setActionStates((prev) => ({
+        ...prev,
+        [eventId]: { status: 'success', message: 'You\u2019re confirmed!' },
+      }));
+    } catch (error) {
+      setActionStates((prev) => ({
+        ...prev,
+        [eventId]: { status: 'error', message: error.message || 'Unable to join this event.' },
+      }));
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-5">
+      <form className="grid gap-3 rounded-2xl border border-brand-forest/10 bg-brand-sand/60 p-4" onSubmit={handleSubmit}>
+        <div className="grid gap-3 sm:[grid-template-columns:repeat(2,minmax(0,1fr))]">
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="font-semibold text-brand-forest">Category</span>
+            <input
+              className="rounded-lg border border-brand-forest/20 bg-white px-3 py-2 text-sm shadow-sm focus:border-brand-green focus:outline-none"
+              type="text"
+              name="category"
+              placeholder="Cleanup, planting, education"
+              value={form.category}
+              onChange={handleChange}
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="font-semibold text-brand-forest">Location</span>
+            <input
+              className="rounded-lg border border-brand-forest/20 bg-white px-3 py-2 text-sm shadow-sm focus:border-brand-green focus:outline-none"
+              type="text"
+              name="location"
+              placeholder="Search by neighbourhood"
+              value={form.location}
+              onChange={handleChange}
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="font-semibold text-brand-forest">Theme</span>
+            <input
+              className="rounded-lg border border-brand-forest/20 bg-white px-3 py-2 text-sm shadow-sm focus:border-brand-green focus:outline-none"
+              type="text"
+              name="theme"
+              placeholder="Biodiversity, climate, circularity"
+              value={form.theme}
+              onChange={handleChange}
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="font-semibold text-brand-forest">Date</span>
+            <input
+              className="rounded-lg border border-brand-forest/20 bg-white px-3 py-2 text-sm shadow-sm focus:border-brand-green focus:outline-none"
+              type="date"
+              name="date"
+              value={form.date}
+              onChange={handleChange}
+            />
+          </label>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <button type="submit" className="btn-primary" disabled={isLoading}>
+            {isLoading ? 'Searching…' : 'Apply filters'}
+          </button>
+          <button
+            type="button"
+            className="rounded-md border border-brand-forest/20 bg-white px-3 py-2 text-sm font-semibold text-brand-forest shadow-sm"
+            onClick={handleReset}
+            disabled={isLoading}
+          >
+            Reset
+          </button>
+          <span className="text-xs text-brand-muted">
+            {events.length ? `${events.length} event${events.length === 1 ? '' : 's'} shown` : 'No events to show yet'}
+          </span>
+        </div>
+      </form>
+
+      <div className="space-y-4">
+        {isLoading ? (
+          <p className="m-0 text-sm text-brand-muted">Loading opportunities…</p>
+        ) : null}
+        {!events.length && !isLoading ? (
+          <p className="m-0 rounded-xl border border-dashed border-brand-forest/30 bg-white p-4 text-sm text-brand-muted">
+            No events match these filters yet. Try widening your search or check back soon.
+          </p>
+        ) : null}
+        {events.map((event) => {
+          const state = actionStates[event.id] || { status: 'idle' };
+          const isWorking = state.status === 'loading';
+          const alreadyJoined = event.isRegistered;
+          const isFull = event.availableSlots <= 0;
+          const canJoin = !alreadyJoined && !isFull && !isWorking;
+          return (
+            <article
+              key={event.id}
+              className="flex flex-col gap-3 rounded-2xl border border-brand-forest/10 bg-white p-4 shadow-[0_12px_28px_rgba(47,133,90,0.08)]"
+            >
+              <header className="flex flex-col gap-1">
+                <h4 className="m-0 text-base font-semibold text-brand-forest">{event.title}</h4>
+                <p className="m-0 text-sm text-brand-muted">{summarize(event)}</p>
+              </header>
+              <dl className="grid gap-2 text-xs text-brand-muted [grid-template-columns:repeat(auto-fit,minmax(140px,1fr))]">
+                <div>
+                  <dt className="font-semibold text-brand-forest">When</dt>
+                  <dd className="m-0">{formatDateRange(event)}</dd>
+                </div>
+                <div>
+                  <dt className="font-semibold text-brand-forest">Where</dt>
+                  <dd className="m-0">{event.location}</dd>
+                </div>
+                <div>
+                  <dt className="font-semibold text-brand-forest">Spots left</dt>
+                  <dd className="m-0">
+                    {event.availableSlots > 0 ? `${event.availableSlots} open` : 'Full'}
+                  </dd>
+                </div>
+              </dl>
+              <div className="flex flex-wrap items-center gap-2">
+                <button
+                  type="button"
+                  className="btn-primary"
+                  disabled={!canJoin}
+                  onClick={() => handleSignup(event.id)}
+                >
+                  {alreadyJoined ? 'Joined' : isFull ? 'Full' : isWorking ? 'Joining…' : 'Sign up'}
+                </button>
+                {alreadyJoined ? (
+                  <span className="text-xs font-semibold text-brand-green">You\u2019re confirmed!</span>
+                ) : null}
+                {isFull && !alreadyJoined ? (
+                  <span className="text-xs text-brand-muted">This event reached capacity.</span>
+                ) : null}
+                {state.status === 'error' ? (
+                  <span className="text-xs text-red-600">{state.message}</span>
+                ) : null}
+                {state.status === 'success' && !alreadyJoined ? (
+                  <span className="text-xs font-semibold text-brand-green">{state.message}</span>
+                ) : null}
+              </div>
+            </article>
+          );
+        })}
+      </div>
+      {events.length ? (
+        <p className="m-0 text-xs text-brand-muted">
+          {totalAvailable
+            ? `${totalAvailable} event${totalAvailable === 1 ? '' : 's'} still ${
+                totalAvailable === 1 ? 'has' : 'have'
+              } volunteer spots available.`
+            : 'All listed events are currently full.'}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/features/volunteer/HoursTracker.jsx
+++ b/frontend/src/features/volunteer/HoursTracker.jsx
@@ -1,0 +1,205 @@
+import { useEffect, useMemo, useState } from 'react';
+
+function formatHours(value) {
+  if (!value) return '0';
+  return (Math.round(value * 10) / 10).toString();
+}
+
+function formatDate(value) {
+  if (!value) return '';
+  const date = new Date(value);
+  return new Intl.DateTimeFormat('en-US', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(date);
+}
+
+export default function HoursTracker({ summary, signups, onLogHours }) {
+  const [form, setForm] = useState({ eventId: '', hours: '', note: '' });
+  const [status, setStatus] = useState(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const upcomingOptions = useMemo(() => {
+    return signups
+      .map((signup) => ({
+        id: signup.eventId,
+        title: signup.event?.title || 'Upcoming event',
+        isUpcoming: signup.isUpcoming,
+      }))
+      .sort((a, b) => {
+        if (a.isUpcoming === b.isUpcoming) return a.title.localeCompare(b.title);
+        return a.isUpcoming ? -1 : 1;
+      });
+  }, [signups]);
+
+  useEffect(() => {
+    if (!upcomingOptions.length) return;
+    if (!upcomingOptions.some((option) => option.id === form.eventId)) {
+      setForm((prev) => ({ ...prev, eventId: upcomingOptions[0].id }));
+    }
+  }, [upcomingOptions, form.eventId]);
+
+  useEffect(() => {
+    if (!summary) return;
+    setStatus(null);
+  }, [summary]);
+
+  const handleChange = (event) => {
+    const { name, value } = event.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    if (!onLogHours || !form.eventId) {
+      setStatus({ type: 'error', message: 'Select an event to log your time.' });
+      return;
+    }
+    const numericHours = Number(form.hours);
+    if (!Number.isFinite(numericHours) || numericHours <= 0) {
+      setStatus({ type: 'error', message: 'Enter the hours you completed (greater than zero).' });
+      return;
+    }
+
+    setSubmitting(true);
+    setStatus(null);
+    try {
+      const minutes = Math.round(numericHours * 60);
+      await onLogHours({ eventId: form.eventId, minutes, note: form.note });
+      setStatus({ type: 'success', message: 'Hours recorded. Thank you for showing up!' });
+      setForm((prev) => ({ ...prev, hours: '', note: '' }));
+    } catch (error) {
+      setStatus({ type: 'error', message: error.message || 'Unable to log your hours.' });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const totalHours = formatHours(summary?.totalHours || 0);
+  const earnedBadges = summary?.badges?.filter((badge) => badge.earned).length || 0;
+
+  return (
+    <div className="flex flex-col gap-5">
+      <section className="rounded-2xl border border-brand-forest/10 bg-white p-4 shadow-[0_12px_24px_rgba(47,133,90,0.08)]">
+        <h4 className="m-0 text-base font-semibold text-brand-forest">Impact snapshot</h4>
+        <p className="mt-2 text-sm text-brand-muted">
+          Hours logged: <strong className="font-semibold text-brand-forest">{totalHours}</strong>
+        </p>
+        <p className="m-0 text-sm text-brand-muted">Badges earned: {earnedBadges}</p>
+      </section>
+
+      <section className="flex flex-col gap-3">
+        <h4 className="m-0 text-base font-semibold text-brand-forest">Log new hours</h4>
+        <form className="flex flex-col gap-3" onSubmit={handleSubmit}>
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="font-semibold text-brand-forest">Event</span>
+            <select
+              className="rounded-lg border border-brand-forest/20 bg-white px-3 py-2 text-sm shadow-sm focus:border-brand-green focus:outline-none"
+              name="eventId"
+              value={form.eventId}
+              onChange={handleChange}
+            >
+              {!upcomingOptions.length ? <option value="">Join an event to log your time</option> : null}
+              {upcomingOptions.map((option) => (
+                <option key={option.id} value={option.id}>
+                  {option.title}
+                  {option.isUpcoming ? ' (upcoming)' : ''}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="font-semibold text-brand-forest">Hours completed</span>
+            <input
+              className="rounded-lg border border-brand-forest/20 bg-white px-3 py-2 text-sm shadow-sm focus:border-brand-green focus:outline-none"
+              type="number"
+              name="hours"
+              min="0"
+              step="0.25"
+              placeholder="e.g. 2"
+              value={form.hours}
+              onChange={handleChange}
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="font-semibold text-brand-forest">Notes (optional)</span>
+            <textarea
+              className="min-h-[72px] rounded-lg border border-brand-forest/20 bg-white px-3 py-2 text-sm shadow-sm focus:border-brand-green focus:outline-none"
+              name="note"
+              placeholder="What did you work on?"
+              value={form.note}
+              onChange={handleChange}
+            />
+          </label>
+          {status ? (
+            <p
+              className={`m-0 text-sm ${
+                status.type === 'success' ? 'text-brand-green' : 'text-red-600'
+              }`}
+            >
+              {status.message}
+            </p>
+          ) : null}
+          <button type="submit" className="btn-primary" disabled={submitting || !upcomingOptions.length}>
+            {submitting ? 'Saving…' : 'Log hours'}
+          </button>
+        </form>
+      </section>
+
+      <section className="flex flex-col gap-3">
+        <h4 className="m-0 text-base font-semibold text-brand-forest">Eco badges</h4>
+        <ul className="m-0 grid list-none gap-3 p-0">
+          {summary?.badges?.map((badge) => (
+            <li
+              key={badge.slug}
+              className={`rounded-2xl border border-brand-forest/10 bg-white p-3 text-sm shadow-sm ${
+                badge.earned ? 'ring-1 ring-brand-green/40' : ''
+              }`}
+            >
+              <div className="flex items-center justify-between gap-2">
+                <div>
+                  <p className="m-0 font-semibold text-brand-forest">{badge.label}</p>
+                  <p className="m-0 text-xs text-brand-muted">{badge.description}</p>
+                </div>
+                <span className="text-xs font-semibold text-brand-muted">{badge.thresholdHours} hrs</span>
+              </div>
+              {badge.earned ? (
+                <p className="mt-2 text-xs font-semibold text-brand-green">
+                  Earned {badge.earnedAt ? `on ${formatDate(badge.earnedAt)}` : '🎉'}
+                </p>
+              ) : (
+                <p className="mt-2 text-xs text-brand-muted">
+                  {`Log ${Math.max(0, badge.thresholdHours - (summary?.totalHours || 0)).toFixed(1)} more hours to unlock.`}
+                </p>
+              )}
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="flex flex-col gap-3">
+        <h4 className="m-0 text-base font-semibold text-brand-forest">Recent log entries</h4>
+        {summary?.entries?.length ? (
+          <ul className="m-0 list-none space-y-2 p-0">
+            {summary.entries.slice(0, 5).map((entry) => (
+              <li
+                key={entry.id}
+                className="rounded-2xl border border-brand-forest/10 bg-white px-3 py-2 text-sm text-brand-muted shadow-sm"
+              >
+                <p className="m-0 font-semibold text-brand-forest">
+                  {entry.event?.title || 'Volunteer hours'}
+                </p>
+                <p className="m-0 text-xs text-brand-muted">
+                  {formatDate(entry.createdAt)} • {(entry.minutes / 60).toFixed(2)} hrs
+                </p>
+                {entry.note ? <p className="m-0 text-xs text-brand-muted">{entry.note}</p> : null}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="m-0 text-sm text-brand-muted">Log your first hours to see them here.</p>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/features/volunteer/ProfileEditor.jsx
+++ b/frontend/src/features/volunteer/ProfileEditor.jsx
@@ -1,0 +1,162 @@
+import { useEffect, useMemo, useState } from 'react';
+
+function listToInput(value) {
+  return Array.isArray(value) && value.length ? value.join(', ') : '';
+}
+
+export default function ProfileEditor({ profile, onSave }) {
+  const [form, setForm] = useState({
+    skills: '',
+    interests: '',
+    availability: '',
+    location: '',
+    bio: '',
+  });
+  const [saving, setSaving] = useState(false);
+  const [status, setStatus] = useState(null);
+
+  const hasChanges = useMemo(() => {
+    if (!profile) return false;
+    return (
+      form.skills !== listToInput(profile.skills) ||
+      form.interests !== listToInput(profile.interests) ||
+      form.availability !== (profile.availability || '') ||
+      form.location !== (profile.location || '') ||
+      form.bio !== (profile.bio || '')
+    );
+  }, [form, profile]);
+
+  useEffect(() => {
+    if (!profile) return;
+    setForm({
+      skills: listToInput(profile.skills),
+      interests: listToInput(profile.interests),
+      availability: profile.availability || '',
+      location: profile.location || '',
+      bio: profile.bio || '',
+    });
+  }, [profile]);
+
+  const handleChange = (event) => {
+    const { name, value } = event.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    if (!onSave || !profile) return;
+    setSaving(true);
+    setStatus(null);
+    try {
+      const payload = {
+        skills: form.skills
+          .split(',')
+          .map((item) => item.trim())
+          .filter(Boolean),
+        interests: form.interests
+          .split(',')
+          .map((item) => item.trim())
+          .filter(Boolean),
+        availability: form.availability,
+        location: form.location,
+        bio: form.bio,
+      };
+      const updated = await onSave(payload);
+      setStatus({ type: 'success', message: 'Profile saved successfully.' });
+      setForm({
+        skills: listToInput(updated.skills),
+        interests: listToInput(updated.interests),
+        availability: updated.availability || '',
+        location: updated.location || '',
+        bio: updated.bio || '',
+      });
+    } catch (error) {
+      setStatus({ type: 'error', message: error.message || 'Unable to update your profile.' });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <form className="flex flex-col gap-4" onSubmit={handleSubmit}>
+      <div className="grid gap-3">
+        <label className="flex flex-col gap-1 text-sm">
+          <span className="font-semibold text-brand-forest">Skills</span>
+          <input
+            className="rounded-lg border border-brand-forest/20 bg-white px-3 py-2 text-sm shadow-sm focus:border-brand-green focus:outline-none"
+            type="text"
+            name="skills"
+            placeholder="e.g. planting, first aid, coordination"
+            value={form.skills}
+            onChange={handleChange}
+          />
+          <span className="text-xs text-brand-muted">Separate skills with commas to help us match you to the right roles.</span>
+        </label>
+        <label className="flex flex-col gap-1 text-sm">
+          <span className="font-semibold text-brand-forest">Interests</span>
+          <input
+            className="rounded-lg border border-brand-forest/20 bg-white px-3 py-2 text-sm shadow-sm focus:border-brand-green focus:outline-none"
+            type="text"
+            name="interests"
+            placeholder="e.g. wetlands, youth mentorship"
+            value={form.interests}
+            onChange={handleChange}
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-sm">
+          <span className="font-semibold text-brand-forest">Availability</span>
+          <input
+            className="rounded-lg border border-brand-forest/20 bg-white px-3 py-2 text-sm shadow-sm focus:border-brand-green focus:outline-none"
+            type="text"
+            name="availability"
+            placeholder="Weekends, weekday evenings, etc."
+            value={form.availability}
+            onChange={handleChange}
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-sm">
+          <span className="font-semibold text-brand-forest">Location</span>
+          <input
+            className="rounded-lg border border-brand-forest/20 bg-white px-3 py-2 text-sm shadow-sm focus:border-brand-green focus:outline-none"
+            type="text"
+            name="location"
+            placeholder="City or neighbourhood"
+            value={form.location}
+            onChange={handleChange}
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-sm">
+          <span className="font-semibold text-brand-forest">Bio</span>
+          <textarea
+            className="min-h-[96px] rounded-lg border border-brand-forest/20 bg-white px-3 py-2 text-sm shadow-sm focus:border-brand-green focus:outline-none"
+            name="bio"
+            placeholder="Share a sentence about why you volunteer."
+            value={form.bio}
+            onChange={handleChange}
+          />
+        </label>
+      </div>
+      {status ? (
+        <p
+          className={`m-0 text-sm ${
+            status.type === 'success' ? 'text-brand-green' : 'text-red-600'
+          }`}
+        >
+          {status.message}
+        </p>
+      ) : null}
+      <div className="flex flex-wrap gap-2">
+        <button
+          type="submit"
+          className="btn-primary"
+          disabled={saving || !hasChanges}
+        >
+          {saving ? 'Saving…' : 'Save profile'}
+        </button>
+        {!hasChanges ? (
+          <span className="text-xs text-brand-muted">Make an update to enable saving.</span>
+        ) : null}
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/features/volunteer/api.js
+++ b/frontend/src/features/volunteer/api.js
@@ -1,0 +1,51 @@
+import { apiRequest } from '../../lib/apiClient';
+
+function buildQuery(filters = {}) {
+  const params = new URLSearchParams();
+  if (filters.category) {
+    params.set('category', filters.category);
+  }
+  if (filters.location) {
+    params.set('location', filters.location);
+  }
+  if (filters.theme) {
+    params.set('theme', filters.theme);
+  }
+  if (filters.date) {
+    params.set('date', filters.date);
+  }
+  const query = params.toString();
+  return query ? `?${query}` : '';
+}
+
+export function fetchVolunteerProfile(token) {
+  return apiRequest('/api/me/profile', { token });
+}
+
+export function updateVolunteerProfile(token, payload) {
+  return apiRequest('/api/me/profile', { method: 'PUT', token, body: payload });
+}
+
+export function fetchEvents(token, filters = {}) {
+  return apiRequest(`/api/events${buildQuery(filters)}`, { token });
+}
+
+export function signupForEvent(token, eventId) {
+  return apiRequest(`/api/events/${eventId}/signup`, { method: 'POST', token });
+}
+
+export function fetchMySignups(token) {
+  return apiRequest('/api/me/signups', { token });
+}
+
+export function logVolunteerHours(token, eventId, payload) {
+  return apiRequest(`/api/events/${eventId}/hours`, { method: 'POST', token, body: payload });
+}
+
+export function fetchVolunteerHours(token) {
+  return apiRequest('/api/me/hours', { token });
+}
+
+export function fetchVolunteerDashboard(token) {
+  return apiRequest('/api/me/dashboard', { token });
+}


### PR DESCRIPTION
## Summary
- add the volunteer journey backend feature module with profile, event discovery, signup, hours logging, and reminder scheduling
- cover volunteer badge and capacity logic with pg-mem powered service tests
- deliver the volunteer dashboard UI refresh with profile editor, discovery, hours tracker, and supporting API helpers
- expand the wiki with phase 2 documentation and testing guidance

## Testing
- npm test (backend)
- npm run build (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68cc6a7e482883338e5eb4c01eb6e3fd