### PR TITLE
Implement event manager workflows

### DIFF
--- a/backend/src/features/event-management/AGENTS.md
+++ b/backend/src/features/event-management/AGENTS.md
@@ -1,0 +1,10 @@
+# Event Management Backend Guidelines
+
+These instructions apply to files within `backend/src/features/event-management/`.
+
+- Keep business logic in the service layer and limit route handlers to validation, auth wiring, and response shaping.
+- Repository functions should accept a database client when transactional work is required; expose helpers that open/close
+  connections internally for simple operations.
+- When emitting emails, reuse the shared `sendTemplatedEmail` helper and guard failures so that the primary request still
+  succeeds while logging the error.
+- Prefer ISO 8601 strings in API responses; convert database timestamps using `toISOString()` before returning them.

--- a/backend/src/features/event-management/eventManagement.repository.js
+++ b/backend/src/features/event-management/eventManagement.repository.js
@@ -1,0 +1,697 @@
+const { randomUUID } = require('crypto');
+const pool = require('../common/db');
+const { ensureSchema } = require('../volunteer-journey/volunteerJourney.repository');
+
+function toIso(value) {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  return date.toISOString();
+}
+
+function mapEventRow(row) {
+  if (!row) {
+    return null;
+  }
+  return {
+    id: row.id,
+    title: row.title,
+    description: row.description,
+    category: row.category,
+    theme: row.theme,
+    dateStart: toIso(row.date_start),
+    dateEnd: toIso(row.date_end),
+    location: row.location,
+    capacity: row.capacity,
+    requirements: row.requirements || '',
+    status: row.status,
+    createdBy: row.created_by || null,
+    publishedAt: toIso(row.published_at),
+    completedAt: toIso(row.completed_at),
+    createdAt: toIso(row.created_at),
+    updatedAt: toIso(row.updated_at),
+    signupCount: Number(row.signup_count || 0),
+    checkedInCount: Number(row.checked_in_count || 0),
+    totalMinutes: Number(row.total_minutes || 0),
+  };
+}
+
+async function withTransaction(handler) {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    const result = await handler(client);
+    await client.query('COMMIT');
+    return result;
+  } catch (error) {
+    await client.query('ROLLBACK');
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+async function createEvent({
+  title,
+  description,
+  category,
+  theme = null,
+  dateStart,
+  dateEnd,
+  location,
+  capacity,
+  requirements = null,
+  createdBy = null,
+}) {
+  await ensureSchema();
+  const id = randomUUID();
+  const result = await pool.query(
+    `
+      INSERT INTO events (
+        id,
+        title,
+        description,
+        category,
+        theme,
+        date_start,
+        date_end,
+        location,
+        capacity,
+        requirements,
+        status,
+        created_by
+      )
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, 'DRAFT', $11)
+      RETURNING *
+    `,
+    [
+      id,
+      title,
+      description,
+      category,
+      theme,
+      dateStart,
+      dateEnd,
+      location,
+      capacity,
+      requirements,
+      createdBy,
+    ],
+  );
+  return mapEventRow(result.rows[0]);
+}
+
+async function updateEvent(eventId, updates = {}) {
+  await ensureSchema();
+  const fields = [];
+  const values = [];
+  const allowed = new Map([
+    ['title', 'title'],
+    ['description', 'description'],
+    ['category', 'category'],
+    ['theme', 'theme'],
+    ['dateStart', 'date_start'],
+    ['dateEnd', 'date_end'],
+    ['location', 'location'],
+    ['capacity', 'capacity'],
+    ['requirements', 'requirements'],
+  ]);
+
+  for (const [key, column] of allowed.entries()) {
+    if (Object.prototype.hasOwnProperty.call(updates, key)) {
+      fields.push(`${column} = $${fields.length + 1}`);
+      values.push(updates[key]);
+    }
+  }
+
+  if (!fields.length) {
+    const current = await pool.query('SELECT * FROM events WHERE id = $1', [eventId]);
+    const row = current.rows[0];
+    if (!row) {
+      throw Object.assign(new Error('Event not found'), { statusCode: 404 });
+    }
+    return mapEventRow(row);
+  }
+
+  values.push(eventId);
+  const result = await pool.query(
+    `
+      UPDATE events
+      SET ${fields.join(', ')}, updated_at = NOW()
+      WHERE id = $${fields.length + 1}
+      RETURNING *
+    `,
+    values,
+  );
+
+  if (!result.rows[0]) {
+    throw Object.assign(new Error('Event not found'), { statusCode: 404 });
+  }
+
+  return mapEventRow(result.rows[0]);
+}
+
+async function setEventStatus(eventId, status) {
+  const allowedStatuses = new Set(['DRAFT', 'PUBLISHED', 'CANCELLED', 'COMPLETED']);
+  if (!allowedStatuses.has(status)) {
+    throw Object.assign(new Error('Unsupported event status'), { statusCode: 400 });
+  }
+
+  return withTransaction(async (client) => {
+    await ensureSchema();
+    const current = await client.query('SELECT status FROM events WHERE id = $1 FOR UPDATE', [eventId]);
+    if (!current.rows[0]) {
+      throw Object.assign(new Error('Event not found'), { statusCode: 404 });
+    }
+
+    const result = await client.query(
+      `
+        UPDATE events
+        SET status = $2,
+            published_at = CASE WHEN $2 = 'PUBLISHED' THEN NOW() ELSE published_at END,
+            completed_at = CASE WHEN $2 = 'COMPLETED' THEN NOW() ELSE completed_at END,
+            updated_at = NOW()
+        WHERE id = $1
+        RETURNING *
+      `,
+      [eventId, status],
+    );
+
+    return mapEventRow(result.rows[0]);
+  });
+}
+
+async function findEventById(eventId, { client = pool } = {}) {
+  await ensureSchema();
+  const result = await client.query(
+    `
+      SELECT
+        e.*,
+        COALESCE(signups.count, 0) AS signup_count,
+        COALESCE(att.checked_in, 0) AS checked_in_count,
+        COALESCE(hours.total_minutes, 0) AS total_minutes
+      FROM events e
+      LEFT JOIN (
+        SELECT event_id, COUNT(*)::INT AS count
+        FROM event_signups
+        GROUP BY event_id
+      ) signups ON signups.event_id = e.id
+      LEFT JOIN (
+        SELECT event_id, COUNT(*)::INT AS checked_in
+        FROM event_attendance
+        WHERE check_in_at IS NOT NULL
+        GROUP BY event_id
+      ) att ON att.event_id = e.id
+      LEFT JOIN (
+        SELECT event_id, COALESCE(SUM(minutes), 0)::INT AS total_minutes
+        FROM volunteer_hours
+        GROUP BY event_id
+      ) hours ON hours.event_id = e.id
+      WHERE e.id = $1
+    `,
+    [eventId],
+  );
+  return mapEventRow(result.rows[0]);
+}
+
+async function listEventsForManager(managerId) {
+  await ensureSchema();
+  const result = await pool.query(
+    `
+      SELECT
+        e.*,
+        COALESCE(signups.count, 0) AS signup_count,
+        COALESCE(att.checked_in, 0) AS checked_in_count,
+        COALESCE(hours.total_minutes, 0) AS total_minutes
+      FROM events e
+      LEFT JOIN (
+        SELECT event_id, COUNT(*)::INT AS count
+        FROM event_signups
+        GROUP BY event_id
+      ) signups ON signups.event_id = e.id
+      LEFT JOIN (
+        SELECT event_id, COUNT(*)::INT AS checked_in
+        FROM event_attendance
+        WHERE check_in_at IS NOT NULL
+        GROUP BY event_id
+      ) att ON att.event_id = e.id
+      LEFT JOIN (
+        SELECT event_id, COALESCE(SUM(minutes), 0)::INT AS total_minutes
+        FROM volunteer_hours
+        GROUP BY event_id
+      ) hours ON hours.event_id = e.id
+      WHERE e.created_by = $1
+      ORDER BY e.date_start ASC
+    `,
+    [managerId],
+  );
+  return result.rows.map(mapEventRow);
+}
+
+async function listTasksForEvent(eventId, { client = pool } = {}) {
+  const result = await client.query(
+    `
+      SELECT id, event_id, title, description, required_count, created_at, updated_at
+      FROM event_tasks
+      WHERE event_id = $1
+      ORDER BY created_at ASC
+    `,
+    [eventId],
+  );
+  return result.rows.map((row) => ({
+    id: row.id,
+    eventId: row.event_id,
+    title: row.title,
+    description: row.description || '',
+    requiredCount: row.required_count,
+    createdAt: toIso(row.created_at),
+    updatedAt: toIso(row.updated_at),
+  }));
+}
+
+async function replaceEventTasks(eventId, tasks = []) {
+  return withTransaction(async (client) => {
+    await ensureSchema();
+    const event = await findEventById(eventId, { client });
+    if (!event) {
+      throw Object.assign(new Error('Event not found'), { statusCode: 404 });
+    }
+
+    const existing = await client.query(`SELECT id FROM event_tasks WHERE event_id = $1`, [eventId]);
+    const existingIds = new Set(existing.rows.map((row) => row.id));
+    const keepIds = new Set();
+
+    for (const task of tasks) {
+      if (!task || !task.title) {
+        throw Object.assign(new Error('Task title is required'), { statusCode: 400 });
+      }
+      const requiredCount = Number(task.requiredCount || task.required_count || 1);
+      if (!Number.isFinite(requiredCount) || requiredCount <= 0) {
+        throw Object.assign(new Error('Task required count must be greater than zero'), { statusCode: 400 });
+      }
+
+      if (task.id && existingIds.has(task.id)) {
+        await client.query(
+          `
+            UPDATE event_tasks
+            SET title = $1, description = $2, required_count = $3, updated_at = NOW()
+            WHERE id = $4 AND event_id = $5
+          `,
+          [task.title, task.description || null, requiredCount, task.id, eventId],
+        );
+        keepIds.add(task.id);
+      } else {
+        const id = randomUUID();
+        await client.query(
+          `
+            INSERT INTO event_tasks (id, event_id, title, description, required_count)
+            VALUES ($1, $2, $3, $4, $5)
+          `,
+          [id, eventId, task.title, task.description || null, requiredCount],
+        );
+        keepIds.add(id);
+      }
+    }
+
+    if (existingIds.size) {
+      const toDelete = [...existingIds].filter((id) => !keepIds.has(id));
+      if (toDelete.length) {
+        await client.query(
+          `DELETE FROM event_tasks WHERE event_id = $1 AND id = ANY($2::UUID[])`,
+          [eventId, toDelete],
+        );
+      }
+    }
+
+    return listTasksForEvent(eventId, { client });
+  });
+}
+
+async function listAssignmentsForEvent(eventId, { client = pool } = {}) {
+  const result = await client.query(
+    `
+      SELECT
+        ea.id,
+        ea.event_id,
+        ea.task_id,
+        ea.user_id,
+        ea.status,
+        ea.created_at,
+        ea.updated_at,
+        et.title AS task_title,
+        et.description AS task_description,
+        et.required_count,
+        u.name AS volunteer_name,
+        u.email AS volunteer_email
+      FROM event_assignments ea
+      JOIN event_tasks et ON et.id = ea.task_id
+      JOIN users u ON u.id = ea.user_id
+      WHERE ea.event_id = $1
+      ORDER BY et.title ASC, u.name ASC
+    `,
+    [eventId],
+  );
+  return result.rows.map((row) => ({
+    id: row.id,
+    eventId: row.event_id,
+    taskId: row.task_id,
+    userId: row.user_id,
+    status: row.status,
+    taskTitle: row.task_title,
+    taskDescription: row.task_description || '',
+    requiredCount: row.required_count,
+    volunteerName: row.volunteer_name,
+    volunteerEmail: row.volunteer_email,
+    createdAt: toIso(row.created_at),
+    updatedAt: toIso(row.updated_at),
+  }));
+}
+
+async function assignVolunteers(eventId, assignments = [], { assignedBy = null } = {}) {
+  if (!assignments.length) {
+    return { assignments: await listAssignmentsForEvent(eventId), newAssignments: [] };
+  }
+
+  return withTransaction(async (client) => {
+    await ensureSchema();
+    const event = await findEventById(eventId, { client });
+    if (!event) {
+      throw Object.assign(new Error('Event not found'), { statusCode: 404 });
+    }
+
+    const newAssignments = [];
+
+    for (const assignment of assignments) {
+      if (!assignment || !assignment.taskId || !assignment.userId) {
+        throw Object.assign(new Error('Task and volunteer identifiers are required'), { statusCode: 400 });
+      }
+
+      const taskResult = await client.query(
+        `SELECT id FROM event_tasks WHERE id = $1 AND event_id = $2`,
+        [assignment.taskId, eventId],
+      );
+      if (!taskResult.rows[0]) {
+        throw Object.assign(new Error('Task not found for this event'), { statusCode: 404 });
+      }
+
+      const signupResult = await client.query(
+        `SELECT id FROM event_signups WHERE event_id = $1 AND user_id = $2`,
+        [eventId, assignment.userId],
+      );
+      if (!signupResult.rows[0]) {
+        throw Object.assign(new Error('Volunteer must be registered for the event before assignment'), {
+          statusCode: 400,
+        });
+      }
+
+      const existing = await client.query(
+        `
+          SELECT id FROM event_assignments
+          WHERE event_id = $1 AND task_id = $2 AND user_id = $3
+        `,
+        [eventId, assignment.taskId, assignment.userId],
+      );
+
+      if (existing.rows[0]) {
+        await client.query(
+          `
+            UPDATE event_assignments
+            SET status = $1, updated_at = NOW()
+            WHERE id = $2
+          `,
+          [assignment.status || 'ASSIGNED', existing.rows[0].id],
+        );
+      } else {
+        const id = randomUUID();
+        const result = await client.query(
+          `
+            INSERT INTO event_assignments (id, event_id, task_id, user_id, status)
+            VALUES ($1, $2, $3, $4, $5)
+            RETURNING id
+          `,
+          [id, eventId, assignment.taskId, assignment.userId, assignment.status || 'ASSIGNED'],
+        );
+        newAssignments.push({ assignmentId: result.rows[0].id, userId: assignment.userId, taskId: assignment.taskId });
+      }
+    }
+
+    const assignmentsWithDetails = await listAssignmentsForEvent(eventId, { client });
+    return { assignments: assignmentsWithDetails, newAssignments };
+  });
+}
+
+async function getAttendanceRecord(eventId, userId, { client = pool } = {}) {
+  const result = await client.query(
+    `
+      SELECT id, event_id, user_id, check_in_at, check_out_at, minutes, hours_entry_id, created_at, updated_at
+      FROM event_attendance
+      WHERE event_id = $1 AND user_id = $2
+    `,
+    [eventId, userId],
+  );
+  return result.rows[0] || null;
+}
+
+async function recordAttendance(eventId, userId, { action, minutesOverride = null } = {}) {
+  if (!['check-in', 'check-out'].includes(action)) {
+    throw Object.assign(new Error('Action must be either check-in or check-out'), { statusCode: 400 });
+  }
+
+  return withTransaction(async (client) => {
+    await ensureSchema();
+    const event = await findEventById(eventId, { client });
+    if (!event) {
+      throw Object.assign(new Error('Event not found'), { statusCode: 404 });
+    }
+
+    const signupResult = await client.query(
+      `SELECT id FROM event_signups WHERE event_id = $1 AND user_id = $2`,
+      [eventId, userId],
+    );
+    if (!signupResult.rows[0]) {
+      throw Object.assign(new Error('Volunteer is not registered for this event'), { statusCode: 400 });
+    }
+
+    let attendance = await getAttendanceRecord(eventId, userId, { client });
+
+    if (!attendance) {
+      const id = randomUUID();
+      const insert = await client.query(
+        `
+          INSERT INTO event_attendance (id, event_id, user_id)
+          VALUES ($1, $2, $3)
+          RETURNING id, event_id, user_id, check_in_at, check_out_at, minutes, hours_entry_id, created_at, updated_at
+        `,
+        [id, eventId, userId],
+      );
+      attendance = insert.rows[0];
+    }
+
+    if (action === 'check-in') {
+      if (attendance.check_in_at) {
+        return {
+          ...attendance,
+          alreadyCheckedIn: true,
+        };
+      }
+      const updated = await client.query(
+        `
+          UPDATE event_attendance
+          SET check_in_at = NOW(), updated_at = NOW()
+          WHERE id = $1
+          RETURNING id, event_id, user_id, check_in_at, check_out_at, minutes, hours_entry_id, created_at, updated_at
+        `,
+        [attendance.id],
+      );
+      return { ...updated.rows[0], alreadyCheckedIn: false };
+    }
+
+    if (!attendance.check_in_at) {
+      throw Object.assign(new Error('Volunteer must be checked in before checking out'), { statusCode: 400 });
+    }
+
+    if (attendance.check_out_at) {
+      return { ...attendance, alreadyCheckedOut: true };
+    }
+
+    const checkInTime = new Date(attendance.check_in_at);
+    const checkoutDate = new Date();
+    const diffMs = Math.max(0, checkoutDate.getTime() - checkInTime.getTime());
+    const minutesComputed = minutesOverride
+      ? Number(minutesOverride)
+      : Math.max(1, Math.round(diffMs / 60000));
+
+    if (!Number.isFinite(minutesComputed) || minutesComputed <= 0) {
+      throw Object.assign(new Error('Computed attendance minutes must be greater than zero'), { statusCode: 400 });
+    }
+
+    let hoursEntryId = attendance.hours_entry_id;
+    if (!hoursEntryId) {
+      const hoursId = randomUUID();
+      const hoursResult = await client.query(
+        `
+          INSERT INTO volunteer_hours (id, user_id, event_id, minutes, note)
+          VALUES ($1, $2, $3, $4, $5)
+          RETURNING id
+        `,
+        [hoursId, userId, eventId, minutesComputed, 'Auto-tracked via event attendance'],
+      );
+      hoursEntryId = hoursResult.rows[0].id;
+    }
+
+    const updated = await client.query(
+      `
+        UPDATE event_attendance
+        SET check_out_at = NOW(), minutes = $2, hours_entry_id = $3, updated_at = NOW()
+        WHERE id = $1
+        RETURNING id, event_id, user_id, check_in_at, check_out_at, minutes, hours_entry_id, created_at, updated_at
+      `,
+      [attendance.id, minutesComputed, hoursEntryId],
+    );
+
+    return { ...updated.rows[0], alreadyCheckedOut: false };
+  });
+}
+
+async function listEventSignups(eventId, { client = pool } = {}) {
+  const result = await client.query(
+    `
+      SELECT
+        es.id,
+        es.user_id,
+        es.status,
+        es.created_at,
+        u.name,
+        u.email,
+        att.check_in_at,
+        att.check_out_at,
+        att.minutes
+      FROM event_signups es
+      JOIN users u ON u.id = es.user_id
+      LEFT JOIN event_attendance att ON att.event_id = es.event_id AND att.user_id = es.user_id
+      WHERE es.event_id = $1
+      ORDER BY u.name ASC
+    `,
+    [eventId],
+  );
+  return result.rows.map((row) => ({
+    signupId: row.id,
+    userId: row.user_id,
+    status: row.status,
+    createdAt: toIso(row.created_at),
+    name: row.name,
+    email: row.email,
+    checkInAt: toIso(row.check_in_at),
+    checkOutAt: toIso(row.check_out_at),
+    minutes: row.minutes,
+  }));
+}
+
+async function getUserContact(userId, { client = pool } = {}) {
+  const result = await client.query(
+    `SELECT id, name, email FROM users WHERE id = $1`,
+    [userId],
+  );
+  return result.rows[0] || null;
+}
+
+async function generateEventReport(eventId) {
+  await ensureSchema();
+  const event = await findEventById(eventId);
+  if (!event) {
+    throw Object.assign(new Error('Event not found'), { statusCode: 404 });
+  }
+
+  const [signupCountResult, checkedInResult, minutesResult] = await Promise.all([
+    pool.query(`SELECT COUNT(*)::INT AS count FROM event_signups WHERE event_id = $1`, [eventId]),
+    pool.query(
+      `SELECT COUNT(*)::INT AS checked_in FROM event_attendance WHERE event_id = $1 AND check_in_at IS NOT NULL`,
+      [eventId],
+    ),
+    pool.query(
+      `SELECT COALESCE(SUM(minutes), 0)::INT AS total_minutes FROM volunteer_hours WHERE event_id = $1`,
+      [eventId],
+    ),
+  ]);
+
+  const totalSignups = Number(signupCountResult.rows[0]?.count || 0);
+  const totalCheckedIn = Number(checkedInResult.rows[0]?.checked_in || 0);
+  const totalMinutes = Number(minutesResult.rows[0]?.total_minutes || 0);
+  const totalHours = totalMinutes / 60;
+  const attendanceRate = totalSignups ? totalCheckedIn / totalSignups : 0;
+
+  const reportResult = await pool.query(
+    `
+      INSERT INTO event_reports (event_id, total_signups, total_checked_in, total_hours, generated_at)
+      VALUES ($1, $2, $3, $4, NOW())
+      ON CONFLICT (event_id)
+      DO UPDATE SET
+        total_signups = EXCLUDED.total_signups,
+        total_checked_in = EXCLUDED.total_checked_in,
+        total_hours = EXCLUDED.total_hours,
+        generated_at = NOW()
+      RETURNING event_id, total_signups, total_checked_in, total_hours, generated_at
+    `,
+    [eventId, totalSignups, totalCheckedIn, Math.round(totalHours)],
+  );
+
+  const reportRow = reportResult.rows[0];
+
+  return {
+    event: mapEventRow(event),
+    totals: {
+      totalSignups,
+      totalCheckedIn,
+      attendanceRate,
+      totalHours,
+    },
+    storedReport: {
+      eventId: reportRow.event_id,
+      totalSignups: reportRow.total_signups,
+      totalCheckedIn: reportRow.total_checked_in,
+      totalHours: reportRow.total_hours,
+      generatedAt: toIso(reportRow.generated_at),
+    },
+  };
+}
+
+async function getEventDetail(eventId) {
+  await ensureSchema();
+  const event = await findEventById(eventId);
+  if (!event) {
+    throw Object.assign(new Error('Event not found'), { statusCode: 404 });
+  }
+
+  const [tasks, assignments, signups] = await Promise.all([
+    listTasksForEvent(eventId),
+    listAssignmentsForEvent(eventId),
+    listEventSignups(eventId),
+  ]);
+
+  return {
+    event,
+    tasks,
+    assignments,
+    signups,
+  };
+}
+
+module.exports = {
+  createEvent,
+  updateEvent,
+  setEventStatus,
+  findEventById,
+  listEventsForManager,
+  replaceEventTasks,
+  listTasksForEvent,
+  listAssignmentsForEvent,
+  assignVolunteers,
+  recordAttendance,
+  listEventSignups,
+  getUserContact,
+  generateEventReport,
+  getEventDetail,
+  withTransaction,
+};

--- a/backend/src/features/event-management/eventManagement.route.js
+++ b/backend/src/features/event-management/eventManagement.route.js
@@ -1,0 +1,231 @@
+const express = require('express');
+const { authenticate, authorizeRoles } = require('../auth/auth.middleware');
+const {
+  createEventDraft,
+  updateEventDetails,
+  publishEvent,
+  completeEvent,
+  getManagerEvents,
+  saveEventTasks,
+  getEventTasks,
+  getEventAssignments,
+  assignVolunteersToTasks,
+  recordVolunteerAttendance,
+  getEventSignups,
+  buildReport,
+  getEventOverview,
+} = require('./eventManagement.service');
+
+const router = express.Router();
+const authOnly = authenticate();
+const managerOnly = authorizeRoles('EVENT_MANAGER', 'ADMIN');
+const uuidPattern = /^[0-9a-fA-F-]{36}$/;
+
+router.use(authOnly, managerOnly);
+
+router.get('/events', async (req, res) => {
+  try {
+    const events = await getManagerEvents(req.user.id);
+    res.json({ events });
+  } catch (error) {
+    const status = error.statusCode || 500;
+    res.status(status).json({ error: error.message });
+  }
+});
+
+router.post('/events', async (req, res) => {
+  try {
+    const event = await createEventDraft({ payload: req.body || {}, actor: req.user });
+    res.status(201).json({ event });
+  } catch (error) {
+    const status = error.statusCode || 500;
+    res.status(status).json({ error: error.message });
+  }
+});
+
+router.patch('/events/:eventId', async (req, res) => {
+  try {
+    const { eventId } = req.params;
+    if (!uuidPattern.test(eventId)) {
+      return res.status(400).json({ error: 'Invalid event identifier' });
+    }
+    const event = await updateEventDetails(eventId, req.body || {});
+    res.json({ event });
+  } catch (error) {
+    const status = error.statusCode || 500;
+    res.status(status).json({ error: error.message });
+  }
+});
+
+router.post('/events/:eventId/publish', async (req, res) => {
+  try {
+    const { eventId } = req.params;
+    if (!uuidPattern.test(eventId)) {
+      return res.status(400).json({ error: 'Invalid event identifier' });
+    }
+    const event = await publishEvent(eventId, req.user);
+    res.json({ event });
+  } catch (error) {
+    const status = error.statusCode || 500;
+    res.status(status).json({ error: error.message });
+  }
+});
+
+router.post('/events/:eventId/complete', async (req, res) => {
+  try {
+    const { eventId } = req.params;
+    if (!uuidPattern.test(eventId)) {
+      return res.status(400).json({ error: 'Invalid event identifier' });
+    }
+    const event = await completeEvent(eventId);
+    res.json({ event });
+  } catch (error) {
+    const status = error.statusCode || 500;
+    res.status(status).json({ error: error.message });
+  }
+});
+
+router.get('/events/:eventId', async (req, res) => {
+  try {
+    const { eventId } = req.params;
+    if (!uuidPattern.test(eventId)) {
+      return res.status(400).json({ error: 'Invalid event identifier' });
+    }
+    const overview = await getEventOverview(eventId);
+    res.json(overview);
+  } catch (error) {
+    const status = error.statusCode || 500;
+    res.status(status).json({ error: error.message });
+  }
+});
+
+router.get('/events/:eventId/tasks', async (req, res) => {
+  try {
+    const { eventId } = req.params;
+    if (!uuidPattern.test(eventId)) {
+      return res.status(400).json({ error: 'Invalid event identifier' });
+    }
+    const tasks = await getEventTasks(eventId);
+    res.json({ tasks });
+  } catch (error) {
+    const status = error.statusCode || 500;
+    res.status(status).json({ error: error.message });
+  }
+});
+
+router.post('/events/:eventId/tasks', async (req, res) => {
+  try {
+    const { eventId } = req.params;
+    if (!uuidPattern.test(eventId)) {
+      return res.status(400).json({ error: 'Invalid event identifier' });
+    }
+    const tasksPayload = Array.isArray(req.body?.tasks) ? req.body.tasks : req.body || [];
+    const tasks = await saveEventTasks(eventId, tasksPayload);
+    res.json({ tasks });
+  } catch (error) {
+    const status = error.statusCode || 500;
+    res.status(status).json({ error: error.message });
+  }
+});
+
+router.get('/events/:eventId/assignments', async (req, res) => {
+  try {
+    const { eventId } = req.params;
+    if (!uuidPattern.test(eventId)) {
+      return res.status(400).json({ error: 'Invalid event identifier' });
+    }
+    const assignments = await getEventAssignments(eventId);
+    res.json({ assignments });
+  } catch (error) {
+    const status = error.statusCode || 500;
+    res.status(status).json({ error: error.message });
+  }
+});
+
+router.post('/events/:eventId/tasks/assignments', async (req, res) => {
+  try {
+    const { eventId } = req.params;
+    if (!uuidPattern.test(eventId)) {
+      return res.status(400).json({ error: 'Invalid event identifier' });
+    }
+    const assignmentsPayload = Array.isArray(req.body?.assignments)
+      ? req.body.assignments
+      : Array.isArray(req.body)
+      ? req.body
+      : [];
+    const assignments = await assignVolunteersToTasks(eventId, assignmentsPayload, req.user);
+    res.json({ assignments });
+  } catch (error) {
+    const status = error.statusCode || 500;
+    res.status(status).json({ error: error.message });
+  }
+});
+
+router.get('/events/:eventId/signups', async (req, res) => {
+  try {
+    const { eventId } = req.params;
+    if (!uuidPattern.test(eventId)) {
+      return res.status(400).json({ error: 'Invalid event identifier' });
+    }
+    const signups = await getEventSignups(eventId);
+    res.json({ signups });
+  } catch (error) {
+    const status = error.statusCode || 500;
+    res.status(status).json({ error: error.message });
+  }
+});
+
+router.post('/events/:eventId/check-in/:userId', async (req, res) => {
+  try {
+    const { eventId, userId } = req.params;
+    if (!uuidPattern.test(eventId) || !uuidPattern.test(userId)) {
+      return res.status(400).json({ error: 'Invalid identifiers supplied' });
+    }
+    const { action, minutes } = req.body || {};
+    const attendance = await recordVolunteerAttendance(eventId, userId, {
+      action: action || 'check-in',
+      minutesOverride: minutes,
+    });
+    res.json({ attendance });
+  } catch (error) {
+    const status = error.statusCode || 500;
+    res.status(status).json({ error: error.message });
+  }
+});
+
+router.get('/events/:eventId/report', async (req, res) => {
+  try {
+    const { eventId } = req.params;
+    if (!uuidPattern.test(eventId)) {
+      return res.status(400).json({ error: 'Invalid event identifier' });
+    }
+    const report = await buildReport(eventId);
+    if ((req.query.format || '').toLowerCase() === 'csv') {
+      const rows = [
+        ['Metric', 'Value'],
+        ['Event Title', report.event.title],
+        ['Start', report.event.dateStart],
+        ['End', report.event.dateEnd],
+        ['Total Signups', report.totals.totalSignups],
+        ['Checked In', report.totals.totalCheckedIn],
+        ['Attendance %', `${report.totals.attendanceRate}`],
+        ['Total Hours', report.totals.totalHours],
+      ];
+      const csv = rows
+        .map((row) => row.map((value) => `"${String(value ?? '').replace(/"/g, '""')}"`).join(','))
+        .join('\n');
+      res.setHeader('Content-Type', 'text/csv');
+      res.setHeader('Content-Disposition', `attachment; filename="event-${eventId}-report.csv"`);
+      return res.send(csv);
+    }
+    res.json({ report });
+  } catch (error) {
+    const status = error.statusCode || 500;
+    res.status(status).json({ error: error.message });
+  }
+});
+
+module.exports = {
+  basePath: '/api/manager',
+  router,
+};

--- a/backend/src/features/event-management/eventManagement.service.js
+++ b/backend/src/features/event-management/eventManagement.service.js
@@ -1,0 +1,313 @@
+const logger = require('../../utils/logger');
+const { sendTemplatedEmail } = require('../email/email.service');
+const {
+  createEvent,
+  updateEvent,
+  setEventStatus,
+  findEventById,
+  listEventsForManager,
+  replaceEventTasks,
+  assignVolunteers,
+  recordAttendance,
+  listEventSignups,
+  listTasksForEvent,
+  listAssignmentsForEvent,
+  generateEventReport,
+  getEventDetail,
+  getUserContact,
+} = require('./eventManagement.repository');
+
+function toIso(value) {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  return date.toISOString();
+}
+
+function parseDate(value, label) {
+  if (!value) {
+    throw Object.assign(new Error(`${label} is required`), { statusCode: 400 });
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    throw Object.assign(new Error(`${label} must be a valid ISO date/time`), { statusCode: 400 });
+  }
+  return date.toISOString();
+}
+
+function ensureCapacity(value) {
+  const num = Number(value);
+  if (!Number.isFinite(num) || num <= 0) {
+    throw Object.assign(new Error('Capacity must be greater than zero'), { statusCode: 400 });
+  }
+  return Math.round(num);
+}
+
+function normalizeEventPayload(payload = {}) {
+  const title = String(payload.title || '').trim();
+  const description = String(payload.description || '').trim();
+  const category = String(payload.category || '').trim();
+  const theme = payload.theme ? String(payload.theme).trim() : null;
+  const location = String(payload.location || '').trim();
+  const requirements = payload.requirements ? String(payload.requirements).trim() : null;
+
+  if (!title) {
+    throw Object.assign(new Error('Title is required'), { statusCode: 400 });
+  }
+  if (!description) {
+    throw Object.assign(new Error('Description is required'), { statusCode: 400 });
+  }
+  if (!category) {
+    throw Object.assign(new Error('Category is required'), { statusCode: 400 });
+  }
+  if (!location) {
+    throw Object.assign(new Error('Location is required'), { statusCode: 400 });
+  }
+
+  const dateStart = parseDate(payload.dateStart || payload.date_start, 'Start date');
+  const dateEnd = parseDate(payload.dateEnd || payload.date_end, 'End date');
+
+  if (new Date(dateEnd).getTime() < new Date(dateStart).getTime()) {
+    throw Object.assign(new Error('End date must be after the start date'), { statusCode: 400 });
+  }
+
+  const capacity = ensureCapacity(payload.capacity);
+
+  return {
+    title,
+    description,
+    category,
+    theme,
+    dateStart,
+    dateEnd,
+    location,
+    capacity,
+    requirements,
+  };
+}
+
+function mapEvent(event) {
+  if (!event) return null;
+  return {
+    ...event,
+    dateStart: toIso(event.dateStart || event.date_start),
+    dateEnd: toIso(event.dateEnd || event.date_end),
+    publishedAt: toIso(event.publishedAt || event.published_at),
+    completedAt: toIso(event.completedAt || event.completed_at),
+    createdAt: toIso(event.createdAt || event.created_at),
+    updatedAt: toIso(event.updatedAt || event.updated_at),
+  };
+}
+
+async function createEventDraft({ payload, actor }) {
+  const normalized = normalizeEventPayload(payload);
+  const event = await createEvent({ ...normalized, createdBy: actor?.id || null });
+  logger.info('Event draft created', { eventId: event.id, createdBy: actor?.id || null });
+  return mapEvent(event);
+}
+
+async function updateEventDetails(eventId, payload) {
+  const existing = await findEventById(eventId);
+  if (!existing) {
+    throw Object.assign(new Error('Event not found'), { statusCode: 404 });
+  }
+  const normalized = normalizeEventPayload({ ...existing, ...payload });
+  const event = await updateEvent(eventId, normalized);
+  logger.info('Event updated', { eventId });
+  return mapEvent(event);
+}
+
+async function publishEvent(eventId, actor) {
+  const event = await findEventById(eventId);
+  if (!event) {
+    throw Object.assign(new Error('Event not found'), { statusCode: 404 });
+  }
+  if (event.status === 'PUBLISHED') {
+    return mapEvent(event);
+  }
+  if (event.status === 'COMPLETED') {
+    throw Object.assign(new Error('Completed events cannot be republished'), { statusCode: 400 });
+  }
+
+  const updated = await setEventStatus(eventId, 'PUBLISHED');
+
+  if (actor?.email) {
+    try {
+      await sendTemplatedEmail({
+        to: actor.email,
+        subject: `Your event "${updated.title}" is now live`,
+        heading: 'Event published successfully',
+        bodyLines: [
+          `Great news, ${actor.name?.split(' ')[0] || 'there'}!`,
+          `Your event <strong>${updated.title}</strong> has been published and is now visible to volunteers.`,
+          `Capacity: ${updated.capacity} · Location: ${updated.location}`,
+        ],
+      });
+    } catch (error) {
+      logger.warn('Failed to send publish confirmation email', {
+        eventId,
+        error: error.message,
+      });
+    }
+  }
+
+  return mapEvent(updated);
+}
+
+async function completeEvent(eventId) {
+  const event = await findEventById(eventId);
+  if (!event) {
+    throw Object.assign(new Error('Event not found'), { statusCode: 404 });
+  }
+  if (event.status === 'COMPLETED') {
+    return mapEvent(event);
+  }
+  const updated = await setEventStatus(eventId, 'COMPLETED');
+  return mapEvent(updated);
+}
+
+async function getManagerEvents(managerId) {
+  const events = await listEventsForManager(managerId);
+  return events.map(mapEvent);
+}
+
+async function saveEventTasks(eventId, tasks) {
+  const list = await replaceEventTasks(eventId, tasks);
+  return list;
+}
+
+async function getEventTasks(eventId) {
+  return listTasksForEvent(eventId);
+}
+
+async function getEventAssignments(eventId) {
+  return listAssignmentsForEvent(eventId);
+}
+
+async function assignVolunteersToTasks(eventId, assignments, actor) {
+  const result = await assignVolunteers(eventId, assignments, { assignedBy: actor?.id || null });
+  const assignmentDetails = result.assignments;
+  const newAssignmentIds = new Set(result.newAssignments.map((item) => item.assignmentId));
+  const event = await findEventById(eventId);
+
+  const notifications = assignmentDetails.filter((assignment) => newAssignmentIds.has(assignment.id));
+
+  await Promise.all(
+    notifications.map(async (assignment) => {
+      if (!assignment.volunteerEmail) {
+        return;
+      }
+      try {
+        await sendTemplatedEmail({
+          to: assignment.volunteerEmail,
+          subject: `You're assigned to ${event.title}`,
+          heading: 'New volunteer assignment',
+          bodyLines: [
+            `Hi ${assignment.volunteerName?.split(' ')[0] || 'there'},`,
+            `You've been assigned to <strong>${assignment.taskTitle}</strong> for ${event.title}.`,
+            `Location: ${event.location}`,
+            `Shift window: ${toIso(event.dateStart)} → ${toIso(event.dateEnd)}`,
+          ],
+        });
+      } catch (error) {
+        logger.warn('Failed to send assignment email', {
+          eventId,
+          volunteerId: assignment.userId,
+          error: error.message,
+        });
+      }
+    }),
+  );
+
+  return assignmentDetails;
+}
+
+async function recordVolunteerAttendance(eventId, userId, { action, minutesOverride } = {}) {
+  const attendance = await recordAttendance(eventId, userId, { action, minutesOverride });
+  const event = await findEventById(eventId);
+  const signup = await getUserContact(userId);
+
+  const response = {
+    id: attendance.id,
+    eventId: attendance.event_id,
+    userId: attendance.user_id,
+    checkInAt: toIso(attendance.check_in_at),
+    checkOutAt: toIso(attendance.check_out_at),
+    minutes: attendance.minutes,
+    hoursEntryId: attendance.hours_entry_id || null,
+    alreadyCheckedIn: Boolean(attendance.alreadyCheckedIn),
+    alreadyCheckedOut: Boolean(attendance.alreadyCheckedOut),
+  };
+
+  if (signup?.email && action === 'check-out' && !attendance.alreadyCheckedOut) {
+    try {
+      await sendTemplatedEmail({
+        to: signup.email,
+        subject: `Thank you for supporting ${event.title}`,
+        heading: 'You made a difference today',
+        bodyLines: [
+          `We appreciate your time at <strong>${event.title}</strong>.`,
+          `Total time recorded: ${attendance.minutes || 0} minutes.`,
+          'Your contribution keeps our community thriving! 🌱',
+        ],
+      });
+    } catch (error) {
+      logger.warn('Failed to send post-event thank you email', {
+        eventId,
+        volunteerId: userId,
+        error: error.message,
+      });
+    }
+  }
+
+  return response;
+}
+
+async function getEventSignups(eventId) {
+  return listEventSignups(eventId);
+}
+
+async function buildReport(eventId) {
+  const report = await generateEventReport(eventId);
+  const attendancePercentage = report.totals.attendanceRate
+    ? Math.round(report.totals.attendanceRate * 10000) / 100
+    : 0;
+  return {
+    event: mapEvent(report.event),
+    totals: {
+      totalSignups: report.totals.totalSignups,
+      totalCheckedIn: report.totals.totalCheckedIn,
+      attendanceRate: attendancePercentage,
+      totalHours: Math.round(report.totals.totalHours * 100) / 100,
+    },
+    storedReport: report.storedReport,
+  };
+}
+
+async function getEventOverview(eventId) {
+  const detail = await getEventDetail(eventId);
+  return {
+    event: mapEvent(detail.event),
+    tasks: detail.tasks,
+    assignments: detail.assignments,
+    signups: detail.signups,
+  };
+}
+
+module.exports = {
+  createEventDraft,
+  updateEventDetails,
+  publishEvent,
+  completeEvent,
+  getManagerEvents,
+  saveEventTasks,
+  getEventTasks,
+  getEventAssignments,
+  assignVolunteersToTasks,
+  recordVolunteerAttendance,
+  getEventSignups,
+  buildReport,
+  getEventOverview,
+};

--- a/backend/src/features/volunteer-journey/volunteerJourney.service.js
+++ b/backend/src/features/volunteer-journey/volunteerJourney.service.js
@@ -123,6 +123,7 @@ function mapEventRow(event) {
     dateEnd: toIsoOrNull(event.date_end),
     location: event.location,
     capacity: event.capacity,
+    requirements: event.requirements || '',
     status: event.status,
     signupCount,
     availableSlots,
@@ -135,6 +136,28 @@ function mapSignupRow(row) {
   const signupCount = Number(row.signup_count || 0);
   const hasAvailable = row.available_slots !== undefined && row.available_slots !== null;
   const availableSlots = hasAvailable ? Number(row.available_slots) : Math.max(row.capacity - signupCount, 0);
+  const assignments = Array.isArray(row.assignments)
+    ? row.assignments.map((assignment) => ({
+        assignmentId: assignment.assignmentId,
+        taskId: assignment.taskId,
+        taskTitle: assignment.taskTitle,
+        taskDescription: assignment.taskDescription || '',
+        status: assignment.status,
+        createdAt: toIsoOrNull(assignment.createdAt),
+        updatedAt: toIsoOrNull(assignment.updatedAt),
+      }))
+    : [];
+  const attendance = row.attendance
+    ? {
+        id: row.attendance.id,
+        checkInAt: toIsoOrNull(row.attendance.check_in_at || row.attendance.checkInAt),
+        checkOutAt: toIsoOrNull(row.attendance.check_out_at || row.attendance.checkOutAt),
+        minutes: row.attendance.minutes ?? null,
+        hoursEntryId: row.attendance.hours_entry_id || row.attendance.hoursEntryId || null,
+        createdAt: toIsoOrNull(row.attendance.created_at || row.attendance.createdAt),
+        updatedAt: toIsoOrNull(row.attendance.updated_at || row.attendance.updatedAt),
+      }
+    : null;
   return {
     id: row.id,
     eventId: row.event_id,
@@ -151,9 +174,12 @@ function mapSignupRow(row) {
       dateEnd: toIsoOrNull(row.date_end),
       location: row.location,
       capacity: row.capacity,
+      requirements: row.requirements || '',
       signupCount,
       availableSlots,
     },
+    assignments,
+    attendance,
   };
 }
 

--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -4,3 +4,8 @@
 - **Date:** 2025-09-18
 - **Change:** Updated the volunteer journey router to register its endpoints relative to the `/api` base path so that dashboard requests such as `/api/me/dashboard` resolve correctly after login.
 - **Impact:** Volunteers can now load their dashboard without receiving the generic "Request failed" error because the routes map to the expected URLs.
+
+## Phase 3 event manager workflows
+- **Date:** 2025-09-19
+- **Change:** Introduced a dedicated event management feature set: managers can draft, update, publish, and complete events; define task boards; assign registered volunteers; process attendance with automatic hour logging; and generate shareable CSV impact reports. The frontend dashboard now surfaces a full workspace for these flows.
+- **Impact:** Event managers can coordinate end-to-end logistics from the dashboard while volunteers immediately see published events, their assignments, and updated hours when checked in on site.

--- a/frontend/src/features/dashboard/EventManagerDashboard.jsx
+++ b/frontend/src/features/dashboard/EventManagerDashboard.jsx
@@ -1,6 +1,6 @@
-import DashboardCard from './DashboardCard';
 import { useAuth } from '../auth/AuthContext';
 import useDocumentTitle from '../../lib/useDocumentTitle';
+import EventManagerWorkspace from '../event-manager/EventManagerWorkspace';
 
 export default function EventManagerDashboard() {
   const { user } = useAuth();
@@ -8,37 +8,14 @@ export default function EventManagerDashboard() {
   useDocumentTitle(`Onkur | Welcome back, ${firstName} 🌱`);
 
   return (
-    <div className="grid gap-5 md:[grid-template-columns:repeat(auto-fit,minmax(280px,1fr))]">
-      <header className="flex flex-col gap-2 md:col-span-full">
-        <h2 className="m-0 font-display text-2xl font-semibold text-brand-forest">
-          Welcome back, {firstName} 🌱
-        </h2>
+    <div className="flex flex-col gap-6">
+      <header className="flex flex-col gap-2">
+        <h2 className="m-0 font-display text-2xl font-semibold text-brand-forest">Welcome back, {firstName} 🌱</h2>
         <p className="m-0 text-sm text-brand-muted sm:text-base">
-          Plan meaningful experiences, assign volunteer crews, and showcase impact with visual storytelling.
+          Launch events, guide your volunteer crews, and share the impact your team creates.
         </p>
       </header>
-      <DashboardCard
-        title="Event pipeline"
-        description="Proposals, approvals, and execution timelines live here. The workflow module arrives in Phase 2."
-      >
-        <span className="inline-flex items-center gap-2 rounded-full bg-brand-sky/20 px-3 py-1 text-sm font-medium text-brand-sky">
-          🚧 Drafting tools on the way
-        </span>
-      </DashboardCard>
-      <DashboardCard
-        title="Volunteer coordination"
-        description="Build task boards, shift schedules, and attendance trackers to keep every event humming."
-      >
-        <p className="m-0 text-sm text-brand-muted">
-          Invite volunteers and assign micro-missions once the coordination suite launches.
-        </p>
-      </DashboardCard>
-      <DashboardCard
-        title="Gallery management"
-        description="Curate post-event photos with captions, highlight beneficiary quotes, and celebrate eco-wins."
-      >
-        <p className="m-0 text-sm text-brand-muted">Upload queues and moderation tools will land in Phase 2.</p>
-      </DashboardCard>
+      <EventManagerWorkspace />
     </div>
   );
 }

--- a/frontend/src/features/event-manager/AGENTS.md
+++ b/frontend/src/features/event-manager/AGENTS.md
@@ -1,0 +1,8 @@
+# Event Manager Frontend Guidelines
+
+These notes apply to files within `frontend/src/features/event-manager/`.
+
+- Keep interactions optimistic where reasonable: update local state first, then reconcile with API responses.
+- Favor lightweight composable components; prefer colocated hooks for data fetching tied to this feature instead of global state.
+- Forms should be mobile-first with stacked inputs and accessible labels; use inline status badges for success/error feedback.
+- When surfacing metrics, accompany numeric values with short descriptive labels for clarity on small screens.

--- a/frontend/src/features/event-manager/EventManagerWorkspace.jsx
+++ b/frontend/src/features/event-manager/EventManagerWorkspace.jsx
@@ -1,0 +1,829 @@
+import { useEffect, useMemo, useState } from 'react';
+import { apiRequest, API_BASE } from '../../lib/apiClient';
+import { useAuth } from '../auth/AuthContext';
+
+function formatDate(value) {
+  if (!value) return 'TBD';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return 'TBD';
+  return new Intl.DateTimeFormat('en-US', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(date);
+}
+
+function summarize(text, max = 160) {
+  if (!text) return '';
+  if (text.length <= max) return text;
+  return `${text.slice(0, max - 1)}…`;
+}
+
+const initialForm = {
+  title: '',
+  description: '',
+  category: '',
+  theme: '',
+  dateStart: '',
+  dateEnd: '',
+  location: '',
+  capacity: 10,
+  requirements: '',
+};
+
+export default function EventManagerWorkspace() {
+  const { token } = useAuth();
+  const [events, setEvents] = useState([]);
+  const [listState, setListState] = useState({ status: 'idle', error: '' });
+  const [form, setForm] = useState(initialForm);
+  const [createState, setCreateState] = useState({ status: 'idle', message: '' });
+  const [selectedId, setSelectedId] = useState(null);
+  const [detail, setDetail] = useState(null);
+  const [detailState, setDetailState] = useState({ status: 'idle', error: '' });
+  const [taskDrafts, setTaskDrafts] = useState([]);
+  const [taskState, setTaskState] = useState({ status: 'idle', message: '' });
+  const [assignmentState, setAssignmentState] = useState({ status: 'idle', message: '' });
+  const [attendanceState, setAttendanceState] = useState({});
+  const [report, setReport] = useState(null);
+  const [reportState, setReportState] = useState({ status: 'idle', error: '' });
+
+  const authHeaders = useMemo(
+    () => ({ token }),
+    [token],
+  );
+
+  useEffect(() => {
+    if (token) {
+      refreshEvents();
+    }
+  }, [token]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    if (detail?.tasks) {
+      setTaskDrafts(
+        detail.tasks.map((task) => ({
+          id: task.id,
+          title: task.title,
+          description: task.description || '',
+          requiredCount: task.requiredCount || 1,
+        })),
+      );
+    }
+  }, [detail?.tasks]);
+
+  const selectedEvent = useMemo(() => {
+    if (!selectedId) return null;
+    return events.find((event) => event.id === selectedId) || null;
+  }, [events, selectedId]);
+
+  async function refreshEvents() {
+    setListState({ status: 'loading', error: '' });
+    try {
+      const response = await apiRequest('/api/manager/events', authHeaders);
+      setEvents(response.events || []);
+      setListState({ status: 'success', error: '' });
+    } catch (error) {
+      setListState({ status: 'error', error: error.message || 'Unable to load events' });
+    }
+  }
+
+  async function refreshDetail(eventId) {
+    setDetailState({ status: 'loading', error: '' });
+    try {
+      const response = await apiRequest(`/api/manager/events/${eventId}`, authHeaders);
+      setDetail(response);
+      setDetailState({ status: 'success', error: '' });
+      setReport(null);
+    } catch (error) {
+      setDetailState({ status: 'error', error: error.message || 'Unable to load event details' });
+    }
+  }
+
+  const availableVolunteers = useMemo(() => {
+    if (!detail?.signups) return [];
+    return detail.signups.map((signup) => ({
+      userId: signup.userId,
+      name: signup.name || 'Volunteer',
+      email: signup.email,
+    }));
+  }, [detail?.signups]);
+
+  const assignmentOptions = useMemo(() => {
+    if (!detail?.tasks) return [];
+    return detail.tasks.map((task) => ({
+      id: task.id,
+      label: `${task.title} · needs ${task.requiredCount}`,
+    }));
+  }, [detail?.tasks]);
+
+  const existingAssignments = useMemo(() => detail?.assignments || [], [detail?.assignments]);
+
+  const checkedInCount = detail?.signups?.filter((signup) => Boolean(signup.checkInAt))?.length || 0;
+  const totalMinutes = detail?.event?.totalMinutes || 0;
+
+  const handleFormChange = (event) => {
+    const { name, value } = event.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleCreate = async (event) => {
+    event.preventDefault();
+    setCreateState({ status: 'loading', message: '' });
+    try {
+      const payload = {
+        ...form,
+        capacity: Number(form.capacity) || 1,
+      };
+      const response = await apiRequest('/api/manager/events', {
+        ...authHeaders,
+        method: 'POST',
+        body: payload,
+      });
+      setCreateState({ status: 'success', message: 'Draft saved' });
+      setForm(initialForm);
+      await refreshEvents();
+      if (response?.event?.id) {
+        setSelectedId(response.event.id);
+        await refreshDetail(response.event.id);
+      }
+    } catch (error) {
+      setCreateState({ status: 'error', message: error.message || 'Unable to create event' });
+    }
+  };
+
+  const handlePublish = async (eventId) => {
+    setListState((prev) => ({ ...prev, status: 'loading' }));
+    try {
+      await apiRequest(`/api/manager/events/${eventId}/publish`, {
+        ...authHeaders,
+        method: 'POST',
+      });
+      await refreshEvents();
+      if (selectedId === eventId) {
+        await refreshDetail(eventId);
+      }
+    } catch (error) {
+      setListState({ status: 'error', error: error.message || 'Unable to publish event' });
+    }
+  };
+
+  const handleComplete = async (eventId) => {
+    try {
+      await apiRequest(`/api/manager/events/${eventId}/complete`, {
+        ...authHeaders,
+        method: 'POST',
+      });
+      await refreshEvents();
+      if (selectedId === eventId) {
+        await refreshDetail(eventId);
+      }
+    } catch (error) {
+      setListState({ status: 'error', error: error.message || 'Unable to complete event' });
+    }
+  };
+
+  const handleSelectEvent = async (eventId) => {
+    setSelectedId(eventId);
+    await refreshDetail(eventId);
+  };
+
+  const handleTaskFieldChange = (taskId, field, value) => {
+    setTaskDrafts((prev) =>
+      prev.map((task) => (task.id === taskId ? { ...task, [field]: field === 'requiredCount' ? Number(value) : value } : task)),
+    );
+  };
+
+  const handleAddTask = () => {
+    const tempId = `temp-${Date.now()}`;
+    setTaskDrafts((prev) => [
+      ...prev,
+      { id: tempId, title: '', description: '', requiredCount: 1 },
+    ]);
+  };
+
+  const handleRemoveTask = (taskId) => {
+    setTaskDrafts((prev) => prev.filter((task) => task.id !== taskId));
+  };
+
+  const handleSaveTasks = async () => {
+    if (!selectedId) return;
+    setTaskState({ status: 'loading', message: '' });
+    try {
+      const payload = taskDrafts
+        .filter((task) => task.title.trim())
+        .map((task) => ({
+          id: task.id.startsWith('temp-') ? undefined : task.id,
+          title: task.title,
+          description: task.description,
+          requiredCount: Number(task.requiredCount) || 1,
+        }));
+      const response = await apiRequest(`/api/manager/events/${selectedId}/tasks`, {
+        ...authHeaders,
+        method: 'POST',
+        body: payload,
+      });
+      setTaskDrafts(
+        (response.tasks || []).map((task) => ({
+          id: task.id,
+          title: task.title,
+          description: task.description || '',
+          requiredCount: task.requiredCount || 1,
+        })),
+      );
+      setTaskState({ status: 'success', message: 'Tasks updated' });
+      await refreshDetail(selectedId);
+    } catch (error) {
+      setTaskState({ status: 'error', message: error.message || 'Unable to update tasks' });
+    }
+  };
+
+  const handleAssign = async (event) => {
+    event.preventDefault();
+    if (!selectedId) return;
+    const data = new FormData(event.target);
+    const taskId = data.get('taskId');
+    const userId = data.get('userId');
+    if (!taskId || !userId) {
+      setAssignmentState({ status: 'error', message: 'Select a task and volunteer' });
+      return;
+    }
+    setAssignmentState({ status: 'loading', message: '' });
+    try {
+      const response = await apiRequest(`/api/manager/events/${selectedId}/tasks/assignments`, {
+        ...authHeaders,
+        method: 'POST',
+        body: [{ taskId, userId }],
+      });
+      setDetail((prev) => ({
+        ...prev,
+        assignments: response.assignments || [],
+      }));
+      setAssignmentState({ status: 'success', message: 'Volunteer assigned' });
+      event.target.reset();
+    } catch (error) {
+      setAssignmentState({ status: 'error', message: error.message || 'Unable to assign volunteer' });
+    }
+  };
+
+  const handleAttendance = async (signup, action) => {
+    if (!selectedId) return;
+    setAttendanceState((prev) => ({ ...prev, [signup.userId]: { status: 'loading' } }));
+    try {
+      const response = await apiRequest(`/api/manager/events/${selectedId}/check-in/${signup.userId}`, {
+        ...authHeaders,
+        method: 'POST',
+        body: { action },
+      });
+      const attendance = response.attendance;
+      setDetail((prev) => {
+        const updatedSignups = (prev.signups || []).map((item) =>
+          item.userId === signup.userId
+            ? {
+                ...item,
+                checkInAt: attendance.checkInAt,
+                checkOutAt: attendance.checkOutAt,
+                minutes: attendance.minutes,
+              }
+            : item,
+        );
+        const updatedCheckedIn = updatedSignups.filter((item) => item.checkInAt).length;
+        setEvents((eventsList) =>
+          eventsList.map((event) =>
+            event.id === selectedId ? { ...event, checkedInCount: updatedCheckedIn } : event,
+          ),
+        );
+        return {
+          ...prev,
+          signups: updatedSignups,
+        };
+      });
+      setAttendanceState((prev) => ({ ...prev, [signup.userId]: { status: 'success', action } }));
+    } catch (error) {
+      setAttendanceState((prev) => ({
+        ...prev,
+        [signup.userId]: { status: 'error', message: error.message || 'Unable to update attendance' },
+      }));
+    }
+  };
+
+  const handleReport = async () => {
+    if (!selectedId) return;
+    setReportState({ status: 'loading', error: '' });
+    try {
+      const response = await apiRequest(`/api/manager/events/${selectedId}/report`, authHeaders);
+      setReport(response.report);
+      setReportState({ status: 'success', error: '' });
+    } catch (error) {
+      setReportState({ status: 'error', error: error.message || 'Unable to generate report' });
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-6">
+      <section className="rounded-2xl border border-brand-forest/10 bg-white p-5 shadow-[0_18px_40px_rgba(47,133,90,0.08)]">
+        <header className="flex flex-col gap-1 pb-4">
+          <h3 className="m-0 text-xl font-semibold text-brand-forest">Plan a new event</h3>
+          <p className="m-0 text-sm text-brand-muted">
+            Draft the essentials now and publish when you&apos;re ready for volunteers to join.
+          </p>
+        </header>
+        <form className="grid gap-3 sm:[grid-template-columns:repeat(2,minmax(0,1fr))]" onSubmit={handleCreate}>
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="font-semibold text-brand-forest">Title</span>
+            <input
+              required
+              name="title"
+              className="rounded-lg border border-brand-forest/20 bg-brand-sand/30 px-3 py-2 text-sm shadow-sm focus:border-brand-green focus:outline-none"
+              value={form.title}
+              onChange={handleFormChange}
+              placeholder="Community shoreline cleanup"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="font-semibold text-brand-forest">Category</span>
+            <input
+              required
+              name="category"
+              className="rounded-lg border border-brand-forest/20 bg-brand-sand/30 px-3 py-2 text-sm shadow-sm focus:border-brand-green focus:outline-none"
+              value={form.category}
+              onChange={handleFormChange}
+              placeholder="Cleanup, planting, education"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm sm:col-span-2">
+            <span className="font-semibold text-brand-forest">Description</span>
+            <textarea
+              required
+              name="description"
+              className="min-h-[96px] rounded-lg border border-brand-forest/20 bg-brand-sand/30 px-3 py-2 text-sm shadow-sm focus:border-brand-green focus:outline-none"
+              value={form.description}
+              onChange={handleFormChange}
+              placeholder="Share the mission, who you&apos;re supporting, and what to expect."
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="font-semibold text-brand-forest">Theme (optional)</span>
+            <input
+              name="theme"
+              className="rounded-lg border border-brand-forest/20 bg-brand-sand/30 px-3 py-2 text-sm shadow-sm focus:border-brand-green focus:outline-none"
+              value={form.theme}
+              onChange={handleFormChange}
+              placeholder="Biodiversity, youth, climate"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="font-semibold text-brand-forest">Location</span>
+            <input
+              required
+              name="location"
+              className="rounded-lg border border-brand-forest/20 bg-brand-sand/30 px-3 py-2 text-sm shadow-sm focus:border-brand-green focus:outline-none"
+              value={form.location}
+              onChange={handleFormChange}
+              placeholder="123 River Street park entrance"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="font-semibold text-brand-forest">Starts</span>
+            <input
+              required
+              type="datetime-local"
+              name="dateStart"
+              className="rounded-lg border border-brand-forest/20 bg-brand-sand/30 px-3 py-2 text-sm shadow-sm focus:border-brand-green focus:outline-none"
+              value={form.dateStart}
+              onChange={handleFormChange}
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="font-semibold text-brand-forest">Ends</span>
+            <input
+              required
+              type="datetime-local"
+              name="dateEnd"
+              className="rounded-lg border border-brand-forest/20 bg-brand-sand/30 px-3 py-2 text-sm shadow-sm focus:border-brand-green focus:outline-none"
+              value={form.dateEnd}
+              onChange={handleFormChange}
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="font-semibold text-brand-forest">Capacity</span>
+            <input
+              required
+              type="number"
+              min="1"
+              name="capacity"
+              className="rounded-lg border border-brand-forest/20 bg-brand-sand/30 px-3 py-2 text-sm shadow-sm focus:border-brand-green focus:outline-none"
+              value={form.capacity}
+              onChange={handleFormChange}
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm sm:col-span-2">
+            <span className="font-semibold text-brand-forest">Requirements</span>
+            <textarea
+              name="requirements"
+              className="min-h-[72px] rounded-lg border border-brand-forest/20 bg-brand-sand/30 px-3 py-2 text-sm shadow-sm focus:border-brand-green focus:outline-none"
+              value={form.requirements}
+              onChange={handleFormChange}
+              placeholder="Safety notes, attire, supplies to bring"
+            />
+          </label>
+          <div className="flex flex-wrap items-center gap-3 sm:col-span-2">
+            <button type="submit" className="btn-primary" disabled={createState.status === 'loading'}>
+              {createState.status === 'loading' ? 'Saving…' : 'Save draft'}
+            </button>
+            {createState.message ? (
+              <span
+                className={`text-xs font-semibold ${
+                  createState.status === 'error' ? 'text-red-600' : 'text-brand-green'
+                }`}
+              >
+                {createState.message}
+              </span>
+            ) : null}
+          </div>
+        </form>
+      </section>
+
+      <section className="flex flex-col gap-4">
+        <header className="flex flex-col gap-1">
+          <h3 className="m-0 text-xl font-semibold text-brand-forest">Your event pipeline</h3>
+          <p className="m-0 text-sm text-brand-muted">
+            Monitor draft, published, and completed events in one glance. Volunteers see published events instantly.
+          </p>
+        </header>
+        {listState.status === 'error' ? (
+          <p className="m-0 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{listState.error}</p>
+        ) : null}
+        <div className="grid gap-4 lg:[grid-template-columns:repeat(auto-fit,minmax(280px,1fr))]">
+          {events.map((event) => {
+            const isSelected = selectedId === event.id;
+            return (
+              <article
+                key={event.id}
+                className={`flex flex-col gap-3 rounded-2xl border border-brand-forest/10 bg-white p-4 shadow-[0_12px_28px_rgba(47,133,90,0.08)] ${
+                  isSelected ? 'ring-2 ring-brand-green' : ''
+                }`}
+              >
+                <header className="flex flex-col gap-1">
+                  <h4 className="m-0 text-base font-semibold text-brand-forest">{event.title}</h4>
+                  <p className="m-0 text-xs text-brand-muted">{summarize(event.description)}</p>
+                </header>
+                <dl className="grid gap-2 text-xs text-brand-muted [grid-template-columns:repeat(auto-fit,minmax(140px,1fr))]">
+                  <div>
+                    <dt className="font-semibold text-brand-forest">Status</dt>
+                    <dd className="m-0 uppercase tracking-wide text-brand-green">{event.status}</dd>
+                  </div>
+                  <div>
+                    <dt className="font-semibold text-brand-forest">Starts</dt>
+                    <dd className="m-0">{formatDate(event.dateStart)}</dd>
+                  </div>
+                  <div>
+                    <dt className="font-semibold text-brand-forest">Signups</dt>
+                    <dd className="m-0">{event.signupCount}</dd>
+                  </div>
+                  <div>
+                    <dt className="font-semibold text-brand-forest">Checked in</dt>
+                    <dd className="m-0">{event.checkedInCount || 0}</dd>
+                  </div>
+                </dl>
+                <div className="flex flex-wrap items-center gap-2">
+                  <button
+                    type="button"
+                    className="rounded-md border border-brand-forest/20 bg-brand-sand/60 px-3 py-1 text-xs font-semibold text-brand-forest"
+                    onClick={() => handleSelectEvent(event.id)}
+                  >
+                    {isSelected ? 'Viewing' : 'View details'}
+                  </button>
+                  {event.status === 'DRAFT' ? (
+                    <button
+                      type="button"
+                      className="btn-primary"
+                      onClick={() => handlePublish(event.id)}
+                    >
+                      Publish
+                    </button>
+                  ) : null}
+                  {event.status === 'PUBLISHED' ? (
+                    <button
+                      type="button"
+                      className="rounded-md border border-brand-forest/20 bg-white px-3 py-1 text-xs font-semibold text-brand-forest"
+                      onClick={() => handleComplete(event.id)}
+                    >
+                      Mark completed
+                    </button>
+                  ) : null}
+                </div>
+              </article>
+            );
+          })}
+          {!events.length && listState.status !== 'loading' ? (
+            <p className="m-0 rounded-2xl border border-dashed border-brand-forest/30 bg-white p-4 text-sm text-brand-muted">
+              Your drafts will appear here. Start planning an event to invite volunteers.
+            </p>
+          ) : null}
+        </div>
+      </section>
+
+      {selectedEvent ? (
+        <section className="rounded-2xl border border-brand-forest/10 bg-white p-5 shadow-[0_18px_40px_rgba(47,133,90,0.08)]">
+          <header className="flex flex-col gap-1 pb-4">
+            <h3 className="m-0 text-xl font-semibold text-brand-forest">{selectedEvent.title}</h3>
+            <p className="m-0 text-sm text-brand-muted">
+              {selectedEvent.status === 'PUBLISHED'
+                ? 'Volunteers can join this event now. Coordinate tasks and track attendance below.'
+                : 'Keep refining this plan before you publish it to volunteers.'}
+            </p>
+          </header>
+
+          {detailState.status === 'error' ? (
+            <p className="m-0 mb-4 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+              {detailState.error}
+            </p>
+          ) : null}
+
+          {detailState.status === 'loading' ? (
+            <p className="m-0 text-sm text-brand-muted">Loading event workspace…</p>
+          ) : null}
+
+          {detail ? (
+            <div className="grid gap-5 lg:[grid-template-columns:360px_1fr]">
+              <aside className="flex flex-col gap-4">
+                <div className="rounded-xl border border-brand-forest/10 bg-brand-sand/40 p-4">
+                  <h4 className="m-0 text-sm font-semibold uppercase tracking-wide text-brand-forest">Snapshot</h4>
+                  <dl className="mt-3 space-y-2 text-sm text-brand-muted">
+                    <div className="flex items-center justify-between">
+                      <dt className="font-medium text-brand-forest">Status</dt>
+                      <dd className="m-0 uppercase text-xs font-semibold text-brand-green">{detail.event.status}</dd>
+                    </div>
+                    <div className="flex items-center justify-between">
+                      <dt className="font-medium text-brand-forest">Capacity</dt>
+                      <dd className="m-0">{detail.event.capacity}</dd>
+                    </div>
+                    <div className="flex items-center justify-between">
+                      <dt className="font-medium text-brand-forest">Signups</dt>
+                      <dd className="m-0">{detail.signups?.length || 0}</dd>
+                    </div>
+                    <div className="flex items-center justify-between">
+                      <dt className="font-medium text-brand-forest">Checked in</dt>
+                      <dd className="m-0">{checkedInCount}</dd>
+                    </div>
+                    <div className="flex items-center justify-between">
+                      <dt className="font-medium text-brand-forest">Total volunteer minutes</dt>
+                      <dd className="m-0">{totalMinutes}</dd>
+                    </div>
+                  </dl>
+                  {detail.event.requirements ? (
+                    <p className="mt-3 rounded-lg bg-white/70 p-3 text-xs text-brand-muted">
+                      <span className="font-semibold text-brand-forest">Requirements:</span> {detail.event.requirements}
+                    </p>
+                  ) : null}
+                </div>
+
+                <div className="rounded-xl border border-brand-forest/10 bg-brand-sand/40 p-4">
+                  <h4 className="m-0 text-sm font-semibold uppercase tracking-wide text-brand-forest">Assignments</h4>
+                  <form className="mt-3 flex flex-col gap-3" onSubmit={handleAssign}>
+                    <label className="flex flex-col gap-1 text-xs">
+                      <span className="font-semibold text-brand-forest">Task</span>
+                      <select
+                        name="taskId"
+                        className="rounded-lg border border-brand-forest/20 bg-white px-3 py-2 text-sm focus:border-brand-green focus:outline-none"
+                        defaultValue=""
+                        required
+                      >
+                        <option value="" disabled>
+                          Choose a task
+                        </option>
+                        {assignmentOptions.map((task) => (
+                          <option key={task.id} value={task.id}>
+                            {task.label}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                    <label className="flex flex-col gap-1 text-xs">
+                      <span className="font-semibold text-brand-forest">Volunteer</span>
+                      <select
+                        name="userId"
+                        className="rounded-lg border border-brand-forest/20 bg-white px-3 py-2 text-sm focus:border-brand-green focus:outline-none"
+                        defaultValue=""
+                        required
+                      >
+                        <option value="" disabled>
+                          Choose a volunteer
+                        </option>
+                        {availableVolunteers.map((volunteer) => (
+                          <option key={volunteer.userId} value={volunteer.userId}>
+                            {volunteer.name} · {volunteer.email}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                    <button type="submit" className="btn-primary" disabled={assignmentState.status === 'loading'}>
+                      {assignmentState.status === 'loading' ? 'Assigning…' : 'Assign volunteer'}
+                    </button>
+                    {assignmentState.message ? (
+                      <span
+                        className={`text-xs font-semibold ${
+                          assignmentState.status === 'error' ? 'text-red-600' : 'text-brand-green'
+                        }`}
+                      >
+                        {assignmentState.message}
+                      </span>
+                    ) : null}
+                  </form>
+                </div>
+
+                <div className="rounded-xl border border-brand-forest/10 bg-brand-sand/40 p-4">
+                  <h4 className="m-0 text-sm font-semibold uppercase tracking-wide text-brand-forest">Impact report</h4>
+                  <div className="mt-3 flex flex-col gap-2 text-xs text-brand-muted">
+                    <button type="button" className="btn-primary" onClick={handleReport} disabled={reportState.status === 'loading'}>
+                      {reportState.status === 'loading' ? 'Crunching numbers…' : 'Generate summary'}
+                    </button>
+                    {reportState.status === 'error' ? (
+                      <span className="text-xs text-red-600">{reportState.error}</span>
+                    ) : null}
+                    {report ? (
+                      <div className="rounded-lg bg-white/80 p-3 text-xs text-brand-muted">
+                        <p className="m-0 font-semibold text-brand-forest">{report.event.title}</p>
+                        <p className="m-0">Signups: {report.totals.totalSignups}</p>
+                        <p className="m-0">Checked in: {report.totals.totalCheckedIn}</p>
+                        <p className="m-0">Attendance rate: {report.totals.attendanceRate}%</p>
+                        <p className="m-0">Total hours: {report.totals.totalHours}</p>
+                        <a
+                          className="mt-2 inline-flex items-center gap-1 text-brand-green"
+                          href={`${API_BASE}/api/manager/events/${selectedId}/report?format=csv`}
+                          target="_blank"
+                          rel="noreferrer"
+                        >
+                          Download CSV
+                        </a>
+                      </div>
+                    ) : null}
+                  </div>
+                </div>
+              </aside>
+
+              <div className="flex flex-col gap-5">
+                <section className="rounded-xl border border-brand-forest/10 bg-brand-sand/40 p-4">
+                  <header className="flex flex-col gap-1 pb-3">
+                    <h4 className="m-0 text-base font-semibold text-brand-forest">Task board</h4>
+                    <p className="m-0 text-xs text-brand-muted">Outline roles so volunteers know how they&apos;ll contribute.</p>
+                  </header>
+                  <div className="flex flex-col gap-3">
+                    {taskDrafts.map((task) => (
+                      <div key={task.id} className="rounded-lg bg-white/80 p-3 shadow-sm">
+                        <div className="grid gap-3 sm:[grid-template-columns:repeat(2,minmax(0,1fr))]">
+                          <label className="flex flex-col gap-1 text-xs">
+                            <span className="font-semibold text-brand-forest">Task title</span>
+                            <input
+                              className="rounded-md border border-brand-forest/20 bg-white px-3 py-2 text-sm focus:border-brand-green focus:outline-none"
+                              value={task.title}
+                              onChange={(event) => handleTaskFieldChange(task.id, 'title', event.target.value)}
+                              placeholder="Registration desk lead"
+                            />
+                          </label>
+                          <label className="flex flex-col gap-1 text-xs">
+                            <span className="font-semibold text-brand-forest">Needed volunteers</span>
+                            <input
+                              type="number"
+                              min="1"
+                              className="rounded-md border border-brand-forest/20 bg-white px-3 py-2 text-sm focus:border-brand-green focus:outline-none"
+                              value={task.requiredCount}
+                              onChange={(event) => handleTaskFieldChange(task.id, 'requiredCount', event.target.value)}
+                            />
+                          </label>
+                          <label className="flex flex-col gap-1 text-xs sm:col-span-2">
+                            <span className="font-semibold text-brand-forest">Description</span>
+                            <textarea
+                              className="min-h-[60px] rounded-md border border-brand-forest/20 bg-white px-3 py-2 text-sm focus:border-brand-green focus:outline-none"
+                              value={task.description}
+                              onChange={(event) => handleTaskFieldChange(task.id, 'description', event.target.value)}
+                              placeholder="Outline duties, schedules, or special gear."
+                            />
+                          </label>
+                        </div>
+                        <div className="mt-2 flex justify-end">
+                          <button
+                            type="button"
+                            className="text-xs text-red-600"
+                            onClick={() => handleRemoveTask(task.id)}
+                          >
+                            Remove
+                          </button>
+                        </div>
+                      </div>
+                    ))}
+                    <button
+                      type="button"
+                      className="rounded-md border border-brand-green bg-white px-3 py-2 text-xs font-semibold text-brand-green"
+                      onClick={handleAddTask}
+                    >
+                      + Add task
+                    </button>
+                    <div className="flex items-center gap-3">
+                      <button type="button" className="btn-primary" onClick={handleSaveTasks} disabled={taskState.status === 'loading'}>
+                        {taskState.status === 'loading' ? 'Saving…' : 'Save tasks'}
+                      </button>
+                      {taskState.message ? (
+                        <span
+                          className={`text-xs font-semibold ${
+                            taskState.status === 'error' ? 'text-red-600' : 'text-brand-green'
+                          }`}
+                        >
+                          {taskState.message}
+                        </span>
+                      ) : null}
+                    </div>
+                  </div>
+                </section>
+
+                <section className="rounded-xl border border-brand-forest/10 bg-brand-sand/40 p-4">
+                  <header className="flex flex-col gap-1 pb-3">
+                    <h4 className="m-0 text-base font-semibold text-brand-forest">Crew roster</h4>
+                    <p className="m-0 text-xs text-brand-muted">See who&apos;s on each task and share quick updates.</p>
+                  </header>
+                  {existingAssignments.length ? (
+                    <ul className="m-0 space-y-3 p-0">
+                      {existingAssignments.map((assignment) => (
+                        <li key={assignment.id} className="list-none rounded-lg bg-white/80 p-3 shadow-sm">
+                          <p className="m-0 text-sm font-semibold text-brand-forest">{assignment.taskTitle}</p>
+                          <p className="m-0 text-xs text-brand-muted">{assignment.volunteerName}</p>
+                          <p className="m-0 text-xs text-brand-muted">{assignment.volunteerEmail}</p>
+                          <p className="m-0 text-xs text-brand-muted">Status: {assignment.status}</p>
+                        </li>
+                      ))}
+                    </ul>
+                  ) : (
+                    <p className="m-0 text-sm text-brand-muted">No volunteers assigned yet.</p>
+                  )}
+                </section>
+
+                <section className="rounded-xl border border-brand-forest/10 bg-brand-sand/40 p-4">
+                  <header className="flex flex-col gap-1 pb-3">
+                    <h4 className="m-0 text-base font-semibold text-brand-forest">Attendance tracker</h4>
+                    <p className="m-0 text-xs text-brand-muted">Check volunteers in as they arrive and close out their hours.</p>
+                  </header>
+                  {detail.signups?.length ? (
+                    <div className="space-y-3">
+                      {detail.signups.map((signup) => {
+                        const state = attendanceState[signup.userId] || { status: 'idle' };
+                        return (
+                          <article key={signup.userId} className="rounded-lg bg-white/80 p-3 shadow-sm">
+                            <header className="flex flex-col gap-1">
+                              <h5 className="m-0 text-sm font-semibold text-brand-forest">{signup.name}</h5>
+                              <p className="m-0 text-xs text-brand-muted">{signup.email}</p>
+                            </header>
+                            <dl className="mt-2 grid gap-2 text-xs text-brand-muted [grid-template-columns:repeat(auto-fit,minmax(140px,1fr))]">
+                              <div>
+                                <dt className="font-semibold text-brand-forest">Checked in</dt>
+                                <dd className="m-0">{signup.checkInAt ? formatDate(signup.checkInAt) : 'Not yet'}</dd>
+                              </div>
+                              <div>
+                                <dt className="font-semibold text-brand-forest">Checked out</dt>
+                                <dd className="m-0">{signup.checkOutAt ? formatDate(signup.checkOutAt) : 'Not yet'}</dd>
+                              </div>
+                              <div>
+                                <dt className="font-semibold text-brand-forest">Minutes</dt>
+                                <dd className="m-0">{signup.minutes || 0}</dd>
+                              </div>
+                            </dl>
+                            <div className="mt-2 flex flex-wrap items-center gap-2">
+                              <button
+                                type="button"
+                                className="rounded-md border border-brand-green bg-white px-3 py-1 text-xs font-semibold text-brand-green"
+                                onClick={() => handleAttendance(signup, 'check-in')}
+                                disabled={Boolean(signup.checkInAt) || state.status === 'loading'}
+                              >
+                                {signup.checkInAt ? 'Checked in' : state.status === 'loading' ? 'Working…' : 'Check in'}
+                              </button>
+                              <button
+                                type="button"
+                                className="btn-primary"
+                                onClick={() => handleAttendance(signup, 'check-out')}
+                                disabled={!signup.checkInAt || Boolean(signup.checkOutAt) || state.status === 'loading'}
+                              >
+                                {signup.checkOutAt ? 'Completed' : state.status === 'loading' ? 'Working…' : 'Check out'}
+                              </button>
+                              {state.status === 'error' ? (
+                                <span className="text-xs text-red-600">{state.message}</span>
+                              ) : null}
+                              {state.status === 'success' ? (
+                                <span className="text-xs font-semibold text-brand-green">
+                                  {state.action === 'check-out' ? 'Hours logged' : 'Checked in!'}
+                                </span>
+                              ) : null}
+                            </div>
+                          </article>
+                        );
+                      })}
+                    </div>
+                  ) : (
+                    <p className="m-0 text-sm text-brand-muted">No volunteer signups yet.</p>
+                  )}
+                </section>
+              </div>
+            </div>
+          ) : null}
+        </section>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a dedicated event-management feature module with routes, service, and repository for drafts, publishing, tasks, assignments, attendance, and reporting
- extend the volunteer journey schema/queries to support uppercase statuses, requirements, tasks, assignments, attendance, and reports
- replace the event manager dashboard with a full workspace UI that handles creation, publishing, task boards, assignments, attendance, and reporting
- document the phase 3 event-manager workflow rollout in the wiki

## Testing
- `npm run test:connections` *(fails: Postgres connection not configured in CI environment)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68cc7a17e474833387a0d6f08eaf4c03