### PR TITLE
Clarify volunteer hours event selection

### DIFF
--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -82,3 +82,8 @@
 - **Date:** 2025-09-25
 - **Change:** Promoted the custom skill and interest buttons on the volunteer profile editor to use the primary button style and documented the expectation in the volunteer frontend guidelines.
 - **Impact:** The calls-to-action to add new skills or interests now stand out visually, guiding members to enrich their profiles without hunting for the controls.
+
+## Volunteer impact tracker event guidance
+- **Date:** 2025-09-25
+- **Change:** Updated the volunteer impact tracker so the event field shows an informational message instead of a selectable option when no eligible signups exist.
+- **Impact:** Volunteers see clearer guidance that they must join an event before logging hours, avoiding confusion from an empty dropdown choice.

--- a/frontend/src/features/volunteer/HoursTracker.jsx
+++ b/frontend/src/features/volunteer/HoursTracker.jsx
@@ -93,20 +93,25 @@ export default function HoursTracker({ summary, signups, onLogHours }) {
         <form className="flex flex-col gap-3" onSubmit={handleSubmit}>
           <label className="flex flex-col gap-1 text-sm">
             <span className="font-semibold text-brand-forest">Event</span>
-            <select
-              className="rounded-lg border border-brand-forest/20 bg-white px-3 py-2 text-sm shadow-sm focus:border-brand-green focus:outline-none"
-              name="eventId"
-              value={form.eventId}
-              onChange={handleChange}
-            >
-              {!upcomingOptions.length ? <option value="">Join an event to log your time</option> : null}
-              {upcomingOptions.map((option) => (
-                <option key={option.id} value={option.id}>
-                  {option.title}
-                  {option.isUpcoming ? ' (upcoming)' : ''}
-                </option>
-              ))}
-            </select>
+            {upcomingOptions.length ? (
+              <select
+                className="rounded-lg border border-brand-forest/20 bg-white px-3 py-2 text-sm shadow-sm focus:border-brand-green focus:outline-none"
+                name="eventId"
+                value={form.eventId}
+                onChange={handleChange}
+              >
+                {upcomingOptions.map((option) => (
+                  <option key={option.id} value={option.id}>
+                    {option.title}
+                    {option.isUpcoming ? ' (upcoming)' : ''}
+                  </option>
+                ))}
+              </select>
+            ) : (
+              <p className="m-0 rounded-lg border border-dashed border-brand-forest/30 bg-white px-3 py-2 text-sm text-brand-muted">
+                Join an event to log your time.
+              </p>
+            )}
           </label>
           <label className="flex flex-col gap-1 text-sm">
             <span className="font-semibold text-brand-forest">Hours completed</span>


### PR DESCRIPTION
## Summary
- replace the volunteer impact tracker dropdown placeholder with an informational message when there are no eligible event signups
- keep the log hours action disabled without upcoming events so volunteers know to join an event first
- document the UX tweak in the wiki change log

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ccb406b52883338cc824d752db8aa4