### PR TITLE
Promote profile custom buttons to primary style

### DIFF
--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -77,3 +77,8 @@
 - **Date:** 2025-09-24
 - **Change:** Replaced free-form profile fields with curated lookup selectors for skills, interests, availability, and location. The backend now seeds Indian-centric reference data for these lookups, exposes authenticated endpoints to fetch cascaded state/city lists, and persists selections alongside optional custom skills or interests.
 - **Impact:** Volunteers and other members update their profiles faster with consistent terminology, coordinators can filter against normalized data, and deployments automatically receive the seeded options without manual database scripts.
+
+## Profile editor primary action buttons
+- **Date:** 2025-09-25
+- **Change:** Promoted the custom skill and interest buttons on the volunteer profile editor to use the primary button style and documented the expectation in the volunteer frontend guidelines.
+- **Impact:** The calls-to-action to add new skills or interests now stand out visually, guiding members to enrich their profiles without hunting for the controls.

--- a/frontend/src/features/volunteer/AGENTS.md
+++ b/frontend/src/features/volunteer/AGENTS.md
@@ -7,3 +7,4 @@ These notes apply to files under `frontend/src/features/volunteer/`.
 - Surfaces that mutate backend data should display inline success and error states rather than relying on alerts.
 - When wiring new flows into the dashboard, reuse the shared refresh helpers so profile, signup, and hours panels stay in sync after mutations.
 - The profile editor relies on lookup APIs for skills, interests, availability, and location; extend those selectors instead of reverting to free-form inputs so members benefit from the curated choices.
+- Use `btn-primary` for forward actions that add or save volunteer profile data so the calls-to-action stand out.

--- a/frontend/src/features/volunteer/ProfileEditor.jsx
+++ b/frontend/src/features/volunteer/ProfileEditor.jsx
@@ -260,7 +260,7 @@ export default function ProfileEditor({
             />
             <button
               type="button"
-              className="btn-secondary"
+              className="btn-primary"
               onClick={() => handleAddCustom('skills', customSkill, setCustomSkill)}
             >
               Add skill
@@ -310,7 +310,7 @@ export default function ProfileEditor({
             />
             <button
               type="button"
-              className="btn-secondary"
+              className="btn-primary"
               onClick={() => handleAddCustom('interests', customInterest, setCustomInterest)}
             >
               Add interest


### PR DESCRIPTION
## Summary
- switch the volunteer profile editor's custom skill and interest actions to the primary button treatment so the calls-to-action are prominent
- document the button styling expectation alongside the existing volunteer frontend guidance
- record the UI tweak in the project wiki

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ccb28a915c8333ac828668fbabe1fd