### PR TITLE
Revamp volunteer profile form with catalogs and modern UI

### DIFF
--- a/backend/src/features/volunteer-journey/AGENTS.md
+++ b/backend/src/features/volunteer-journey/AGENTS.md
@@ -4,6 +4,7 @@ These instructions apply to files within `backend/src/features/volunteer-journey
 
 - Keep data-access logic inside `volunteerJourney.repository.js`; service files should orchestrate validation, domain rules, and messaging.
 - Reuse helpers for array sanitization so profile fields remain lowercase-trimmed without duplicates.
+- Keep the profile option catalog in sync: update `DEFAULT_PROFILE_OPTIONS` and the state list together when adjusting presets.
 - When adding new badge thresholds, update both the badge catalogue in the service and the volunteer wiki documentation.
 - Ensure new queries remain friendly to the in-memory `pg-mem` test harness (avoid Postgres-only syntax outside common SQL).
 - Keep reminder scheduler changes behind the `NODE_ENV!=='test'` guard. When adjusting intervals, ensure timers call `unref()` so background jobs do not block Node process shutdown.

--- a/backend/tests/volunteerJourney.service.test.js
+++ b/backend/tests/volunteerJourney.service.test.js
@@ -88,19 +88,28 @@ describe('volunteerJourney.service', () => {
       userId: volunteer.id,
       skills: ['Tree Planting', 'tree planting', 'Community Outreach'],
       interests: ['Forests', 'Education'],
-      availability: 'Weekends',
+      availability: ['Weekends', 'weekday-evenings'],
       location: ' Pune ',
+      state: ' maharashtra ',
       bio: 'Ready to help nurture our urban forests.',
     });
 
     expect(updated.skills).toEqual(['tree planting', 'community outreach']);
     expect(updated.interests).toEqual(['forests', 'education']);
-    expect(updated.availability).toBe('Weekends');
+    expect(updated.availability).toEqual(['weekends', 'weekday-evenings']);
     expect(updated.location).toBe('Pune');
+    expect(updated.state).toBe('Maharashtra');
 
     const profile = await volunteerService.getProfile(volunteer.id);
     expect(profile.skills).toEqual(updated.skills);
     expect(profile.interests).toEqual(updated.interests);
+    expect(profile.availability).toEqual(updated.availability);
+    expect(profile.state).toBe(updated.state);
+
+    const catalogs = await volunteerService.getProfileCatalogs();
+    expect(Array.isArray(catalogs.skills)).toBe(true);
+    expect(catalogs.skills.length).toBeGreaterThan(0);
+    expect(catalogs.locations.some((option) => option.value === 'Pune')).toBe(true);
   });
 
   test('event signup enforces uniqueness and capacity while sending confirmation email', async () => {

--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -4,3 +4,8 @@
 - **Date:** 2025-09-18
 - **Change:** Updated the volunteer journey router to register its endpoints relative to the `/api` base path so that dashboard requests such as `/api/me/dashboard` resolve correctly after login.
 - **Impact:** Volunteers can now load their dashboard without receiving the generic "Request failed" error because the routes map to the expected URLs.
+
+## Volunteer profile form modernization
+- **Date:** 2025-09-19
+- **Change:** Revamped the volunteer profile API and editor to support curated catalogs for skills, interests, availability slots, Indian states, and city suggestions with the ability to contribute new skills, interests, and cities.
+- **Impact:** Coordinators can now filter volunteers using structured availability, state, and location data while volunteers enjoy a modernized multi-select interface that keeps the option lists in sync.

--- a/frontend/src/features/dashboard/VolunteerDashboard.jsx
+++ b/frontend/src/features/dashboard/VolunteerDashboard.jsx
@@ -33,6 +33,7 @@ export default function VolunteerDashboard() {
   const [error, setError] = useState(null);
   const [dashboard, setDashboard] = useState(null);
   const [profile, setProfile] = useState(null);
+  const [profileCatalogs, setProfileCatalogs] = useState(null);
   const [hoursSummary, setHoursSummary] = useState(null);
   const [signups, setSignups] = useState([]);
   const [events, setEvents] = useState([]);
@@ -73,6 +74,7 @@ export default function VolunteerDashboard() {
     if (!active) return;
     setDashboard(data);
     setProfile(data.profile);
+    setProfileCatalogs(data.profileCatalogs || null);
   }
 
   async function refreshHours(activeToken = token, active = true) {
@@ -106,10 +108,21 @@ export default function VolunteerDashboard() {
   }
 
   const handleProfileSave = async (payload) => {
-    const updated = await updateVolunteerProfile(token, payload);
-    setProfile(updated);
-    setDashboard((prev) => (prev ? { ...prev, profile: updated } : prev));
-    return updated;
+    const result = await updateVolunteerProfile(token, payload);
+    const updatedProfile = result?.profile || result;
+    if (updatedProfile) {
+      setProfile(updatedProfile);
+      setDashboard((prev) =>
+        prev ? { ...prev, profile: updatedProfile } : prev
+      );
+    }
+    if (result?.catalogs) {
+      setProfileCatalogs(result.catalogs);
+      setDashboard((prev) =>
+        prev ? { ...prev, profileCatalogs: result.catalogs } : prev
+      );
+    }
+    return result;
   };
 
   const handleEventSignup = async (eventId) => {
@@ -150,7 +163,7 @@ export default function VolunteerDashboard() {
         title="Profile & availability"
         description="Keep your skills and availability current so coordinators can match you to the best opportunities."
       >
-        <ProfileEditor profile={profile} onSave={handleProfileSave} />
+        <ProfileEditor profile={profile} catalogs={profileCatalogs} onSave={handleProfileSave} />
       </DashboardCard>
       <DashboardCard
         title="Upcoming commitments"

--- a/frontend/src/features/volunteer/AGENTS.md
+++ b/frontend/src/features/volunteer/AGENTS.md
@@ -7,3 +7,4 @@ These notes apply to files under `frontend/src/features/volunteer/`.
 - Surfaces that mutate backend data should display inline success and error states rather than relying on alerts.
 - When wiring new flows into the dashboard, reuse the shared refresh helpers so profile, signup, and hours panels stay in sync a
   fter mutations.
+- Reuse the token-input and picker patterns from `ProfileEditor.jsx` when adding new profile form affordances so the UX stays consistent.

--- a/frontend/src/features/volunteer/ProfileEditor.jsx
+++ b/frontend/src/features/volunteer/ProfileEditor.jsx
@@ -1,46 +1,357 @@
 import { useEffect, useMemo, useState } from 'react';
 
-function listToInput(value) {
-  return Array.isArray(value) && value.length ? value.join(', ') : '';
+const EMPTY_CATALOGS = {
+  skills: [],
+  interests: [],
+  availability: [],
+  locations: [],
+  states: [],
+};
+
+function toTitleCase(value) {
+  return String(value || '')
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join(' ');
 }
 
-export default function ProfileEditor({ profile, onSave }) {
+function arraysEqualIgnoreOrder(a = [], b = []) {
+  if (a.length !== b.length) return false;
+  const sortedA = [...a].sort();
+  const sortedB = [...b].sort();
+  return sortedA.every((value, index) => value === sortedB[index]);
+}
+
+function mergeOptionsWithSelections(options = [], selections = []) {
+  const map = new Map(options.map((option) => [option.value, option.label]));
+  const enriched = [...options];
+  selections.forEach((value) => {
+    if (!map.has(value)) {
+      enriched.push({ value, label: toTitleCase(value) });
+    }
+  });
+  return enriched;
+}
+
+function MultiTagField({
+  label,
+  helperText,
+  placeholder,
+  options = [],
+  value = [],
+  onChange,
+  name,
+}) {
+  const [inputValue, setInputValue] = useState('');
+  const [isFocused, setIsFocused] = useState(false);
+
+  const optionLookup = useMemo(() => {
+    const lookup = new Map();
+    options.forEach((option) => lookup.set(option.value, option.label));
+    return lookup;
+  }, [options]);
+
+  const filteredSuggestions = useMemo(() => {
+    const query = inputValue.trim().toLowerCase();
+    return options.filter((option) => {
+      if (value.includes(option.value)) return false;
+      if (!query) return true;
+      return option.label.toLowerCase().includes(query);
+    });
+  }, [inputValue, options, value]);
+
+  const handleAdd = (raw) => {
+    const normalized = raw && raw.trim().toLowerCase();
+    if (!normalized || value.includes(normalized)) {
+      return;
+    }
+    onChange([...value, normalized]);
+    setInputValue('');
+  };
+
+  const handleRemove = (item) => {
+    onChange(value.filter((entry) => entry !== item));
+  };
+
+  const handleKeyDown = (event) => {
+    if (['Enter', 'Tab', ','].includes(event.key)) {
+      if (inputValue.trim()) {
+        event.preventDefault();
+        handleAdd(inputValue);
+      }
+    } else if (event.key === 'Backspace' && !inputValue) {
+      onChange(value.slice(0, -1));
+    }
+  };
+
+  const handleBlur = () => {
+    if (inputValue.trim()) {
+      handleAdd(inputValue);
+    }
+    // Delay closing suggestions to allow click events to register.
+    setTimeout(() => setIsFocused(false), 100);
+  };
+
+  const getLabel = (item) => optionLookup.get(item) || toTitleCase(item);
+
+  return (
+    <label className="flex flex-col gap-2 text-sm">
+      <span className="font-semibold text-brand-forest">{label}</span>
+      <div className="flex flex-wrap items-center gap-2 rounded-xl border border-brand-forest/20 bg-white px-3 py-2 shadow-sm focus-within:border-brand-green focus-within:ring-1 focus-within:ring-brand-green/40">
+        {value.map((item) => (
+          <span
+            key={item}
+            className="flex items-center gap-1 rounded-full bg-brand-forest/10 px-2 py-1 text-xs font-medium text-brand-forest"
+          >
+            {getLabel(item)}
+            <button
+              type="button"
+              className="rounded-full p-0.5 text-brand-muted transition hover:text-brand-forest"
+              aria-label={`Remove ${getLabel(item)}`}
+              onClick={() => handleRemove(item)}
+            >
+              ×
+            </button>
+          </span>
+        ))}
+        <div className="relative flex-1 min-w-[140px]">
+          <input
+            className="w-full border-0 bg-transparent text-sm text-brand-forest placeholder:text-brand-muted focus:outline-none"
+            type="text"
+            name={name}
+            value={inputValue}
+            onChange={(event) => setInputValue(event.target.value)}
+            onFocus={() => setIsFocused(true)}
+            onKeyDown={handleKeyDown}
+            onBlur={handleBlur}
+            placeholder={placeholder}
+            autoComplete="off"
+          />
+          {isFocused && filteredSuggestions.length ? (
+            <ul className="absolute z-10 mt-2 max-h-48 min-w-[220px] overflow-auto rounded-lg border border-brand-forest/10 bg-white shadow-lg">
+              {filteredSuggestions.map((option) => (
+                <li key={option.value}>
+                  <button
+                    type="button"
+                    className="flex w-full items-center justify-start px-3 py-2 text-left text-sm text-brand-forest transition hover:bg-brand-sand/70"
+                    onMouseDown={(event) => event.preventDefault()}
+                    onClick={() => {
+                      handleAdd(option.value);
+                      setIsFocused(false);
+                    }}
+                  >
+                    {option.label}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+        </div>
+      </div>
+      {helperText ? <span className="text-xs text-brand-muted">{helperText}</span> : null}
+    </label>
+  );
+}
+
+function AvailabilityToggleGroup({ label, helperText, options = [], value = [], onChange }) {
+  const toggle = (optionValue) => {
+    if (value.includes(optionValue)) {
+      onChange(value.filter((item) => item !== optionValue));
+    } else {
+      onChange([...value, optionValue]);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-2 text-sm">
+      <span className="font-semibold text-brand-forest">{label}</span>
+      <div className="flex flex-wrap gap-2">
+        {options.map((option) => {
+          const active = value.includes(option.value);
+          return (
+            <button
+              type="button"
+              key={option.value}
+              className={`rounded-full border px-3 py-1 text-xs font-medium transition focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-forest/40 ${
+                active
+                  ? 'border-brand-forest bg-brand-forest text-white shadow-sm'
+                  : 'border-brand-forest/20 bg-white text-brand-forest hover:border-brand-forest/60'
+              }`}
+              onClick={() => toggle(option.value)}
+            >
+              {option.label}
+            </button>
+          );
+        })}
+      </div>
+      {helperText ? <span className="text-xs text-brand-muted">{helperText}</span> : null}
+    </div>
+  );
+}
+
+function LocationSelectField({
+  label,
+  helperText,
+  placeholder,
+  options = [],
+  value = '',
+  onChange,
+}) {
+  const [query, setQuery] = useState('');
+  const [isOpen, setIsOpen] = useState(false);
+
+  useEffect(() => {
+    if (!value) {
+      setQuery('');
+      return;
+    }
+    const match = options.find((option) => option.value === value || option.label === value);
+    if (match) {
+      setQuery(match.label);
+    } else {
+      setQuery(value);
+    }
+  }, [value, options]);
+
+  const filteredOptions = useMemo(() => {
+    const search = query.trim().toLowerCase();
+    if (!search) {
+      return options;
+    }
+    return options.filter((option) => option.label.toLowerCase().includes(search));
+  }, [options, query]);
+
+  const commitValue = (nextValue) => {
+    const trimmed = nextValue.trim();
+    if (!trimmed) {
+      onChange('');
+      setQuery('');
+      return;
+    }
+    const normalized = toTitleCase(trimmed);
+    onChange(normalized);
+    setQuery(normalized);
+  };
+
+  return (
+    <label className="flex flex-col gap-2 text-sm">
+      <span className="font-semibold text-brand-forest">{label}</span>
+      <div className="relative">
+        <input
+          className="w-full rounded-xl border border-brand-forest/20 bg-white px-3 py-2 text-sm text-brand-forest shadow-sm focus:border-brand-green focus:outline-none focus:ring-1 focus:ring-brand-green/40"
+          type="text"
+          value={query}
+          placeholder={placeholder}
+          onFocus={() => setIsOpen(true)}
+          onChange={(event) => {
+            setQuery(event.target.value);
+            setIsOpen(true);
+          }}
+          onBlur={() => {
+            setTimeout(() => setIsOpen(false), 100);
+            commitValue(query);
+          }}
+        />
+        {isOpen && filteredOptions.length ? (
+          <ul className="absolute z-10 mt-2 max-h-48 w-full overflow-auto rounded-lg border border-brand-forest/10 bg-white shadow-lg">
+            {filteredOptions.map((option) => (
+              <li key={option.value}>
+                <button
+                  type="button"
+                  className="flex w-full items-center justify-start px-3 py-2 text-left text-sm text-brand-forest transition hover:bg-brand-sand/70"
+                  onMouseDown={(event) => event.preventDefault()}
+                  onClick={() => {
+                    onChange(option.value);
+                    setQuery(option.label);
+                    setIsOpen(false);
+                  }}
+                >
+                  {option.label}
+                </button>
+              </li>
+            ))}
+          </ul>
+        ) : null}
+      </div>
+      {helperText ? <span className="text-xs text-brand-muted">{helperText}</span> : null}
+    </label>
+  );
+}
+
+function StateSelectField({ label, helperText, options = [], value = '', onChange }) {
+  return (
+    <label className="flex flex-col gap-2 text-sm">
+      <span className="font-semibold text-brand-forest">{label}</span>
+      <select
+        className="rounded-xl border border-brand-forest/20 bg-white px-3 py-2 text-sm text-brand-forest shadow-sm focus:border-brand-green focus:outline-none focus:ring-1 focus:ring-brand-green/40"
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+      >
+        <option value="">Select state</option>
+        {options.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+      {helperText ? <span className="text-xs text-brand-muted">{helperText}</span> : null}
+    </label>
+  );
+}
+
+export default function ProfileEditor({ profile, catalogs, onSave }) {
   const [form, setForm] = useState({
-    skills: '',
-    interests: '',
-    availability: '',
+    skills: [],
+    interests: [],
+    availability: [],
     location: '',
+    state: '',
     bio: '',
   });
   const [saving, setSaving] = useState(false);
   const [status, setStatus] = useState(null);
 
-  const hasChanges = useMemo(() => {
-    if (!profile) return false;
-    return (
-      form.skills !== listToInput(profile.skills) ||
-      form.interests !== listToInput(profile.interests) ||
-      form.availability !== (profile.availability || '') ||
-      form.location !== (profile.location || '') ||
-      form.bio !== (profile.bio || '')
-    );
-  }, [form, profile]);
+  const mergedCatalogs = catalogs || EMPTY_CATALOGS;
 
   useEffect(() => {
     if (!profile) return;
     setForm({
-      skills: listToInput(profile.skills),
-      interests: listToInput(profile.interests),
-      availability: profile.availability || '',
+      skills: Array.isArray(profile.skills) ? profile.skills : [],
+      interests: Array.isArray(profile.interests) ? profile.interests : [],
+      availability: Array.isArray(profile.availability) ? profile.availability : [],
       location: profile.location || '',
+      state: profile.state || '',
       bio: profile.bio || '',
     });
   }, [profile]);
 
-  const handleChange = (event) => {
-    const { name, value } = event.target;
-    setForm((prev) => ({ ...prev, [name]: value }));
-  };
+  const skillOptions = useMemo(
+    () => mergeOptionsWithSelections(mergedCatalogs.skills, form.skills),
+    [mergedCatalogs.skills, form.skills]
+  );
+  const interestOptions = useMemo(
+    () => mergeOptionsWithSelections(mergedCatalogs.interests, form.interests),
+    [mergedCatalogs.interests, form.interests]
+  );
+  const availabilityOptions = mergedCatalogs.availability || [];
+  const locationOptions = useMemo(
+    () => mergeOptionsWithSelections(mergedCatalogs.locations, form.location ? [form.location] : []),
+    [mergedCatalogs.locations, form.location]
+  );
+  const stateOptions = mergedCatalogs.states || [];
+
+  const hasChanges = useMemo(() => {
+    if (!profile) return false;
+    return (
+      !arraysEqualIgnoreOrder(form.skills, profile.skills || []) ||
+      !arraysEqualIgnoreOrder(form.interests, profile.interests || []) ||
+      !arraysEqualIgnoreOrder(form.availability, profile.availability || []) ||
+      (form.location || '') !== (profile.location || '') ||
+      (form.state || '') !== (profile.state || '') ||
+      (form.bio || '') !== (profile.bio || '')
+    );
+  }, [form, profile]);
 
   const handleSubmit = async (event) => {
     event.preventDefault();
@@ -49,90 +360,87 @@ export default function ProfileEditor({ profile, onSave }) {
     setStatus(null);
     try {
       const payload = {
-        skills: form.skills
-          .split(',')
-          .map((item) => item.trim())
-          .filter(Boolean),
-        interests: form.interests
-          .split(',')
-          .map((item) => item.trim())
-          .filter(Boolean),
+        skills: form.skills,
+        interests: form.interests,
         availability: form.availability,
         location: form.location,
+        state: form.state,
         bio: form.bio,
       };
-      const updated = await onSave(payload);
+      const result = await onSave(payload);
+      const nextProfile = result?.profile || result;
       setStatus({ type: 'success', message: 'Profile saved successfully.' });
-      setForm({
-        skills: listToInput(updated.skills),
-        interests: listToInput(updated.interests),
-        availability: updated.availability || '',
-        location: updated.location || '',
-        bio: updated.bio || '',
-      });
+      if (nextProfile) {
+        setForm({
+          skills: Array.isArray(nextProfile.skills) ? nextProfile.skills : [],
+          interests: Array.isArray(nextProfile.interests) ? nextProfile.interests : [],
+          availability: Array.isArray(nextProfile.availability) ? nextProfile.availability : [],
+          location: nextProfile.location || '',
+          state: nextProfile.state || '',
+          bio: nextProfile.bio || '',
+        });
+      }
     } catch (error) {
-      setStatus({ type: 'error', message: error.message || 'Unable to update your profile.' });
+      setStatus({
+        type: 'error',
+        message: error.message || 'Unable to update your profile.',
+      });
     } finally {
       setSaving(false);
     }
   };
 
   return (
-    <form className="flex flex-col gap-4" onSubmit={handleSubmit}>
-      <div className="grid gap-3">
-        <label className="flex flex-col gap-1 text-sm">
-          <span className="font-semibold text-brand-forest">Skills</span>
-          <input
-            className="rounded-lg border border-brand-forest/20 bg-white px-3 py-2 text-sm shadow-sm focus:border-brand-green focus:outline-none"
-            type="text"
-            name="skills"
-            placeholder="e.g. planting, first aid, coordination"
-            value={form.skills}
-            onChange={handleChange}
-          />
-          <span className="text-xs text-brand-muted">Separate skills with commas to help us match you to the right roles.</span>
-        </label>
-        <label className="flex flex-col gap-1 text-sm">
-          <span className="font-semibold text-brand-forest">Interests</span>
-          <input
-            className="rounded-lg border border-brand-forest/20 bg-white px-3 py-2 text-sm shadow-sm focus:border-brand-green focus:outline-none"
-            type="text"
-            name="interests"
-            placeholder="e.g. wetlands, youth mentorship"
-            value={form.interests}
-            onChange={handleChange}
-          />
-        </label>
-        <label className="flex flex-col gap-1 text-sm">
-          <span className="font-semibold text-brand-forest">Availability</span>
-          <input
-            className="rounded-lg border border-brand-forest/20 bg-white px-3 py-2 text-sm shadow-sm focus:border-brand-green focus:outline-none"
-            type="text"
-            name="availability"
-            placeholder="Weekends, weekday evenings, etc."
-            value={form.availability}
-            onChange={handleChange}
-          />
-        </label>
-        <label className="flex flex-col gap-1 text-sm">
-          <span className="font-semibold text-brand-forest">Location</span>
-          <input
-            className="rounded-lg border border-brand-forest/20 bg-white px-3 py-2 text-sm shadow-sm focus:border-brand-green focus:outline-none"
-            type="text"
-            name="location"
-            placeholder="City or neighbourhood"
-            value={form.location}
-            onChange={handleChange}
-          />
-        </label>
-        <label className="flex flex-col gap-1 text-sm">
+    <form className="flex flex-col gap-5" onSubmit={handleSubmit}>
+      <div className="grid gap-4">
+        <MultiTagField
+          label="Skills"
+          helperText="Add all the talents you want coordinators to know about."
+          placeholder="Add a skill and press Enter"
+          options={skillOptions}
+          value={form.skills}
+          onChange={(next) => setForm((prev) => ({ ...prev, skills: next }))}
+          name="skills"
+        />
+        <MultiTagField
+          label="Interests"
+          helperText="What causes energize you? Add as many interests as you like."
+          placeholder="Add an interest"
+          options={interestOptions}
+          value={form.interests}
+          onChange={(next) => setForm((prev) => ({ ...prev, interests: next }))}
+          name="interests"
+        />
+        <AvailabilityToggleGroup
+          label="Availability"
+          helperText="Choose all the time windows you can typically support."
+          options={availabilityOptions}
+          value={form.availability}
+          onChange={(next) => setForm((prev) => ({ ...prev, availability: next }))}
+        />
+        <LocationSelectField
+          label="Location"
+          helperText="Pick your city so we can recommend nearby opportunities."
+          placeholder="Search or add your city"
+          options={locationOptions}
+          value={form.location}
+          onChange={(next) => setForm((prev) => ({ ...prev, location: next }))}
+        />
+        <StateSelectField
+          label="State"
+          helperText="States help us route you to the right regional coordinator."
+          options={stateOptions}
+          value={form.state}
+          onChange={(next) => setForm((prev) => ({ ...prev, state: next }))}
+        />
+        <label className="flex flex-col gap-2 text-sm">
           <span className="font-semibold text-brand-forest">Bio</span>
           <textarea
-            className="min-h-[96px] rounded-lg border border-brand-forest/20 bg-white px-3 py-2 text-sm shadow-sm focus:border-brand-green focus:outline-none"
+            className="min-h-[96px] rounded-xl border border-brand-forest/20 bg-white px-3 py-2 text-sm text-brand-forest shadow-sm focus:border-brand-green focus:outline-none focus:ring-1 focus:ring-brand-green/40"
             name="bio"
             placeholder="Share a sentence about why you volunteer."
             value={form.bio}
-            onChange={handleChange}
+            onChange={(event) => setForm((prev) => ({ ...prev, bio: event.target.value }))}
           />
         </label>
       </div>
@@ -145,12 +453,8 @@ export default function ProfileEditor({ profile, onSave }) {
           {status.message}
         </p>
       ) : null}
-      <div className="flex flex-wrap gap-2">
-        <button
-          type="submit"
-          className="btn-primary"
-          disabled={saving || !hasChanges}
-        >
+      <div className="flex flex-wrap items-center gap-2">
+        <button type="submit" className="btn-primary" disabled={saving || !hasChanges}>
           {saving ? 'Saving…' : 'Save profile'}
         </button>
         {!hasChanges ? (


### PR DESCRIPTION
## Summary
- restructure volunteer profile storage to support availability arrays, state field, and shared option catalogs
- surface catalog metadata via API routes and dashboard, ensuring tests cover new normalization
- refresh profile editor UI with token inputs, availability toggles, and updated documentation and guidelines

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc7d5e82008333bf330158b8b8fbe5