### PR TITLE
Bootstrap admin user from env config

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Consult the living [product wiki](docs/Wiki.md) for design rationale, API schema
    - `JWT_SECRET`, `JWT_EXPIRY`, `JWT_ISSUER` – JWT signing + expiry configuration.
    - `BCRYPT_SALT_ROUNDS` – bcrypt cost factor (defaults to 12).
    - `APP_BASE_URL` – canonical frontend URL used in transactional emails.
+   - `ADMIN_NAME`, `ADMIN_EMAIL`, `ADMIN_PASSWORD` – bootstrap credentials for the default admin account created at startup.
    - `EMAIL_FROM`, `EMAIL_SMTP_HOST`, `EMAIL_SMTP_PORT`, `EMAIL_SMTP_SECURE`, `EMAIL_SMTP_USER`, `EMAIL_SMTP_PASS` – SMTP settings for outbound email.
    - `CORS_ORIGIN`, `PORT`, `LOG_LEVEL`, `LOG_FILE` – server + logging controls.
    - `MINIO_*` – optional object storage wiring from the base template.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -24,6 +24,11 @@ JWT_EXPIRY=1h
 JWT_ISSUER=onkur-api
 BCRYPT_SALT_ROUNDS=12
 
+# Admin bootstrap
+ADMIN_NAME=Onkur Platform Admin
+ADMIN_EMAIL=admin@example.com
+ADMIN_PASSWORD=ChangeMeNow123
+
 # MinIO / Object storage
 MINIO_ENDPOINT=192.168.1.3
 MINIO_PORT=2000

--- a/backend/src/config/index.js
+++ b/backend/src/config/index.js
@@ -36,6 +36,11 @@ const config = {
     bucket: process.env.MINIO_BUCKET,
     useSSL: process.env.MINIO_USE_SSL === "true",
   },
+  admin: {
+    name: process.env.ADMIN_NAME || "",
+    email: process.env.ADMIN_EMAIL || "",
+    password: process.env.ADMIN_PASSWORD || "",
+  },
 };
 
 module.exports = config;

--- a/backend/src/features/auth/AGENTS.md
+++ b/backend/src/features/auth/AGENTS.md
@@ -7,3 +7,4 @@ These notes cover files within `backend/src/features/auth/`.
 - Prefer structured audit metadata objects that can be serialized to JSON without circular references.
 - Whenever you add a new token type, document it in `docs/wiki/README.md` and extend the revoke helpers instead of creating new tables.
 - User records now maintain a primary `role` plus an expanded `user_roles` join table; always update both via the repository helpers so API responses expose a normalized `roles` array.
+- The admin bootstrapper seeds or promotes an ADMIN account from environment variables; prefer updating `admin.bootstrap.js` when adjusting default admin behavior.

--- a/backend/src/features/auth/admin.bootstrap.js
+++ b/backend/src/features/auth/admin.bootstrap.js
@@ -1,0 +1,83 @@
+const bcrypt = require("bcryptjs");
+const config = require("../../config");
+const logger = require("../../utils/logger");
+const {
+  createUser,
+  findUserByEmail,
+  replaceUserRoles,
+  markEmailVerified,
+  recordAuditLog,
+} = require("./auth.repository");
+
+const ADMIN_ROLE = "ADMIN";
+
+function normalizeConfigValue(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+async function ensureAdminUser() {
+  const configuredName = normalizeConfigValue(config.admin?.name);
+  const configuredEmail = normalizeConfigValue(config.admin?.email).toLowerCase();
+  const configuredPassword = config.admin?.password || "";
+
+  if (!configuredName || !configuredEmail || !configuredPassword) {
+    logger.info("Admin bootstrap skipped: ADMIN_NAME, ADMIN_EMAIL, and ADMIN_PASSWORD must be set");
+    return;
+  }
+
+  const existing = await findUserByEmail(configuredEmail);
+  if (existing) {
+    const existingRoles = Array.isArray(existing.roles) && existing.roles.length
+      ? existing.roles
+      : existing.role
+      ? [existing.role]
+      : [];
+
+    const rolesWithoutAdmin = existingRoles.filter((role) => role !== ADMIN_ROLE);
+    const desiredRoles = [ADMIN_ROLE, ...rolesWithoutAdmin];
+
+    const needsRoleUpdate =
+      existing.role !== ADMIN_ROLE || existingRoles.length !== desiredRoles.length ||
+      desiredRoles.some((role, index) => existingRoles[index] !== role);
+
+    if (needsRoleUpdate) {
+      const updatedUser = await replaceUserRoles({ userId: existing.id, roles: desiredRoles });
+      await recordAuditLog({
+        actorId: existing.id,
+        action: "auth.bootstrap.admin.promote",
+        metadata: { email: existing.email, roles: updatedUser?.roles || desiredRoles },
+      });
+      logger.info("Admin bootstrap: ensured existing user has ADMIN role", { email: configuredEmail });
+    } else {
+      logger.info("Admin bootstrap: existing admin user detected", { email: configuredEmail });
+    }
+
+    if (!existing.email_verified_at) {
+      await markEmailVerified({ userId: existing.id });
+    }
+
+    return;
+  }
+
+  const passwordHash = await bcrypt.hash(configuredPassword, config.bcrypt.saltRounds);
+  const adminUser = await createUser({
+    name: configuredName,
+    email: configuredEmail,
+    passwordHash,
+    roles: [ADMIN_ROLE],
+  });
+
+  await markEmailVerified({ userId: adminUser.id });
+
+  await recordAuditLog({
+    actorId: adminUser.id,
+    action: "auth.bootstrap.admin.created",
+    metadata: { email: adminUser.email },
+  });
+
+  logger.info("Admin bootstrap: created default admin user", { email: configuredEmail });
+}
+
+module.exports = {
+  ensureAdminUser,
+};

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -1,7 +1,18 @@
 const app = require("./app");
 const config = require("./config");
 const logger = require("./utils/logger");
+const { ensureAdminUser } = require("./features/auth/admin.bootstrap");
 
-app.listen(config.port, () => {
-  logger.info(`Backend running on port ${config.port}`);
-});
+async function startServer() {
+  try {
+    await ensureAdminUser();
+  } catch (error) {
+    logger.error("Admin bootstrap failed", { error: error.message });
+  }
+
+  app.listen(config.port, () => {
+    logger.info(`Backend running on port ${config.port}`);
+  });
+}
+
+startServer();

--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -26,3 +26,8 @@
 - **Change:** Expanded signup to let new members pick multiple roles (volunteer, event manager, sponsor) via accessible checkboxes, persisted through a new `user_roles` join table. Admin tooling now edits multi-role assignments, and all auth responses expose a normalized `roles` array alongside the primary role.
 - **Impact:** Members can express every way they want to contribute from day one, and admin workflows stay in sync with richer role data across the platform.
 
+## Admin bootstrap configuration
+- **Date:** 2025-09-21
+- **Change:** Added startup logic that seeds a default admin account whenever `ADMIN_NAME`, `ADMIN_EMAIL`, and `ADMIN_PASSWORD` are provided. The bootstrapper promotes existing records to the ADMIN role or creates a verified admin using the configured credentials.
+- **Impact:** Deployments now guarantee an ADMIN user without manual SQL, ensuring future admin-only features have an account ready for use.
+


### PR DESCRIPTION
## Summary
- add configuration entries for default admin credentials sourced from environment variables
- create an admin bootstrapper that seeds or promotes an admin user before the server starts
- document the new environment variables in the README, wiki, and sample env file

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc8d15dd9c8333841d36315fd238b3