### PR TITLE
Include volunteer profile in auth responses

### DIFF
--- a/backend/src/features/auth/AGENTS.md
+++ b/backend/src/features/auth/AGENTS.md
@@ -9,3 +9,4 @@ These notes cover files within `backend/src/features/auth/`.
 - User records now maintain a primary `role` plus an expanded `user_roles` join table; always update both via the repository helpers so API responses expose a normalized `roles` array.
 - The admin bootstrapper seeds or promotes an ADMIN account from environment variables; prefer updating `admin.bootstrap.js` when adjusting default admin behavior.
 - Shared role ordering logic now lives in `role.helpers.js`; reuse those helpers whenever you need to normalize, sort, or compare user roles.
+- Public auth responses should provide the volunteer profile payload by way of `toPublicUserWithProfile` so dashboards can render completion prompts consistently across roles.

--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -67,3 +67,8 @@
 - **Date:** 2025-09-23
 - **Change:** Extended the profile completion call-to-action to event manager and sponsor dashboards, centralizing the UI so each role reuses the same visual pattern while customizing motivational copy.
 - **Impact:** Coordinators and partners now receive tailored encouragement to complete their profiles, improving trust with volunteers and giving the team better context for recognition efforts.
+
+## Sponsor & manager profile CTA data fix
+- **Date:** 2025-09-23
+- **Change:** Updated the auth service to include volunteer profile payloads in public user responses so sponsor and event manager dashboards can measure completion progress immediately after login.
+- **Impact:** Non-volunteer roles now see the profile completion prompts that were previously scoped to volunteers, keeping the cross-role guidance consistent.


### PR DESCRIPTION
## Summary
- add a shared helper that decorates auth user responses with the volunteer profile payload
- ensure signup, login, verification, and role reassignment now return profile data so sponsor and event manager dashboards receive completion progress
- document the expectation in auth AGENTS and record the fix in the wiki change log

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cca813f2e4833383545b4386861c72