### PR TITLE
Add desktop navigation parity and dedicated dashboard routes

### DIFF
--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -1,5 +1,10 @@
 # Onkur Change Log
 
+## Desktop navigation parity
+- **Date:** 2025-09-18
+- **Change:** Introduced a desktop header navigation that mirrors the mobile bottom menu, centralized the navigation config, and wired menu items to new `/app/events`, `/app/gallery`, and `/app/profile` routes.
+- **Impact:** Authenticated users can now move between dashboard sections on both mobile and desktop, with dedicated views for events, gallery spotlights, and profile management.
+
 ## Volunteer dashboard API routing fix
 - **Date:** 2025-09-18
 - **Change:** Updated the volunteer journey router to register its endpoints relative to the `/api` base path so that dashboard requests such as `/api/me/dashboard` resolve correctly after login.

--- a/frontend/src/features/dashboard/DashboardRouter.jsx
+++ b/frontend/src/features/dashboard/DashboardRouter.jsx
@@ -1,8 +1,26 @@
+import { Navigate, Route, Routes } from 'react-router-dom';
+
 import { useAuth } from '../auth/AuthContext';
 import AdminDashboard from './AdminDashboard';
 import EventManagerDashboard from './EventManagerDashboard';
+import EventsPage from './EventsPage';
+import GalleryPage from './GalleryPage';
+import ProfilePage from './ProfilePage';
 import SponsorDashboard from './SponsorDashboard';
 import VolunteerDashboard from './VolunteerDashboard';
+
+const HOME_COMPONENTS = {
+  ADMIN: AdminDashboard,
+  EVENT_MANAGER: EventManagerDashboard,
+  SPONSOR: SponsorDashboard,
+};
+
+function resolveHome(role) {
+  if (role && HOME_COMPONENTS[role]) {
+    return HOME_COMPONENTS[role];
+  }
+  return VolunteerDashboard;
+}
 
 export default function DashboardRouter() {
   const { user } = useAuth();
@@ -11,14 +29,15 @@ export default function DashboardRouter() {
     return null;
   }
 
-  switch (user.role) {
-    case 'ADMIN':
-      return <AdminDashboard />;
-    case 'EVENT_MANAGER':
-      return <EventManagerDashboard />;
-    case 'SPONSOR':
-      return <SponsorDashboard />;
-    default:
-      return <VolunteerDashboard />;
-  }
+  const HomeComponent = resolveHome(user.role);
+
+  return (
+    <Routes>
+      <Route index element={<HomeComponent />} />
+      <Route path="events" element={<EventsPage role={user.role} />} />
+      <Route path="gallery" element={<GalleryPage role={user.role} />} />
+      <Route path="profile" element={<ProfilePage role={user.role} />} />
+      <Route path="*" element={<Navigate to="." replace />} />
+    </Routes>
+  );
 }

--- a/frontend/src/features/dashboard/EventsPage.jsx
+++ b/frontend/src/features/dashboard/EventsPage.jsx
@@ -1,0 +1,113 @@
+import { useEffect, useMemo, useState } from 'react';
+
+import useDocumentTitle from '../../lib/useDocumentTitle';
+import { useAuth } from '../auth/AuthContext';
+import EventDiscovery from '../volunteer/EventDiscovery';
+import { fetchEvents, signupForEvent } from '../volunteer/api';
+import DashboardCard from './DashboardCard';
+
+const DEFAULT_FILTERS = { category: '', location: '', theme: '', date: '' };
+
+function buildIntro(role, firstName) {
+  switch (role) {
+    case 'EVENT_MANAGER':
+      return {
+        title: `Plan your next experience, ${firstName}`,
+        description:
+          'Monitor live opportunities, confirm details, and ensure volunteers can find the right fit. Use the filters to audit what is published.',
+      };
+    case 'SPONSOR':
+      return {
+        title: `Spotlight upcoming collaborations, ${firstName}`,
+        description:
+          'Review the experiences you support and get a quick snapshot of what is open for the community right now.',
+      };
+    case 'ADMIN':
+      return {
+        title: `Track events across Onkur, ${firstName}`,
+        description:
+          'Keep a pulse on the opportunities that are currently collecting volunteers so you can coordinate support if needed.',
+      };
+    default:
+      return {
+        title: `Find your next event, ${firstName}`,
+        description:
+          'Filter by category, location, theme, or date to discover opportunities that match your energy and availability.',
+      };
+  }
+}
+
+export default function EventsPage({ role }) {
+  const { token, user } = useAuth();
+  const [events, setEvents] = useState([]);
+  const [filters, setFilters] = useState(DEFAULT_FILTERS);
+  const [status, setStatus] = useState({ phase: 'loading', message: '' });
+
+  const firstName = useMemo(() => user?.name?.split(' ')[0] || 'friend', [user?.name]);
+  const intro = useMemo(() => buildIntro(role, firstName), [role, firstName]);
+
+  useDocumentTitle('Onkur | Events');
+
+  useEffect(() => {
+    if (!token) return undefined;
+    let active = true;
+
+    setStatus({ phase: 'loading', message: '' });
+
+    (async () => {
+      try {
+        const response = await fetchEvents(token, filters);
+        if (!active) return;
+        setEvents(Array.isArray(response?.events) ? response.events : []);
+        setStatus({ phase: 'ready', message: '' });
+      } catch (error) {
+        if (!active) return;
+        setStatus({ phase: 'error', message: error.message || 'Unable to load events right now.' });
+      }
+    })();
+
+    return () => {
+      active = false;
+    };
+  }, [token, filters]);
+
+  const handleFilterChange = (nextFilters) => {
+    setFilters({ ...DEFAULT_FILTERS, ...nextFilters });
+  };
+
+  const handleSignup = async (eventId) => {
+    if (!token) {
+      throw new Error('You need to be signed in to join an event.');
+    }
+    const result = await signupForEvent(token, eventId);
+    setFilters((previous) => ({ ...previous }));
+    return result;
+  };
+
+  const isLoading = status.phase === 'loading';
+
+  return (
+    <div className="flex flex-col gap-6">
+      <header className="flex flex-col gap-2">
+        <h2 className="m-0 font-display text-2xl font-semibold text-brand-forest">{intro.title}</h2>
+        <p className="m-0 text-sm text-brand-muted sm:text-base">{intro.description}</p>
+      </header>
+      {status.phase === 'error' ? (
+        <p className="m-0 rounded-2xl border border-red-200 bg-red-50 p-4 text-sm text-red-700">{status.message}</p>
+      ) : null}
+      <DashboardCard
+        title="Opportunities open now"
+        description="Search the community calendar and jump into the experiences that excite you."
+        className="md:col-span-full"
+      >
+        <EventDiscovery
+          events={events}
+          filters={filters}
+          isLoading={isLoading}
+          onFilterChange={handleFilterChange}
+          onSignup={handleSignup}
+        />
+      </DashboardCard>
+    </div>
+  );
+}

--- a/frontend/src/features/dashboard/GalleryPage.jsx
+++ b/frontend/src/features/dashboard/GalleryPage.jsx
@@ -1,0 +1,132 @@
+import { useMemo } from 'react';
+
+import useDocumentTitle from '../../lib/useDocumentTitle';
+import { useAuth } from '../auth/AuthContext';
+import DashboardCard from './DashboardCard';
+
+const GALLERY_SPOTLIGHTS = [
+  {
+    id: 'mangrove',
+    emoji: '🌿',
+    title: 'Mangrove guardians',
+    summary: '50 volunteers restored 2km of coastline habitat with new mangrove plantings.',
+    impact: '1,200 seedlings planted',
+    tags: ['Habitat', 'Coastal resilience'],
+  },
+  {
+    id: 'bike',
+    emoji: '🚲',
+    title: 'Bike kitchen reboot',
+    summary: 'A youth-led repair-a-thon tuned 86 community bikes and hosted a pop-up safety clinic.',
+    impact: '86 bikes back on the road',
+    tags: ['Mobility', 'Youth'],
+  },
+  {
+    id: 'canopy',
+    emoji: '🌳',
+    title: 'City canopy census',
+    summary: 'Volunteers catalogued 1,400 trees and tagged gaps for next season’s planting map.',
+    impact: '12 new micro-forests planned',
+    tags: ['Urban forestry', 'Data'],
+  },
+];
+
+const STORY_TIPS = [
+  'Capture before-and-after scenes to show how spaces transform.',
+  'Highlight two quotes—one from a volunteer and one from a community member.',
+  'Log attendance and hours so sponsors can see their impact grow.',
+  'Upload at least five photos per story to keep galleries immersive.',
+];
+
+function buildIntro(role, firstName) {
+  switch (role) {
+    case 'EVENT_MANAGER':
+      return {
+        title: `Curate your event stories, ${firstName}`,
+        description:
+          'Every gallery entry helps teams relive the day. Organize photos, quotes, and metrics so celebrations stay vibrant.',
+      };
+    case 'SPONSOR':
+      return {
+        title: `Celebrate the partnerships you power, ${firstName}`,
+        description:
+          'Review highlight reels from supported events and gather assets for your next board update.',
+      };
+    case 'ADMIN':
+      return {
+        title: `Moderate and elevate Onkur stories, ${firstName}`,
+        description:
+          'Ensure every gallery reflects our shared values, then surface inspiring examples to the broader community.',
+      };
+    default:
+      return {
+        title: `Revisit the moments you created, ${firstName}`,
+        description:
+          'Explore galleries from recent events, download your favourite memories, and share them with your crew.',
+      };
+  }
+}
+
+export default function GalleryPage({ role }) {
+  const { user } = useAuth();
+  const firstName = useMemo(() => user?.name?.split(' ')[0] || 'friend', [user?.name]);
+  const intro = useMemo(() => buildIntro(role, firstName), [role, firstName]);
+
+  useDocumentTitle('Onkur | Gallery');
+
+  return (
+    <div className="flex flex-col gap-6">
+      <header className="flex flex-col gap-2">
+        <h2 className="m-0 font-display text-2xl font-semibold text-brand-forest">{intro.title}</h2>
+        <p className="m-0 text-sm text-brand-muted sm:text-base">{intro.description}</p>
+      </header>
+      <DashboardCard
+        title="Spotlight galleries"
+        description="The latest stories from our community. Dive in for photos, quotes, and measurable impact."
+        className="md:col-span-full"
+      >
+        <div className="grid gap-4 md:[grid-template-columns:repeat(auto-fit,minmax(220px,1fr))]">
+          {GALLERY_SPOTLIGHTS.map((gallery) => (
+            <article
+              key={gallery.id}
+              className="flex flex-col gap-3 rounded-2xl border border-brand-forest/10 bg-brand-sand/60 p-4"
+            >
+              <header className="flex items-center gap-3">
+                <span aria-hidden="true" className="text-2xl">
+                  {gallery.emoji}
+                </span>
+                <div>
+                  <h3 className="m-0 text-base font-semibold text-brand-forest">{gallery.title}</h3>
+                  <p className="m-0 text-xs font-semibold uppercase tracking-[0.14em] text-brand-muted">
+                    {gallery.impact}
+                  </p>
+                </div>
+              </header>
+              <p className="m-0 text-sm text-brand-muted">{gallery.summary}</p>
+              <div className="mt-auto flex flex-wrap gap-2">
+                {gallery.tags.map((tag) => (
+                  <span
+                    key={tag}
+                    className="rounded-full border border-brand-forest/20 bg-white/70 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-brand-forest"
+                  >
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            </article>
+          ))}
+        </div>
+      </DashboardCard>
+      <DashboardCard
+        title="Storytelling checklist"
+        description="Use this quick list before publishing to keep every gallery polished and informative."
+      >
+        <ol className="m-0 list-decimal space-y-2 pl-5 text-sm text-brand-muted">
+          {STORY_TIPS.map((tip) => (
+            <li key={tip}>{tip}</li>
+          ))}
+        </ol>
+      </DashboardCard>
+    </div>
+  );
+}

--- a/frontend/src/features/dashboard/ProfilePage.jsx
+++ b/frontend/src/features/dashboard/ProfilePage.jsx
@@ -1,0 +1,110 @@
+import { useEffect, useMemo, useState } from 'react';
+
+import useDocumentTitle from '../../lib/useDocumentTitle';
+import { useAuth } from '../auth/AuthContext';
+import ProfileEditor from '../volunteer/ProfileEditor';
+import { fetchVolunteerProfile, updateVolunteerProfile } from '../volunteer/api';
+import DashboardCard from './DashboardCard';
+
+function buildIntro(role, firstName) {
+  switch (role) {
+    case 'EVENT_MANAGER':
+      return {
+        title: `Share your expertise, ${firstName}`,
+        description:
+          'Keep your skills, credentials, and contact details current so volunteers know who is guiding their experience.',
+      };
+    case 'SPONSOR':
+      return {
+        title: `Tell partners about your focus, ${firstName}`,
+        description:
+          'Update your interests and availability to stay in sync with the campaigns and stories you champion.',
+      };
+    case 'ADMIN':
+      return {
+        title: `Steward your platform presence, ${firstName}`,
+        description:
+          'Refresh your profile to help teams reach the right steward when approvals or support are needed.',
+      };
+    default:
+      return {
+        title: `Tune your volunteer profile, ${firstName}`,
+        description:
+          'Highlight your strengths, availability, and motivations so coordinators can match you to the perfect opportunities.',
+      };
+  }
+}
+
+export default function ProfilePage({ role }) {
+  const { token, user, refreshProfile } = useAuth();
+  const [profile, setProfile] = useState(null);
+  const [status, setStatus] = useState({ phase: 'loading', message: '' });
+
+  const firstName = useMemo(() => user?.name?.split(' ')[0] || 'there', [user?.name]);
+  const intro = useMemo(() => buildIntro(role, firstName), [role, firstName]);
+
+  useDocumentTitle('Onkur | Profile');
+
+  useEffect(() => {
+    if (!token) return undefined;
+    let active = true;
+
+    setStatus({ phase: 'loading', message: '' });
+
+    (async () => {
+      try {
+        const response = await fetchVolunteerProfile(token);
+        if (!active) return;
+        setProfile(response);
+        setStatus({ phase: 'ready', message: '' });
+      } catch (error) {
+        if (!active) return;
+        setStatus({ phase: 'error', message: error.message || 'Unable to load your profile right now.' });
+      }
+    })();
+
+    return () => {
+      active = false;
+    };
+  }, [token]);
+
+  const handleSave = async (payload) => {
+    if (!token) {
+      throw new Error('You need to be signed in to update your profile.');
+    }
+    const updated = await updateVolunteerProfile(token, payload);
+    setProfile(updated);
+    try {
+      await refreshProfile();
+    } catch (error) {
+      console.warn('Unable to refresh profile', error);
+    }
+    return updated;
+  };
+
+  const isLoading = status.phase === 'loading';
+
+  return (
+    <div className="flex flex-col gap-6">
+      <header className="flex flex-col gap-2">
+        <h2 className="m-0 font-display text-2xl font-semibold text-brand-forest">{intro.title}</h2>
+        <p className="m-0 text-sm text-brand-muted sm:text-base">{intro.description}</p>
+      </header>
+      {status.phase === 'error' ? (
+        <p className="m-0 rounded-2xl border border-red-200 bg-red-50 p-4 text-sm text-red-700">{status.message}</p>
+      ) : null}
+      <DashboardCard
+        title="Profile & availability"
+        description="Keep this up to date so the right opportunities find you first."
+      >
+        {isLoading ? (
+          <p className="m-0 text-sm text-brand-muted">Loading your profile…</p>
+        ) : profile ? (
+          <ProfileEditor profile={profile} onSave={handleSave} />
+        ) : (
+          <p className="m-0 text-sm text-brand-muted">We could not load your profile yet. Please try again shortly.</p>
+        )}
+      </DashboardCard>
+    </div>
+  );
+}

--- a/frontend/src/features/layout/AGENTS.md
+++ b/frontend/src/features/layout/AGENTS.md
@@ -1,0 +1,7 @@
+# Layout Components Guidelines
+
+These notes apply to files within `frontend/src/features/layout/`.
+
+- Keep shared navigation data in `navConfig.js` so the desktop and mobile menus stay synchronized.
+- When updating header or navigation spacing, verify both mobile (bottom navigation) and desktop (header navigation) breakpoints remain accessible.
+- Prefer declarative `Link` components from `react-router-dom` over `button` elements for navigation interactions.

--- a/frontend/src/features/layout/AppLayout.jsx
+++ b/frontend/src/features/layout/AppLayout.jsx
@@ -3,6 +3,7 @@ import { useMemo } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { useAuth } from '../auth/AuthContext';
 import BottomNav from './BottomNav';
+import DesktopNav from './DesktopNav';
 
 function formatRole(role) {
   if (!role) return '';
@@ -25,9 +26,11 @@ export default function AppLayout({ children }) {
   }, [isAuthenticated]);
 
   const activeNav = useMemo(() => {
-    if (location.pathname.startsWith('/gallery')) return 'gallery';
-    if (location.pathname.startsWith('/events')) return 'events';
-    if (location.pathname.startsWith('/profile')) return 'profile';
+    const path = location.pathname;
+    if (path.startsWith('/app/gallery') || path.startsWith('/gallery')) return 'gallery';
+    if (path.startsWith('/app/events') || path.startsWith('/events')) return 'events';
+    if (path.startsWith('/app/profile') || path.startsWith('/profile')) return 'profile';
+    if (path.startsWith('/app')) return 'home';
     return 'home';
   }, [location.pathname]);
 
@@ -82,6 +85,7 @@ export default function AppLayout({ children }) {
             </nav>
           )}
         </div>
+        {isAuthenticated ? <DesktopNav active={activeNav} /> : null}
       </header>
       <main className="flex-1 px-5 pb-16 pt-6 sm:px-8">
         <div className="mx-auto flex w-full max-w-4xl flex-col gap-6">{children}</div>

--- a/frontend/src/features/layout/BottomNav.jsx
+++ b/frontend/src/features/layout/BottomNav.jsx
@@ -1,9 +1,6 @@
-const NAV_ITEMS = [
-  { id: 'home', label: 'Home', icon: '🌿' },
-  { id: 'events', label: 'Events', icon: '📅' },
-  { id: 'gallery', label: 'Gallery', icon: '🖼️' },
-  { id: 'profile', label: 'Profile', icon: '😊' },
-];
+import { Link } from 'react-router-dom';
+
+import { NAV_ITEMS } from './navConfig';
 
 export default function BottomNav({ active }) {
   return (
@@ -14,22 +11,21 @@ export default function BottomNav({ active }) {
       {NAV_ITEMS.map((item) => {
         const isActive = item.id === active;
         return (
-          <button
+          <Link
             key={item.id}
-            type="button"
-            className={`flex flex-col items-center gap-1 rounded-md px-2 py-1.5 text-xs font-medium transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-green/60 disabled:cursor-not-allowed disabled:opacity-60 ${
+            to={item.to}
+            className={`flex flex-col items-center gap-1 rounded-md px-2 py-1.5 text-xs font-medium transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-green/60 ${
               isActive
                 ? 'bg-brand-green/15 text-brand-green'
                 : 'text-brand-muted hover:text-brand-green'
             }`}
             aria-current={isActive ? 'page' : undefined}
-            disabled={item.id !== 'home'}
           >
             <span aria-hidden="true" className="text-base">
               {item.icon}
             </span>
             {item.label}
-          </button>
+          </Link>
         );
       })}
     </nav>

--- a/frontend/src/features/layout/DesktopNav.jsx
+++ b/frontend/src/features/layout/DesktopNav.jsx
@@ -1,0 +1,32 @@
+import { Link } from 'react-router-dom';
+
+import { NAV_ITEMS } from './navConfig';
+
+export default function DesktopNav({ active }) {
+  return (
+    <nav className="hidden border-t border-white/20 bg-brand-green/95 backdrop-blur-sm md:block">
+      <div className="mx-auto flex w-full max-w-4xl items-center justify-between px-6 py-3">
+        {NAV_ITEMS.map((item) => {
+          const isActive = item.id === active;
+          return (
+            <Link
+              key={item.id}
+              to={item.to}
+              className={`flex items-center gap-2 rounded-lg px-3 py-1.5 text-sm font-semibold tracking-wide transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/70 ${
+                isActive
+                  ? 'bg-white/20 text-white shadow-[0_8px_20px_rgba(6,55,24,0.35)]'
+                  : 'text-white/80 hover:bg-white/10 hover:text-white'
+              }`}
+              aria-current={isActive ? 'page' : undefined}
+            >
+              <span aria-hidden="true" className="text-base">
+                {item.icon}
+              </span>
+              {item.label}
+            </Link>
+          );
+        })}
+      </div>
+    </nav>
+  );
+}

--- a/frontend/src/features/layout/navConfig.js
+++ b/frontend/src/features/layout/navConfig.js
@@ -1,0 +1,8 @@
+export const NAV_ITEMS = [
+  { id: 'home', label: 'Home', icon: '🌿', to: '/app' },
+  { id: 'events', label: 'Events', icon: '📅', to: '/app/events' },
+  { id: 'gallery', label: 'Gallery', icon: '🖼️', to: '/app/gallery' },
+  { id: 'profile', label: 'Profile', icon: '😊', to: '/app/profile' },
+];
+
+export default NAV_ITEMS;


### PR DESCRIPTION
## Summary
- add a desktop header navigation that mirrors the authenticated mobile menu
- wire the primary menu to real `/app/events`, `/app/gallery`, and `/app/profile` routes with dedicated views
- document the navigation parity work in the wiki and add layout contribution guidance

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc87ab14cc8333ab5b93889ce41a83