### PR TITLE
feat: volunteer dashboard profile completion prompt

### DIFF
--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -57,3 +57,8 @@
 - **Date:** 2025-09-22
 - **Change:** Retired the "Discover new events" panel from the volunteer home view so the dashboard centers on commitments and impact tracking while directing discovery traffic to the dedicated events hub.
 - **Impact:** Volunteers see a streamlined home focused on what they’ve scheduled and accomplished, using the events hub when they’re ready to browse new opportunities.
+
+## Profile completion reminder on volunteer home
+- **Date:** 2025-09-23
+- **Change:** Added a volunteer dashboard call-to-action that surfaces when profile data is incomplete, showing percent completion, highlighting missing sections, and linking directly to the profile editor.
+- **Impact:** Volunteers understand why finishing their profile matters and can jump straight to the editor, helping event managers match the right people to upcoming opportunities.

--- a/frontend/src/features/dashboard/AGENTS.md
+++ b/frontend/src/features/dashboard/AGENTS.md
@@ -6,3 +6,4 @@ These notes apply to files within `frontend/src/features/dashboard/`.
 - Keep dashboard routes declarative; export simple React components and let `DashboardRouter` determine which variant to render.
 - The volunteer landing view should focus on commitments and impact summaries; surface profile editing only via the dedicated profile page and keep the commitments card full-width for consistency across roles.
 - Do not reintroduce event discovery feeds on the volunteer dashboard; direct volunteers to the dedicated events hub for browsing opportunities.
+- Keep the profile completion call-to-action lightweight and motivational; only surface it when the dashboard API reports missing profile fields and link the button to `/app/profile`.

--- a/frontend/src/features/dashboard/VolunteerDashboard.jsx
+++ b/frontend/src/features/dashboard/VolunteerDashboard.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
 import DashboardCard from './DashboardCard';
 import { useAuth } from '../auth/AuthContext';
 import useDocumentTitle from '../../lib/useDocumentTitle';
@@ -29,6 +30,46 @@ export default function VolunteerDashboard() {
   const [dashboard, setDashboard] = useState(null);
   const [hoursSummary, setHoursSummary] = useState(null);
   const [signups, setSignups] = useState([]);
+
+  const profileProgress = useMemo(() => {
+    if (!dashboard?.profile) {
+      return null;
+    }
+
+    const { profile } = dashboard;
+    const requirements = [
+      {
+        label: 'Add at least one skill',
+        complete: Array.isArray(profile.skills) && profile.skills.length > 0,
+      },
+      {
+        label: 'Share the causes you care about',
+        complete: Array.isArray(profile.interests) && profile.interests.length > 0,
+      },
+      {
+        label: 'Set your availability',
+        complete: Boolean(profile.availability && profile.availability.trim().length),
+      },
+      {
+        label: 'Add your home base or region',
+        complete: Boolean(profile.location && profile.location.trim().length),
+      },
+      {
+        label: 'Introduce yourself with a short bio',
+        complete: Boolean(profile.bio && profile.bio.trim().length),
+      },
+    ];
+
+    const completed = requirements.filter((item) => item.complete).length;
+    const percentage = Math.round((completed / requirements.length) * 100);
+    const missing = requirements.filter((item) => !item.complete).map((item) => item.label);
+
+    return {
+      percentage,
+      missing,
+      isComplete: completed === requirements.length,
+    };
+  }, [dashboard]);
 
   const totalBadgesEarned = useMemo(() => {
     if (!hoursSummary?.badges) return 0;
@@ -98,6 +139,33 @@ export default function VolunteerDashboard() {
               }. Keep growing your impact!`}
         </p>
       </header>
+      {!loading && !error && profileProgress && !profileProgress.isComplete ? (
+        <section className="md:col-span-full rounded-3xl border border-amber-200 bg-amber-50 p-5">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+            <div className="space-y-2 sm:max-w-2xl">
+              <div className="inline-flex items-center gap-2 rounded-full bg-white px-3 py-1 text-xs font-semibold uppercase tracking-[0.14em] text-amber-600">
+                <span>{profileProgress.percentage}% complete</span>
+              </div>
+              <h3 className="m-0 font-display text-xl font-semibold text-brand-forest">Complete your profile to unlock tailored invites</h3>
+              <p className="m-0 text-sm text-brand-muted">
+                Finishing your profile helps event managers match you with roles faster and gives check-in teams the context they need to support you on site.
+              </p>
+              {profileProgress.missing.length ? (
+                <ul className="m-0 list-disc space-y-1 pl-5 text-sm text-amber-700">
+                  {profileProgress.missing.map((item) => (
+                    <li key={item}>{item}</li>
+                  ))}
+                </ul>
+              ) : null}
+            </div>
+            <div className="flex shrink-0 items-center">
+              <Link className="btn-primary" to="/app/profile">
+                Update my profile
+              </Link>
+            </div>
+          </div>
+        </section>
+      ) : null}
       {error ? (
         <p className="md:col-span-full rounded-2xl border border-red-200 bg-red-50 p-4 text-sm text-red-700">
           {error}


### PR DESCRIPTION
## Summary
- add a volunteer dashboard call-to-action that highlights profile completion progress and directs members to the profile editor
- compute completion percentage and list missing profile fields based on dashboard profile data so the prompt only renders when information is incomplete
- document the new reminder in the dashboard guidelines and wiki for future contributors

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cca288d41883338b801968aec7284d