### PR TITLE
Remove volunteer dashboard event discovery card

### DIFF
--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -52,3 +52,8 @@
 - **Date:** 2025-09-22
 - **Change:** Removed the in-dashboard profile editor for volunteers and expanded the upcoming commitments card to span the dashboard width so all roles treat profile updates through the dedicated profile page.
 - **Impact:** Volunteers manage their profiles from the Profile menu while the dashboard highlights schedules and logged impact without split attention.
+
+## Volunteer dashboard event discovery removal
+- **Date:** 2025-09-22
+- **Change:** Retired the "Discover new events" panel from the volunteer home view so the dashboard centers on commitments and impact tracking while directing discovery traffic to the dedicated events hub.
+- **Impact:** Volunteers see a streamlined home focused on what they’ve scheduled and accomplished, using the events hub when they’re ready to browse new opportunities.

--- a/frontend/src/features/dashboard/AGENTS.md
+++ b/frontend/src/features/dashboard/AGENTS.md
@@ -5,3 +5,4 @@ These notes apply to files within `frontend/src/features/dashboard/`.
 - Prefer deriving role-aware UI states through `roleUtils.js` so sponsor, event manager, and volunteer experiences stay in sync when members hold multiple roles.
 - Keep dashboard routes declarative; export simple React components and let `DashboardRouter` determine which variant to render.
 - The volunteer landing view should focus on commitments and impact summaries; surface profile editing only via the dedicated profile page and keep the commitments card full-width for consistency across roles.
+- Do not reintroduce event discovery feeds on the volunteer dashboard; direct volunteers to the dedicated events hub for browsing opportunities.


### PR DESCRIPTION
## Summary
- remove the volunteer dashboard event discovery card and related data fetching so the home view centers on commitments and impact
- update dashboard contributor guidance to discourage reintroducing inline event discovery feeds
- record the volunteer dashboard change in the project wiki

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cca11444fc83338f9e17b64df4aa3f