### PR TITLE
Fix volunteer dashboard route mounting

### DIFF
--- a/backend/src/features/volunteer-journey/AGENTS.md
+++ b/backend/src/features/volunteer-journey/AGENTS.md
@@ -6,5 +6,5 @@ These instructions apply to files within `backend/src/features/volunteer-journey
 - Reuse helpers for array sanitization so profile fields remain lowercase-trimmed without duplicates.
 - When adding new badge thresholds, update both the badge catalogue in the service and the volunteer wiki documentation.
 - Ensure new queries remain friendly to the in-memory `pg-mem` test harness (avoid Postgres-only syntax outside common SQL).
-- Keep reminder scheduler changes behind the `NODE_ENV!=='test'` guard. When adjusting intervals, ensure timers call `unref()` s
-  o background jobs do not block Node process shutdown.
+- Keep reminder scheduler changes behind the `NODE_ENV!=='test'` guard. When adjusting intervals, ensure timers call `unref()` so background jobs do not block Node process shutdown.
+- When adding or updating routes, remember the router mounts at `/api`; define paths like `/me/profile` rather than duplicating the prefix.

--- a/backend/src/features/volunteer-journey/volunteerJourney.route.js
+++ b/backend/src/features/volunteer-journey/volunteerJourney.route.js
@@ -43,7 +43,7 @@ function parseFilters(query = {}) {
   return filters;
 }
 
-router.get('/api/me/profile', authOnly, async (req, res) => {
+router.get('/me/profile', authOnly, async (req, res) => {
   try {
     const profile = await getProfile(req.user.id);
     res.json(profile);
@@ -53,7 +53,7 @@ router.get('/api/me/profile', authOnly, async (req, res) => {
   }
 });
 
-router.put('/api/me/profile', authOnly, async (req, res) => {
+router.put('/me/profile', authOnly, async (req, res) => {
   try {
     const { skills, interests, availability, location, bio } = req.body || {};
     const updated = await updateProfile({
@@ -71,7 +71,7 @@ router.put('/api/me/profile', authOnly, async (req, res) => {
   }
 });
 
-router.get('/api/events', authOnly, async (req, res) => {
+router.get('/events', authOnly, async (req, res) => {
   try {
     const filters = parseFilters(req.query || {});
     const events = await browseEvents(filters, { userId: req.user.id });
@@ -82,7 +82,7 @@ router.get('/api/events', authOnly, async (req, res) => {
   }
 });
 
-router.post('/api/events/:eventId/signup', authOnly, async (req, res) => {
+router.post('/events/:eventId/signup', authOnly, async (req, res) => {
   try {
     const { eventId } = req.params;
     if (!uuidPattern.test(eventId)) {
@@ -96,7 +96,7 @@ router.post('/api/events/:eventId/signup', authOnly, async (req, res) => {
   }
 });
 
-router.get('/api/me/signups', authOnly, async (req, res) => {
+router.get('/me/signups', authOnly, async (req, res) => {
   try {
     const signups = await listMySignups(req.user.id);
     res.json({ signups });
@@ -106,7 +106,7 @@ router.get('/api/me/signups', authOnly, async (req, res) => {
   }
 });
 
-router.post('/api/events/:eventId/hours', authOnly, async (req, res) => {
+router.post('/events/:eventId/hours', authOnly, async (req, res) => {
   try {
     const { eventId } = req.params;
     if (!uuidPattern.test(eventId)) {
@@ -126,7 +126,7 @@ router.post('/api/events/:eventId/hours', authOnly, async (req, res) => {
   }
 });
 
-router.get('/api/me/hours', authOnly, async (req, res) => {
+router.get('/me/hours', authOnly, async (req, res) => {
   try {
     const summary = await getVolunteerHours(req.user.id);
     res.json(summary);
@@ -136,7 +136,7 @@ router.get('/api/me/hours', authOnly, async (req, res) => {
   }
 });
 
-router.get('/api/me/dashboard', authOnly, async (req, res) => {
+router.get('/me/dashboard', authOnly, async (req, res) => {
   try {
     const dashboard = await getVolunteerDashboard(req.user.id);
     res.json(dashboard);

--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -1,0 +1,6 @@
+# Onkur Change Log
+
+## Volunteer dashboard API routing fix
+- **Date:** 2025-09-18
+- **Change:** Updated the volunteer journey router to register its endpoints relative to the `/api` base path so that dashboard requests such as `/api/me/dashboard` resolve correctly after login.
+- **Impact:** Volunteers can now load their dashboard without receiving the generic "Request failed" error because the routes map to the expected URLs.


### PR DESCRIPTION
## Summary
- update volunteer journey router paths to mount under the /api base without duplicating the prefix
- document the routing fix in the volunteer feature guidelines and project wiki change log

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68cc77e524ec8333ae1d2524036fb5ad