### PR TITLE
Streamline volunteer dashboard commitments

### DIFF
--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -48,3 +48,7 @@
 - **Date:** 2025-09-22
 - **Change:** Centralized role-priority helpers on the backend and dashboard so users holding multiple roles always expose a deterministic `primaryRole`, ensuring dashboards, galleries, and profiles tailor their intros correctly while preserving all role badges.
 - **Impact:** Members who are simultaneously volunteers, event managers, and sponsors now see the full toolset without losing access to any experience, and administrators reuse a single helper when adjusting role order.
+## Volunteer home focuses on commitments
+- **Date:** 2025-09-22
+- **Change:** Removed the in-dashboard profile editor for volunteers and expanded the upcoming commitments card to span the dashboard width so all roles treat profile updates through the dedicated profile page.
+- **Impact:** Volunteers manage their profiles from the Profile menu while the dashboard highlights schedules and logged impact without split attention.

--- a/frontend/src/features/dashboard/AGENTS.md
+++ b/frontend/src/features/dashboard/AGENTS.md
@@ -4,3 +4,4 @@ These notes apply to files within `frontend/src/features/dashboard/`.
 
 - Prefer deriving role-aware UI states through `roleUtils.js` so sponsor, event manager, and volunteer experiences stay in sync when members hold multiple roles.
 - Keep dashboard routes declarative; export simple React components and let `DashboardRouter` determine which variant to render.
+- The volunteer landing view should focus on commitments and impact summaries; surface profile editing only via the dedicated profile page and keep the commitments card full-width for consistency across roles.

--- a/frontend/src/features/dashboard/VolunteerDashboard.jsx
+++ b/frontend/src/features/dashboard/VolunteerDashboard.jsx
@@ -2,7 +2,6 @@ import { useEffect, useMemo, useState } from 'react';
 import DashboardCard from './DashboardCard';
 import { useAuth } from '../auth/AuthContext';
 import useDocumentTitle from '../../lib/useDocumentTitle';
-import ProfileEditor from '../volunteer/ProfileEditor';
 import EventDiscovery from '../volunteer/EventDiscovery';
 import HoursTracker from '../volunteer/HoursTracker';
 import {
@@ -10,7 +9,6 @@ import {
   fetchVolunteerHours,
   fetchEvents,
   fetchMySignups,
-  updateVolunteerProfile,
   signupForEvent,
   logVolunteerHours,
 } from '../volunteer/api';
@@ -32,7 +30,6 @@ export default function VolunteerDashboard() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [dashboard, setDashboard] = useState(null);
-  const [profile, setProfile] = useState(null);
   const [hoursSummary, setHoursSummary] = useState(null);
   const [signups, setSignups] = useState([]);
   const [events, setEvents] = useState([]);
@@ -72,7 +69,6 @@ export default function VolunteerDashboard() {
     const data = await fetchVolunteerDashboard(activeToken);
     if (!active) return;
     setDashboard(data);
-    setProfile(data.profile);
   }
 
   async function refreshHours(activeToken = token, active = true) {
@@ -104,13 +100,6 @@ export default function VolunteerDashboard() {
       }
     }
   }
-
-  const handleProfileSave = async (payload) => {
-    const updated = await updateVolunteerProfile(token, payload);
-    setProfile(updated);
-    setDashboard((prev) => (prev ? { ...prev, profile: updated } : prev));
-    return updated;
-  };
 
   const handleEventSignup = async (eventId) => {
     const result = await signupForEvent(token, eventId);
@@ -147,12 +136,7 @@ export default function VolunteerDashboard() {
         </p>
       ) : null}
       <DashboardCard
-        title="Profile & availability"
-        description="Keep your skills and availability current so coordinators can match you to the best opportunities."
-      >
-        <ProfileEditor profile={profile} onSave={handleProfileSave} />
-      </DashboardCard>
-      <DashboardCard
+        className="md:col-span-full"
         title="Upcoming commitments"
         description={
           upcomingEvents.length


### PR DESCRIPTION
## Summary
- remove the in-dashboard profile editor so volunteers manage details from the profile page
- expand the upcoming commitments card to span the dashboard width for parity across roles
- document the volunteer dashboard focus shift and update dashboard guidelines

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cca03d26ec8333a083d5edc332d7db