### PR TITLE
Add lookup-driven profile editor and location lookups

### DIFF
--- a/backend/src/features/volunteer-journey/AGENTS.md
+++ b/backend/src/features/volunteer-journey/AGENTS.md
@@ -8,3 +8,4 @@ These instructions apply to files within `backend/src/features/volunteer-journey
 - Ensure new queries remain friendly to the in-memory `pg-mem` test harness (avoid Postgres-only syntax outside common SQL).
 - Keep reminder scheduler changes behind the `NODE_ENV!=='test'` guard. When adjusting intervals, ensure timers call `unref()` so background jobs do not block Node process shutdown.
 - When adding or updating routes, remember the router mounts at `/api`; define paths like `/me/profile` rather than duplicating the prefix.
+- When expanding profile metadata, keep the lookup seeding in `profile.bootstrap.js` in sync so startups continue to populate reference data without manual SQL.

--- a/backend/src/features/volunteer-journey/profile.bootstrap.js
+++ b/backend/src/features/volunteer-journey/profile.bootstrap.js
@@ -1,0 +1,149 @@
+const logger = require('../../utils/logger');
+const {
+  ensureSkillOption,
+  ensureInterestOption,
+  ensureAvailabilityOption,
+  ensureState,
+  ensureCity,
+} = require('./volunteerJourney.repository');
+
+const SKILL_SEEDS = [
+  { value: 'tree planting', label: 'Tree Planting' },
+  { value: 'beach cleanup coordination', label: 'Beach Cleanup Coordination' },
+  { value: 'first aid support', label: 'First Aid Support' },
+  { value: 'community outreach', label: 'Community Outreach' },
+  { value: 'teaching and mentoring', label: 'Teaching and Mentoring' },
+  { value: 'graphic design', label: 'Graphic Design' },
+  { value: 'social media storytelling', label: 'Social Media Storytelling' },
+  { value: 'waste segregation', label: 'Waste Segregation' },
+  { value: 'fundraising', label: 'Fundraising' },
+  { value: 'photography and videography', label: 'Photography and Videography' },
+];
+
+const INTEREST_SEEDS = [
+  { value: 'urban forestry', label: 'Urban Forestry' },
+  { value: 'coastal conservation', label: 'Coastal Conservation' },
+  { value: 'animal welfare', label: 'Animal Welfare' },
+  { value: 'education access', label: 'Education Access' },
+  { value: 'rural development', label: 'Rural Development' },
+  { value: 'climate advocacy', label: 'Climate Advocacy' },
+  { value: 'women empowerment', label: "Women Empowerment" },
+  { value: 'youth leadership', label: 'Youth Leadership' },
+  { value: 'health camps', label: 'Health Camps' },
+  { value: 'disaster relief', label: 'Disaster Relief' },
+];
+
+const AVAILABILITY_SEEDS = [
+  { value: 'weekday_mornings', label: 'Weekday mornings', sortOrder: 10 },
+  { value: 'weekday_afternoons', label: 'Weekday afternoons', sortOrder: 20 },
+  { value: 'weekday_evenings', label: 'Weekday evenings', sortOrder: 30 },
+  { value: 'weekends', label: 'Weekends', sortOrder: 40 },
+  { value: 'flexible', label: 'Flexible / On-call', sortOrder: 50 },
+];
+
+const STATE_SEEDS = [
+  { code: 'DL', name: 'Delhi' },
+  { code: 'MH', name: 'Maharashtra' },
+  { code: 'KA', name: 'Karnataka' },
+  { code: 'TN', name: 'Tamil Nadu' },
+  { code: 'TG', name: 'Telangana' },
+  { code: 'WB', name: 'West Bengal' },
+  { code: 'GJ', name: 'Gujarat' },
+  { code: 'UP', name: 'Uttar Pradesh' },
+  { code: 'RJ', name: 'Rajasthan' },
+  { code: 'KL', name: 'Kerala' },
+  { code: 'HR', name: 'Haryana' },
+  { code: 'PB', name: 'Punjab' },
+];
+
+const CITY_SEEDS = [
+  { stateCode: 'DL', name: 'New Delhi' },
+  { stateCode: 'MH', name: 'Mumbai' },
+  { stateCode: 'MH', name: 'Pune' },
+  { stateCode: 'MH', name: 'Nagpur' },
+  { stateCode: 'MH', name: 'Nashik' },
+  { stateCode: 'KA', name: 'Bengaluru' },
+  { stateCode: 'KA', name: 'Mysuru' },
+  { stateCode: 'KA', name: 'Mangaluru' },
+  { stateCode: 'KA', name: 'Hubballi-Dharwad' },
+  { stateCode: 'TN', name: 'Chennai' },
+  { stateCode: 'TN', name: 'Coimbatore' },
+  { stateCode: 'TN', name: 'Madurai' },
+  { stateCode: 'TN', name: 'Tiruchirappalli' },
+  { stateCode: 'TG', name: 'Hyderabad' },
+  { stateCode: 'TG', name: 'Warangal' },
+  { stateCode: 'TG', name: 'Nizamabad' },
+  { stateCode: 'WB', name: 'Kolkata' },
+  { stateCode: 'WB', name: 'Howrah' },
+  { stateCode: 'WB', name: 'Durgapur' },
+  { stateCode: 'WB', name: 'Siliguri' },
+  { stateCode: 'GJ', name: 'Ahmedabad' },
+  { stateCode: 'GJ', name: 'Surat' },
+  { stateCode: 'GJ', name: 'Vadodara' },
+  { stateCode: 'GJ', name: 'Rajkot' },
+  { stateCode: 'UP', name: 'Lucknow' },
+  { stateCode: 'UP', name: 'Kanpur' },
+  { stateCode: 'UP', name: 'Varanasi' },
+  { stateCode: 'UP', name: 'Noida' },
+  { stateCode: 'RJ', name: 'Jaipur' },
+  { stateCode: 'RJ', name: 'Udaipur' },
+  { stateCode: 'RJ', name: 'Jodhpur' },
+  { stateCode: 'RJ', name: 'Kota' },
+  { stateCode: 'KL', name: 'Thiruvananthapuram' },
+  { stateCode: 'KL', name: 'Kochi' },
+  { stateCode: 'KL', name: 'Kozhikode' },
+  { stateCode: 'KL', name: 'Thrissur' },
+  { stateCode: 'HR', name: 'Gurugram' },
+  { stateCode: 'HR', name: 'Faridabad' },
+  { stateCode: 'HR', name: 'Karnal' },
+  { stateCode: 'HR', name: 'Hisar' },
+  { stateCode: 'PB', name: 'Chandigarh' },
+  { stateCode: 'PB', name: 'Ludhiana' },
+  { stateCode: 'PB', name: 'Amritsar' },
+  { stateCode: 'PB', name: 'Jalandhar' },
+];
+
+function makeCitySlug(stateCode, name) {
+  const normalizedName = String(name)
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return `${String(stateCode).toLowerCase()}-${normalizedName}`;
+}
+
+async function seedVolunteerProfileLookups() {
+  try {
+    await Promise.all(SKILL_SEEDS.map((seed) => ensureSkillOption(seed)));
+    await Promise.all(INTEREST_SEEDS.map((seed) => ensureInterestOption(seed)));
+    await Promise.all(AVAILABILITY_SEEDS.map((seed) => ensureAvailabilityOption(seed)));
+
+    for (const state of STATE_SEEDS) {
+      await ensureState(state);
+    }
+
+    for (const city of CITY_SEEDS) {
+      await ensureCity({
+        slug: makeCitySlug(city.stateCode, city.name),
+        stateCode: city.stateCode,
+        name: city.name,
+      });
+    }
+
+    logger.info('Volunteer profile lookup seeds applied', {
+      skills: SKILL_SEEDS.length,
+      interests: INTEREST_SEEDS.length,
+      availability: AVAILABILITY_SEEDS.length,
+      states: STATE_SEEDS.length,
+      cities: CITY_SEEDS.length,
+    });
+  } catch (error) {
+    logger.error('Failed to seed volunteer profile lookups', { error: error.message });
+    throw error;
+  }
+}
+
+module.exports = {
+  seedVolunteerProfileLookups,
+  makeCitySlug,
+};

--- a/backend/src/features/volunteer-journey/volunteerJourney.route.js
+++ b/backend/src/features/volunteer-journey/volunteerJourney.route.js
@@ -3,6 +3,8 @@ const { authenticate } = require('../auth/auth.middleware');
 const {
   getProfile,
   updateProfile,
+  getProfileLookups,
+  getCitiesForState,
   browseEvents,
   signupForEvent,
   listMySignups,
@@ -55,16 +57,38 @@ router.get('/me/profile', authOnly, async (req, res) => {
 
 router.put('/me/profile', authOnly, async (req, res) => {
   try {
-    const { skills, interests, availability, location, bio } = req.body || {};
+    const { skills, interests, availability, stateCode, citySlug, bio } = req.body || {};
     const updated = await updateProfile({
       userId: req.user.id,
       skills,
       interests,
       availability,
-      location,
+      stateCode,
+      citySlug,
       bio,
     });
     res.json(updated);
+  } catch (error) {
+    const status = error.statusCode || 500;
+    res.status(status).json({ error: error.message });
+  }
+});
+
+router.get('/profile/lookups', authOnly, async (req, res) => {
+  try {
+    const lookups = await getProfileLookups();
+    res.json(lookups);
+  } catch (error) {
+    const status = error.statusCode || 500;
+    res.status(status).json({ error: error.message });
+  }
+});
+
+router.get('/profile/states/:stateCode/cities', authOnly, async (req, res) => {
+  try {
+    const { stateCode } = req.params;
+    const response = await getCitiesForState(stateCode);
+    res.json(response);
   } catch (error) {
     const status = error.statusCode || 500;
     res.status(status).json({ error: error.message });

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -2,12 +2,19 @@ const app = require("./app");
 const config = require("./config");
 const logger = require("./utils/logger");
 const { ensureAdminUser } = require("./features/auth/admin.bootstrap");
+const { seedVolunteerProfileLookups } = require("./features/volunteer-journey/profile.bootstrap");
 
 async function startServer() {
   try {
     await ensureAdminUser();
   } catch (error) {
     logger.error("Admin bootstrap failed", { error: error.message });
+  }
+
+  try {
+    await seedVolunteerProfileLookups();
+  } catch (error) {
+    logger.error("Volunteer profile lookup bootstrap failed", { error: error.message });
   }
 
   app.listen(config.port, () => {

--- a/backend/tests/volunteerJourney.service.test.js
+++ b/backend/tests/volunteerJourney.service.test.js
@@ -7,6 +7,7 @@ describe('volunteerJourney.service', () => {
   let volunteerService;
   let emailServiceMock;
   let repository;
+  let seedLookups;
 
   beforeEach(async () => {
     jest.resetModules();
@@ -38,6 +39,9 @@ describe('volunteerJourney.service', () => {
     authService = require('../src/features/auth/auth.service');
     volunteerService = require('../src/features/volunteer-journey/volunteerJourney.service');
     repository = require('../src/features/volunteer-journey/volunteerJourney.repository');
+    ({ seedVolunteerProfileLookups: seedLookups } = require('../src/features/volunteer-journey/profile.bootstrap'));
+
+    await seedLookups();
   });
 
   afterEach(() => {
@@ -88,19 +92,27 @@ describe('volunteerJourney.service', () => {
       userId: volunteer.id,
       skills: ['Tree Planting', 'tree planting', 'Community Outreach'],
       interests: ['Forests', 'Education'],
-      availability: 'Weekends',
-      location: ' Pune ',
+      availability: 'weekends',
+      stateCode: 'MH',
+      citySlug: 'mh-pune',
       bio: 'Ready to help nurture our urban forests.',
     });
 
     expect(updated.skills).toEqual(['tree planting', 'community outreach']);
     expect(updated.interests).toEqual(['forests', 'education']);
-    expect(updated.availability).toBe('Weekends');
-    expect(updated.location).toBe('Pune');
+    expect(updated.availability).toBe('weekends');
+    expect(updated.availabilityLabel).toBe('Weekends');
+    expect(updated.stateCode).toBe('MH');
+    expect(updated.stateName).toBe('Maharashtra');
+    expect(updated.citySlug).toBe('mh-pune');
+    expect(updated.cityName).toBe('Pune');
+    expect(updated.location).toBe('Pune, Maharashtra');
 
     const profile = await volunteerService.getProfile(volunteer.id);
     expect(profile.skills).toEqual(updated.skills);
     expect(profile.interests).toEqual(updated.interests);
+    expect(profile.stateCode).toBe('MH');
+    expect(profile.citySlug).toBe('mh-pune');
   });
 
   test('event signup enforces uniqueness and capacity while sending confirmation email', async () => {

--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -72,3 +72,8 @@
 - **Date:** 2025-09-23
 - **Change:** Updated the auth service to include volunteer profile payloads in public user responses so sponsor and event manager dashboards can measure completion progress immediately after login.
 - **Impact:** Non-volunteer roles now see the profile completion prompts that were previously scoped to volunteers, keeping the cross-role guidance consistent.
+
+## Lookup-driven profile editor
+- **Date:** 2025-09-24
+- **Change:** Replaced free-form profile fields with curated lookup selectors for skills, interests, availability, and location. The backend now seeds Indian-centric reference data for these lookups, exposes authenticated endpoints to fetch cascaded state/city lists, and persists selections alongside optional custom skills or interests.
+- **Impact:** Volunteers and other members update their profiles faster with consistent terminology, coordinators can filter against normalized data, and deployments automatically receive the seeded options without manual database scripts.

--- a/frontend/src/features/dashboard/profileProgress.js
+++ b/frontend/src/features/dashboard/profileProgress.js
@@ -18,7 +18,10 @@ export function calculateProfileProgress(profile) {
     },
     {
       label: 'Add your home base or region',
-      complete: Boolean(profile.location && profile.location.trim().length),
+      complete: Boolean(
+        (profile.stateCode && profile.citySlug) ||
+          (profile.location && profile.location.trim().length)
+      ),
     },
     {
       label: 'Introduce yourself with a short bio',

--- a/frontend/src/features/volunteer/AGENTS.md
+++ b/frontend/src/features/volunteer/AGENTS.md
@@ -5,5 +5,5 @@ These notes apply to files under `frontend/src/features/volunteer/`.
 - Keep components mobile-first: stack sections vertically and rely on responsive utilities for wider breakpoints.
 - Prefer colocated hooks/helpers in the same folder rather than reaching into shared libs unless the logic is reused elsewhere.
 - Surfaces that mutate backend data should display inline success and error states rather than relying on alerts.
-- When wiring new flows into the dashboard, reuse the shared refresh helpers so profile, signup, and hours panels stay in sync a
-  fter mutations.
+- When wiring new flows into the dashboard, reuse the shared refresh helpers so profile, signup, and hours panels stay in sync after mutations.
+- The profile editor relies on lookup APIs for skills, interests, availability, and location; extend those selectors instead of reverting to free-form inputs so members benefit from the curated choices.

--- a/frontend/src/features/volunteer/ProfileEditor.jsx
+++ b/frontend/src/features/volunteer/ProfileEditor.jsx
@@ -1,44 +1,186 @@
 import { useEffect, useMemo, useState } from 'react';
 
-function listToInput(value) {
-  return Array.isArray(value) && value.length ? value.join(', ') : '';
+function normalizeValue(value) {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  return String(value).trim().toLowerCase();
 }
 
-export default function ProfileEditor({ profile, onSave }) {
+function formatLabel(value) {
+  return String(value)
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(' ');
+}
+
+function mergeSelections(baseOptions = [], selectedValues = []) {
+  const map = new Map();
+  baseOptions.forEach((option) => {
+    if (!option || !option.value) return;
+    map.set(option.value, {
+      value: option.value,
+      label: option.label || formatLabel(option.value),
+    });
+  });
+  selectedValues.forEach((value) => {
+    if (!map.has(value)) {
+      map.set(value, { value, label: formatLabel(value) });
+    }
+  });
+  return Array.from(map.values()).sort((a, b) => a.label.localeCompare(b.label));
+}
+
+function sameSet(a = [], b = []) {
+  if (a.length !== b.length) return false;
+  const compare = new Set(b);
+  return a.every((value) => compare.has(value));
+}
+
+function resolveLabel(options = [], value) {
+  const option = options.find((item) => item.value === value);
+  return option ? option.label : formatLabel(value);
+}
+
+function mapProfileList(values) {
+  if (!Array.isArray(values)) {
+    return [];
+  }
+  return values
+    .map((entry) => normalizeValue(entry))
+    .filter((entry, index, array) => entry && array.indexOf(entry) === index);
+}
+
+export default function ProfileEditor({
+  profile,
+  onSave,
+  lookups = { skills: [], interests: [], availability: [], states: [] },
+  onRequestCities,
+  initialCities = [],
+}) {
   const [form, setForm] = useState({
-    skills: '',
-    interests: '',
+    skills: [],
+    interests: [],
     availability: '',
-    location: '',
+    stateCode: '',
+    citySlug: '',
     bio: '',
   });
   const [saving, setSaving] = useState(false);
   const [status, setStatus] = useState(null);
+  const [customSkill, setCustomSkill] = useState('');
+  const [customInterest, setCustomInterest] = useState('');
+  const [cityOptions, setCityOptions] = useState(Array.isArray(initialCities) ? initialCities : []);
+
+  const profileSkills = useMemo(() => mapProfileList(profile?.skills), [profile]);
+  const profileInterests = useMemo(() => mapProfileList(profile?.interests), [profile]);
+
+  const skillOptions = useMemo(
+    () => mergeSelections(lookups?.skills || [], form.skills),
+    [lookups?.skills, form.skills],
+  );
+  const interestOptions = useMemo(
+    () => mergeSelections(lookups?.interests || [], form.interests),
+    [lookups?.interests, form.interests],
+  );
 
   const hasChanges = useMemo(() => {
     if (!profile) return false;
-    return (
-      form.skills !== listToInput(profile.skills) ||
-      form.interests !== listToInput(profile.interests) ||
-      form.availability !== (profile.availability || '') ||
-      form.location !== (profile.location || '') ||
-      form.bio !== (profile.bio || '')
-    );
-  }, [form, profile]);
+    if (!sameSet(form.skills, profileSkills)) return true;
+    if (!sameSet(form.interests, profileInterests)) return true;
+    if ((form.availability || '') !== (profile.availability || '')) return true;
+    if ((form.stateCode || '') !== (profile.stateCode || '')) return true;
+    if ((form.citySlug || '') !== (profile.citySlug || '')) return true;
+    if ((form.bio || '') !== (profile.bio || '')) return true;
+    return false;
+  }, [form, profile, profileSkills, profileInterests]);
 
   useEffect(() => {
     if (!profile) return;
     setForm({
-      skills: listToInput(profile.skills),
-      interests: listToInput(profile.interests),
+      skills: profileSkills,
+      interests: profileInterests,
       availability: profile.availability || '',
-      location: profile.location || '',
+      stateCode: profile.stateCode || '',
+      citySlug: profile.citySlug || '',
       bio: profile.bio || '',
     });
-  }, [profile]);
+    setStatus(null);
+  }, [profile, profileSkills, profileInterests]);
 
-  const handleChange = (event) => {
+  useEffect(() => {
+    if (Array.isArray(initialCities)) {
+      setCityOptions(initialCities);
+    }
+  }, [initialCities]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const loadCities = async () => {
+      if (!form.stateCode) {
+        setCityOptions([]);
+        return;
+      }
+      if (typeof onRequestCities !== 'function') {
+        return;
+      }
+      try {
+        const response = await onRequestCities(form.stateCode);
+        if (cancelled) return;
+        const options = Array.isArray(response) ? response : Array.isArray(response?.cities) ? response.cities : [];
+        setCityOptions(options);
+        if (!options.some((option) => option.value === form.citySlug)) {
+          setForm((prev) => ({ ...prev, citySlug: '' }));
+        }
+      } catch (error) {
+        if (!cancelled) {
+          setCityOptions([]);
+        }
+      }
+    };
+    loadCities();
+    return () => {
+      cancelled = true;
+    };
+  }, [form.stateCode, form.citySlug, onRequestCities]);
+
+  const toggleSelection = (field, value) => {
+    const normalized = normalizeValue(value);
+    if (!normalized) return;
+    setForm((prev) => {
+      const current = new Set(prev[field]);
+      if (current.has(normalized)) {
+        current.delete(normalized);
+      } else {
+        current.add(normalized);
+      }
+      return { ...prev, [field]: Array.from(current) };
+    });
+  };
+
+  const handleAddCustom = (field, value, setter) => {
+    const normalized = normalizeValue(value);
+    if (!normalized) {
+      setter('');
+      return;
+    }
+    setForm((prev) => {
+      if (prev[field].includes(normalized)) {
+        return prev;
+      }
+      const next = [...prev[field], normalized];
+      return { ...prev, [field]: next };
+    });
+    setter('');
+  };
+
+  const handleSelectChange = (event) => {
     const { name, value } = event.target;
+    if (name === 'stateCode') {
+      setForm((prev) => ({ ...prev, stateCode: value, citySlug: '' }));
+      return;
+    }
     setForm((prev) => ({ ...prev, [name]: value }));
   };
 
@@ -49,25 +191,21 @@ export default function ProfileEditor({ profile, onSave }) {
     setStatus(null);
     try {
       const payload = {
-        skills: form.skills
-          .split(',')
-          .map((item) => item.trim())
-          .filter(Boolean),
-        interests: form.interests
-          .split(',')
-          .map((item) => item.trim())
-          .filter(Boolean),
-        availability: form.availability,
-        location: form.location,
+        skills: form.skills,
+        interests: form.interests,
+        availability: form.availability || null,
+        stateCode: form.stateCode || null,
+        citySlug: form.citySlug || null,
         bio: form.bio,
       };
       const updated = await onSave(payload);
       setStatus({ type: 'success', message: 'Profile saved successfully.' });
       setForm({
-        skills: listToInput(updated.skills),
-        interests: listToInput(updated.interests),
+        skills: mapProfileList(updated.skills),
+        interests: mapProfileList(updated.interests),
         availability: updated.availability || '',
-        location: updated.location || '',
+        stateCode: updated.stateCode || '',
+        citySlug: updated.citySlug || '',
         bio: updated.bio || '',
       });
     } catch (error) {
@@ -77,54 +215,174 @@ export default function ProfileEditor({ profile, onSave }) {
     }
   };
 
+  const selectedSkills = useMemo(
+    () => form.skills.map((value) => ({ value, label: resolveLabel(skillOptions, value) })),
+    [form.skills, skillOptions],
+  );
+  const selectedInterests = useMemo(
+    () => form.interests.map((value) => ({ value, label: resolveLabel(interestOptions, value) })),
+    [form.interests, interestOptions],
+  );
+
   return (
     <form className="flex flex-col gap-4" onSubmit={handleSubmit}>
       <div className="grid gap-3">
-        <label className="flex flex-col gap-1 text-sm">
-          <span className="font-semibold text-brand-forest">Skills</span>
-          <input
-            className="rounded-lg border border-brand-forest/20 bg-white px-3 py-2 text-sm shadow-sm focus:border-brand-green focus:outline-none"
-            type="text"
-            name="skills"
-            placeholder="e.g. planting, first aid, coordination"
-            value={form.skills}
-            onChange={handleChange}
-          />
-          <span className="text-xs text-brand-muted">Separate skills with commas to help us match you to the right roles.</span>
-        </label>
-        <label className="flex flex-col gap-1 text-sm">
-          <span className="font-semibold text-brand-forest">Interests</span>
-          <input
-            className="rounded-lg border border-brand-forest/20 bg-white px-3 py-2 text-sm shadow-sm focus:border-brand-green focus:outline-none"
-            type="text"
-            name="interests"
-            placeholder="e.g. wetlands, youth mentorship"
-            value={form.interests}
-            onChange={handleChange}
-          />
-        </label>
+        <fieldset className="flex flex-col gap-2">
+          <legend className="text-sm font-semibold text-brand-forest">Skills</legend>
+          <p className="m-0 text-xs text-brand-muted">
+            Pick every skill you bring. Add your own if it is missing.
+          </p>
+          <div className="grid gap-2 rounded-lg border border-brand-forest/20 bg-white p-3 shadow-sm sm:grid-cols-2">
+            {skillOptions.length ? (
+              skillOptions.map((option) => (
+                <label key={option.value} className="flex items-center gap-2 text-sm">
+                  <input
+                    type="checkbox"
+                    className="h-4 w-4 rounded border-brand-forest/40 text-brand-green focus:ring-brand-green"
+                    checked={form.skills.includes(option.value)}
+                    onChange={() => toggleSelection('skills', option.value)}
+                  />
+                  <span>{option.label}</span>
+                </label>
+              ))
+            ) : (
+              <span className="text-sm text-brand-muted">Loading skill options…</span>
+            )}
+          </div>
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+            <input
+              className="flex-1 rounded-lg border border-brand-forest/20 bg-white px-3 py-2 text-sm shadow-sm focus:border-brand-green focus:outline-none"
+              type="text"
+              name="customSkill"
+              placeholder="Add a custom skill"
+              value={customSkill}
+              onChange={(event) => setCustomSkill(event.target.value)}
+            />
+            <button
+              type="button"
+              className="btn-secondary"
+              onClick={() => handleAddCustom('skills', customSkill, setCustomSkill)}
+            >
+              Add skill
+            </button>
+          </div>
+          {selectedSkills.length ? (
+            <div className="flex flex-wrap gap-2 text-xs">
+              {selectedSkills.map((item) => (
+                <span key={item.value} className="rounded-full bg-brand-mint/40 px-3 py-1 text-brand-forest">
+                  {item.label}
+                </span>
+              ))}
+            </div>
+          ) : null}
+        </fieldset>
+
+        <fieldset className="flex flex-col gap-2">
+          <legend className="text-sm font-semibold text-brand-forest">Interests</legend>
+          <p className="m-0 text-xs text-brand-muted">
+            Highlight the causes you want to champion. Add more if we missed one.
+          </p>
+          <div className="grid gap-2 rounded-lg border border-brand-forest/20 bg-white p-3 shadow-sm sm:grid-cols-2">
+            {interestOptions.length ? (
+              interestOptions.map((option) => (
+                <label key={option.value} className="flex items-center gap-2 text-sm">
+                  <input
+                    type="checkbox"
+                    className="h-4 w-4 rounded border-brand-forest/40 text-brand-green focus:ring-brand-green"
+                    checked={form.interests.includes(option.value)}
+                    onChange={() => toggleSelection('interests', option.value)}
+                  />
+                  <span>{option.label}</span>
+                </label>
+              ))
+            ) : (
+              <span className="text-sm text-brand-muted">Loading interest options…</span>
+            )}
+          </div>
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+            <input
+              className="flex-1 rounded-lg border border-brand-forest/20 bg-white px-3 py-2 text-sm shadow-sm focus:border-brand-green focus:outline-none"
+              type="text"
+              name="customInterest"
+              placeholder="Add a custom interest"
+              value={customInterest}
+              onChange={(event) => setCustomInterest(event.target.value)}
+            />
+            <button
+              type="button"
+              className="btn-secondary"
+              onClick={() => handleAddCustom('interests', customInterest, setCustomInterest)}
+            >
+              Add interest
+            </button>
+          </div>
+          {selectedInterests.length ? (
+            <div className="flex flex-wrap gap-2 text-xs">
+              {selectedInterests.map((item) => (
+                <span key={item.value} className="rounded-full bg-brand-sand px-3 py-1 text-brand-forest">
+                  {item.label}
+                </span>
+              ))}
+            </div>
+          ) : null}
+        </fieldset>
+
         <label className="flex flex-col gap-1 text-sm">
           <span className="font-semibold text-brand-forest">Availability</span>
-          <input
+          <select
             className="rounded-lg border border-brand-forest/20 bg-white px-3 py-2 text-sm shadow-sm focus:border-brand-green focus:outline-none"
-            type="text"
             name="availability"
-            placeholder="Weekends, weekday evenings, etc."
             value={form.availability}
-            onChange={handleChange}
-          />
+            onChange={handleSelectChange}
+          >
+            <option value="">Select when you can contribute</option>
+            {(lookups?.availability || []).map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
         </label>
-        <label className="flex flex-col gap-1 text-sm">
-          <span className="font-semibold text-brand-forest">Location</span>
-          <input
-            className="rounded-lg border border-brand-forest/20 bg-white px-3 py-2 text-sm shadow-sm focus:border-brand-green focus:outline-none"
-            type="text"
-            name="location"
-            placeholder="City or neighbourhood"
-            value={form.location}
-            onChange={handleChange}
-          />
-        </label>
+
+        <div className="grid gap-3 sm:grid-cols-2">
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="font-semibold text-brand-forest">State</span>
+            <select
+              className="rounded-lg border border-brand-forest/20 bg-white px-3 py-2 text-sm shadow-sm focus:border-brand-green focus:outline-none"
+              name="stateCode"
+              value={form.stateCode}
+              onChange={handleSelectChange}
+            >
+              <option value="">Select your state</option>
+              {(lookups?.states || []).map((state) => (
+                <option key={state.value} value={state.value}>
+                  {state.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="font-semibold text-brand-forest">City</span>
+            <select
+              className="rounded-lg border border-brand-forest/20 bg-white px-3 py-2 text-sm shadow-sm focus:border-brand-green focus:outline-none"
+              name="citySlug"
+              value={form.citySlug}
+              onChange={handleSelectChange}
+              disabled={!form.stateCode || !cityOptions.length}
+            >
+              <option value="">{form.stateCode ? 'Select your city' : 'Choose a state first'}</option>
+              {cityOptions.map((city) => (
+                <option key={city.value} value={city.value}>
+                  {city.label}
+                </option>
+              ))}
+            </select>
+            {form.stateCode && !cityOptions.length ? (
+              <span className="text-xs text-brand-muted">Loading cities for your state…</span>
+            ) : null}
+          </label>
+        </div>
+
         <label className="flex flex-col gap-1 text-sm">
           <span className="font-semibold text-brand-forest">Bio</span>
           <textarea
@@ -132,25 +390,19 @@ export default function ProfileEditor({ profile, onSave }) {
             name="bio"
             placeholder="Share a sentence about why you volunteer."
             value={form.bio}
-            onChange={handleChange}
+            onChange={(event) => setForm((prev) => ({ ...prev, bio: event.target.value }))}
           />
         </label>
       </div>
       {status ? (
         <p
-          className={`m-0 text-sm ${
-            status.type === 'success' ? 'text-brand-green' : 'text-red-600'
-          }`}
+          className={`m-0 text-sm ${status.type === 'success' ? 'text-brand-green' : 'text-red-600'}`}
         >
           {status.message}
         </p>
       ) : null}
       <div className="flex flex-wrap gap-2">
-        <button
-          type="submit"
-          className="btn-primary"
-          disabled={saving || !hasChanges}
-        >
+        <button type="submit" className="btn-primary" disabled={saving || !hasChanges}>
           {saving ? 'Saving…' : 'Save profile'}
         </button>
         {!hasChanges ? (

--- a/frontend/src/features/volunteer/api.js
+++ b/frontend/src/features/volunteer/api.js
@@ -26,6 +26,18 @@ export function updateVolunteerProfile(token, payload) {
   return apiRequest('/api/me/profile', { method: 'PUT', token, body: payload });
 }
 
+export function fetchProfileLookups(token) {
+  return apiRequest('/api/profile/lookups', { token });
+}
+
+export function fetchCitiesForState(token, stateCode) {
+  const normalized = stateCode ? String(stateCode).trim() : '';
+  if (!normalized) {
+    return Promise.resolve({ state: null, cities: [] });
+  }
+  return apiRequest(`/api/profile/states/${encodeURIComponent(normalized)}/cities`, { token });
+}
+
 export function fetchEvents(token, filters = {}) {
   return apiRequest(`/api/events${buildQuery(filters)}`, { token });
 }


### PR DESCRIPTION
## Summary
- seed skills, interests, availability, and India-specific state/city reference data during backend bootstrap and expose lookup endpoints for profile editors
- normalize volunteer profile storage to keep state and city slugs, enforce lookup validation, and refresh API responses with derived labels and location metadata
- replace the volunteer profile form with lookup-driven selectors that support custom skills/interests, cascading state/city choices, and refreshed availability options across the dashboard

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ccad8bf0508333b81af49ebc9d07c2