### PR TITLE
Fix Vite /app route handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ These instructions apply to the entire repository unless a nested `AGENTS.md` ov
 - Group related UI pieces under `frontend/src/features/<feature-name>/` and prefer feature-level components over editing `App.jsx` directly.
 - Ensure new API calls read `import.meta.env.VITE_API_BASE_URL` for the backend origin.
 - Run `npm run build` from the `frontend` directory to validate that the Vite build still succeeds after making frontend changes.
+- Preserve the `/app` HTML rewrite middleware in `vite.config.js` so that deep links like `/app/events` continue to resolve when the dev server is accessed directly.
 
 ## Tooling
 - Do not commit environment secrets or generated assets under `dist/` or `build/`.

--- a/docs/wiki/README.md
+++ b/docs/wiki/README.md
@@ -381,5 +381,6 @@ docker compose up --build
 - **CORS issues?** Confirm `CORS_ORIGIN` in `backend/.env` matches the frontend origin (for Vite dev this is usually `http://localhost:5173`).
 - **Connection errors?** Run `npm run test:db` and `npm run test:minio` for quick diagnostics and double-check credentials.
 - **Frontend cannot reach backend?** Verify `VITE_API_BASE_URL` points at the backend port (use `http://localhost:5000` when running both locally outside Docker, or `http://localhost:5001` when using `docker compose`).
+- **Direct links under `/app` 404?** The dev server now rewrites `/app` routes back to `/` so React Router can boot; if that overlay reappears, confirm the `app-route-rewrite` middleware still exists in `frontend/vite.config.js`.
 
 Happy building! 🎉

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,8 +1,25 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
+const appRouteRewritePlugin = {
+  name: 'app-route-rewrite',
+  configureServer(server) {
+    server.middlewares.use((req, _res, next) => {
+      const acceptHeader = req.headers.accept || '';
+      if (
+        req.method === 'GET' &&
+        req.url?.startsWith('/app') &&
+        acceptHeader.includes('text/html')
+      ) {
+        req.url = '/';
+      }
+      next();
+    });
+  },
+};
+
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), appRouteRewritePlugin],
   server: {
     proxy: {
       '/api': 'http://localhost:5000', // Proxy API requests to backend


### PR DESCRIPTION
## Summary
- add a development middleware to Vite so direct /app deep links fall back to the SPA entry
- document the /app rewrite expectation in the contributor playbook and wiki troubleshooting guide

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc748375d88333abe621751ccb70b2