### PR TITLE
feat(email): refresh template and add test script

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -9,7 +9,8 @@
     "test:db": "node src/utils/test-db.js",
     "test:minio": "node src/utils/test-minio.js",
     "test:connections": "npm run test:db && npm run test:minio",
-    "test": "jest"
+    "test": "jest",
+    "send:test-email": "node scripts/send-test-email.js"
   },
   "keywords": [],
   "author": "",

--- a/backend/scripts/send-test-email.js
+++ b/backend/scripts/send-test-email.js
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+
+/*
+ * Utility script to dispatch a sample Onkur email using the configured SMTP transport.
+ * Usage: node scripts/send-test-email.js recipient@example.com
+ * or set TEST_EMAIL_TO in your environment.
+ */
+
+const path = require('path');
+const dotenv = require('dotenv');
+
+// Load environment variables for standalone execution.
+dotenv.config({ path: process.env.DOTENV_CONFIG_PATH || path.resolve(__dirname, '../.env') });
+
+const { sendTemplatedEmail } = require('../src/features/email/email.service');
+const config = require('../src/config');
+
+async function main() {
+  const cliRecipient = process.argv[2];
+  const recipient = cliRecipient || process.env.TEST_EMAIL_TO;
+
+  if (!recipient) {
+    console.error('Missing recipient. Pass an email address as an argument or set TEST_EMAIL_TO.');
+    process.exit(1);
+  }
+
+  const appBaseUrl = (config.app && config.app.baseUrl) || 'https://onkur.org';
+
+  try {
+    const result = await sendTemplatedEmail({
+      to: recipient,
+      subject: 'Sample email delivery test',
+      heading: 'Thanks for helping us take root',
+      bodyLines: [
+        'This is a test message to confirm that your SMTP credentials for Onkur are working as expected.',
+        'If you received this email, no further action is required. Otherwise, please double-check your SMTP settings in the backend .env file.',
+      ],
+      cta: {
+        label: 'Open the Onkur dashboard',
+        url: `${appBaseUrl}/app`,
+      },
+      previewText: 'Confirm your Onkur email delivery setup with this quick test.',
+    });
+
+    if (!result) {
+      console.log('Email transport is not configured. Check your SMTP environment variables.');
+      process.exit(0);
+    }
+
+    console.log(`Email sent! Message ID: ${result.messageId}`);
+  } catch (error) {
+    console.error('Failed to send the test email:', error.message);
+    process.exit(1);
+  }
+}
+
+main();

--- a/backend/src/features/email/AGENTS.md
+++ b/backend/src/features/email/AGENTS.md
@@ -1,0 +1,7 @@
+# Email Feature Guidelines
+
+These conventions apply to files within `backend/src/features/email/`.
+
+- Always construct outbound subjects through `sendEmail` so the `[Onkur]` prefix is applied automatically. Avoid hard-coding the prefix elsewhere.
+- Use `renderStandardTemplate` (or helpers built on it) for transactional email markup. Keep updates theme-driven and responsive.
+- When adding new scripts or tests that dispatch emails, prefer `sendTemplatedEmail` unless plain-text payloads are required for diagnostics.

--- a/backend/src/features/email/email.service.js
+++ b/backend/src/features/email/email.service.js
@@ -2,6 +2,23 @@ const nodemailer = require('nodemailer');
 const logger = require('../../utils/logger');
 const config = require('../../config');
 
+const SUBJECT_PREFIX = '[Onkur]';
+
+const TEMPLATE_THEME = {
+  brandName: 'Onkur',
+  brandTagline: 'Rooted in nature. Built for community action.',
+  colors: {
+    background: '#f4f7f6',
+    card: '#ffffff',
+    primary: '#2F855A',
+    accent: '#bde7cf',
+    body: '#1f2937',
+    muted: '#6b7280',
+    footer: '#9ca3af',
+  },
+  fontFamily: "'Inter', 'Segoe UI', sans-serif",
+};
+
 let transporter;
 let transportInitialized = false;
 
@@ -39,42 +56,167 @@ function resolveTransporter() {
 function renderStandardTemplate({ heading, bodyLines = [], cta, previewText }) {
   const safeBody = Array.isArray(bodyLines) ? bodyLines : [String(bodyLines || '')];
   const bodyHtml = safeBody
-    .map((line) => `<p style="margin: 0 0 16px; font-size: 16px; line-height: 24px; color: #1f2937;">${line}</p>`)
+    .map(
+      (line) =>
+        `<p class="paragraph">${line}</p>`
+    )
     .join('');
 
   const ctaHtml = cta && cta.url && cta.label
-    ? `<p style="margin: 24px 0; text-align: center;"><a href="${cta.url}" style="display: inline-block; padding: 12px 24px; background: #2F855A; color: #ffffff; text-decoration: none; border-radius: 9999px; font-weight: 600;">${cta.label}</a></p>`
+    ? `<div class="cta"><a class="ctaButton" href="${cta.url}" target="_blank" rel="noreferrer">${cta.label}</a></div>`
     : '';
+
+  const resolvedPreview = previewText || heading;
 
   const html = `<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>${heading}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="color-scheme" content="light" />
+    <meta name="supported-color-schemes" content="light" />
+    <title>${heading}</title>
+    <style>
+      :root {
+        color-scheme: light;
+        supported-color-schemes: light;
+      }
+
+      body {
+        margin: 0;
+        padding: 24px 0;
+        background: ${TEMPLATE_THEME.colors.background};
+        font-family: ${TEMPLATE_THEME.fontFamily};
+        -webkit-text-size-adjust: 100%;
+      }
+
+      table {
+        border-spacing: 0;
+        border-collapse: collapse;
+      }
+
+      .wrapper {
+        width: 100%;
+        max-width: 640px;
+        background: ${TEMPLATE_THEME.colors.card};
+        border-radius: 20px;
+        box-shadow: 0 24px 48px rgba(47, 133, 90, 0.22);
+        overflow: hidden;
+      }
+
+      .header {
+        background: linear-gradient(135deg, ${TEMPLATE_THEME.colors.primary}, ${TEMPLATE_THEME.colors.accent});
+        padding: 36px 32px 32px;
+        text-align: left;
+        color: #ffffff;
+      }
+
+      .brand {
+        margin: 0;
+        font-size: 28px;
+        font-weight: 700;
+        letter-spacing: 0.02em;
+      }
+
+      .tagline {
+        margin: 8px 0 0;
+        font-size: 15px;
+        line-height: 22px;
+        opacity: 0.85;
+      }
+
+      .content {
+        padding: 36px 40px;
+      }
+
+      .heading {
+        margin: 0 0 20px;
+        font-size: 24px;
+        line-height: 32px;
+        color: ${TEMPLATE_THEME.colors.primary};
+      }
+
+      .paragraph {
+        margin: 0 0 18px;
+        font-size: 16px;
+        line-height: 26px;
+        color: ${TEMPLATE_THEME.colors.body};
+      }
+
+      .cta {
+        margin: 32px 0;
+        text-align: center;
+      }
+
+      .ctaButton {
+        display: inline-block;
+        padding: 14px 28px;
+        border-radius: 9999px;
+        background: ${TEMPLATE_THEME.colors.primary};
+        color: #ffffff !important;
+        text-decoration: none;
+        font-weight: 600;
+        box-shadow: 0 12px 24px rgba(47, 133, 90, 0.35);
+      }
+
+      .signature {
+        margin: 36px 0 0;
+        font-size: 14px;
+        line-height: 22px;
+        color: ${TEMPLATE_THEME.colors.muted};
+      }
+
+      .footer {
+        padding: 24px 32px 32px;
+        background: ${TEMPLATE_THEME.colors.background};
+        text-align: center;
+        font-size: 12px;
+        line-height: 18px;
+        color: ${TEMPLATE_THEME.colors.footer};
+      }
+
+      @media (max-width: 620px) {
+        body {
+          padding: 0;
+        }
+
+        .wrapper {
+          border-radius: 0;
+        }
+
+        .content {
+          padding: 28px 20px;
+        }
+
+        .heading {
+          font-size: 22px;
+        }
+      }
+    </style>
   </head>
-  <body style="margin: 0; padding: 0; background: #f7faf5; font-family: 'Inter', 'Segoe UI', sans-serif;">
-    <table role="presentation" cellpadding="0" cellspacing="0" width="100%" style="background: #f7faf5; padding: 32px 0;">
+  <body>
+    <div style="display:none; visibility:hidden; opacity:0; height:0; width:0; overflow:hidden;">${resolvedPreview}</div>
+    <table role="presentation" width="100%">
       <tr>
-        <td align="center">
-          <table role="presentation" cellpadding="0" cellspacing="0" width="600" style="max-width: 600px; background: #ffffff; border-radius: 16px; box-shadow: 0 18px 40px rgba(47, 133, 90, 0.18); overflow: hidden;">
+        <td align="center" style="padding: 0 16px;">
+          <table role="presentation" class="wrapper">
             <tr>
-              <td style="background: #2F855A; padding: 28px 32px; color: #ffffff;">
-                <h1 style="margin: 0; font-size: 24px; font-weight: 600; letter-spacing: 0.02em;">Onkur</h1>
-                <p style="margin: 8px 0 0; font-size: 14px; opacity: 0.85;">Rooted in nature. Built for community action.</p>
+              <td class="header">
+                <h1 class="brand">${TEMPLATE_THEME.brandName}</h1>
+                <p class="tagline">${TEMPLATE_THEME.brandTagline}</p>
               </td>
             </tr>
             <tr>
-              <td style="padding: 32px;">
-                <h2 style="margin: 0 0 16px; font-size: 22px; color: #2F855A;">${heading}</h2>
+              <td class="content">
+                <h2 class="heading">${heading}</h2>
                 ${bodyHtml}
                 ${ctaHtml}
-                <p style="margin: 32px 0 0; font-size: 14px; color: #6b7280;">With gratitude,<br />The Onkur team</p>
+                <p class="signature">With gratitude,<br />The Onkur team</p>
               </td>
             </tr>
             <tr>
-              <td style="background: #f7faf5; padding: 20px 32px; text-align: center; font-size: 12px; color: #9ca3af;">
-                You are receiving this email because you created an account on Onkur.
+              <td class="footer">
+                You are receiving this email because you created an account on Onkur. Manage your notification preferences inside your profile.
               </td>
             </tr>
           </table>
@@ -91,22 +233,31 @@ function renderStandardTemplate({ heading, bodyLines = [], cta, previewText }) {
   textParts.push('', 'With gratitude,', 'The Onkur team');
   const text = textParts.join('\n');
 
-  return { html, text, previewText: previewText || heading };
+  return { html, text, previewText: resolvedPreview };
+}
+
+function applySubjectPrefix(subject) {
+  const normalized = String(subject || '').trim();
+  if (!normalized) {
+    return SUBJECT_PREFIX;
+  }
+  return normalized.startsWith(SUBJECT_PREFIX) ? normalized : `${SUBJECT_PREFIX} ${normalized}`;
 }
 
 async function sendEmail({ to, subject, html, text, headers = {} }) {
   const transport = resolveTransporter();
   const from = (config.email && config.email.from) || 'Onkur <no-reply@onkur.org>';
+  const finalSubject = applySubjectPrefix(subject);
 
   if (!transport) {
-    logger.info('Email send skipped because transport is not configured', { to, subject });
+    logger.info('Email send skipped because transport is not configured', { to, subject: finalSubject });
     return null;
   }
 
   const payload = {
     from,
     to,
-    subject,
+    subject: finalSubject,
     html,
     text,
     headers,
@@ -116,14 +267,14 @@ async function sendEmail({ to, subject, html, text, headers = {} }) {
     const info = await transport.sendMail(payload);
     logger.info('Email dispatched', {
       to,
-      subject,
+      subject: finalSubject,
       messageId: info.messageId,
     });
     return info;
   } catch (error) {
     logger.error('Failed to send email', {
       to,
-      subject,
+      subject: finalSubject,
       error: error.message,
     });
     throw error;
@@ -132,11 +283,16 @@ async function sendEmail({ to, subject, html, text, headers = {} }) {
 
 async function sendTemplatedEmail({ to, subject, heading, bodyLines, cta, previewText, headers }) {
   const template = renderStandardTemplate({ heading, bodyLines, cta, previewText });
-  return sendEmail({ to, subject, html: template.html, text: template.text, headers });
+  const enrichedHeaders = Object.assign({}, headers);
+  if (template.previewText) {
+    enrichedHeaders['X-Preheader-Text'] = template.previewText;
+  }
+  return sendEmail({ to, subject, html: template.html, text: template.text, headers: enrichedHeaders });
 }
 
 module.exports = {
   sendEmail,
   sendTemplatedEmail,
   renderStandardTemplate,
+  applySubjectPrefix,
 };

--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -26,3 +26,8 @@
 - **Change:** Expanded signup to let new members pick multiple roles (volunteer, event manager, sponsor) via accessible checkboxes, persisted through a new `user_roles` join table. Admin tooling now edits multi-role assignments, and all auth responses expose a normalized `roles` array alongside the primary role.
 - **Impact:** Members can express every way they want to contribute from day one, and admin workflows stay in sync with richer role data across the platform.
 
+## Branded email foundation
+- **Date:** 2025-09-21
+- **Change:** Refreshed the Nodemailer service with a reusable Onkur theme that injects a responsive CSS layout, standardized the `[Onkur]` subject prefix, and added a `npm run send:test-email` utility for verifying SMTP credentials via the new template.
+- **Impact:** Contributors have a modern baseline for transactional emails and a simple script to confirm delivery without duplicating setup work.
+


### PR DESCRIPTION
## Summary
- refresh the Nodemailer service with a theme-driven responsive template and automatic `[Onkur]` subject prefixing
- add a reusable CLI script and npm alias to send a sample templated email for SMTP verification
- document the email foundation update and authoring guidelines in the repo wiki and feature agent file

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc8e60f7ec8333bc060ac01e2305bd