### PR TITLE
feat(volunteer): gate hours logging behind event participation

### DIFF
--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -82,3 +82,8 @@
 - **Date:** 2025-09-25
 - **Change:** Promoted the custom skill and interest buttons on the volunteer profile editor to use the primary button style and documented the expectation in the volunteer frontend guidelines.
 - **Impact:** The calls-to-action to add new skills or interests now stand out visually, guiding members to enrich their profiles without hunting for the controls.
+
+## Hours logging requires event participation
+- **Date:** 2025-09-25
+- **Change:** Updated the volunteer hours tracker to hide the logging form when a volunteer has not joined any events, replacing it with guidance to explore the events hub. Documented the pattern in the volunteer frontend guidelines.
+- **Impact:** Volunteers understand they must RSVP to an event before logging time and are directed to the appropriate place to do so, preventing empty submissions.

--- a/frontend/src/features/volunteer/AGENTS.md
+++ b/frontend/src/features/volunteer/AGENTS.md
@@ -8,3 +8,4 @@ These notes apply to files under `frontend/src/features/volunteer/`.
 - When wiring new flows into the dashboard, reuse the shared refresh helpers so profile, signup, and hours panels stay in sync after mutations.
 - The profile editor relies on lookup APIs for skills, interests, availability, and location; extend those selectors instead of reverting to free-form inputs so members benefit from the curated choices.
 - Use `btn-primary` for forward actions that add or save volunteer profile data so the calls-to-action stand out.
+- Hours logging UI should hide mutation forms when there are no eligible events and instead guide volunteers to join an event first.

--- a/frontend/src/features/volunteer/HoursTracker.jsx
+++ b/frontend/src/features/volunteer/HoursTracker.jsx
@@ -77,6 +77,7 @@ export default function HoursTracker({ summary, signups, onLogHours }) {
 
   const totalHours = formatHours(summary?.totalHours || 0);
   const earnedBadges = summary?.badges?.filter((badge) => badge.earned).length || 0;
+  const hasEligibleEvents = upcomingOptions.length > 0;
 
   return (
     <div className="flex flex-col gap-5">
@@ -90,7 +91,8 @@ export default function HoursTracker({ summary, signups, onLogHours }) {
 
       <section className="flex flex-col gap-3">
         <h4 className="m-0 text-base font-semibold text-brand-forest">Log new hours</h4>
-        <form className="flex flex-col gap-3" onSubmit={handleSubmit}>
+        {hasEligibleEvents ? (
+          <form className="flex flex-col gap-3" onSubmit={handleSubmit}>
           <label className="flex flex-col gap-1 text-sm">
             <span className="font-semibold text-brand-forest">Event</span>
             <select
@@ -99,7 +101,6 @@ export default function HoursTracker({ summary, signups, onLogHours }) {
               value={form.eventId}
               onChange={handleChange}
             >
-              {!upcomingOptions.length ? <option value="">Join an event to log your time</option> : null}
               {upcomingOptions.map((option) => (
                 <option key={option.id} value={option.id}>
                   {option.title}
@@ -140,10 +141,20 @@ export default function HoursTracker({ summary, signups, onLogHours }) {
               {status.message}
             </p>
           ) : null}
-          <button type="submit" className="btn-primary" disabled={submitting || !upcomingOptions.length}>
+          <button type="submit" className="btn-primary" disabled={submitting}>
             {submitting ? 'Saving…' : 'Log hours'}
           </button>
         </form>
+        ) : (
+          <div className="flex flex-col gap-3 rounded-2xl border border-dashed border-brand-forest/30 bg-brand-ivory p-4 text-sm text-brand-muted">
+            <p className="m-0">
+              Join an event to log your time. Head to the events hub to browse opportunities and RSVP.
+            </p>
+            <a className="btn-primary w-full text-center sm:w-auto" href="/app/events">
+              Explore events
+            </a>
+          </div>
+        )}
       </section>
 
       <section className="flex flex-col gap-3">


### PR DESCRIPTION
## Summary
- hide the volunteer hours logging form when no event signups exist and show a call-to-action linking to the events hub
- document the guardrail for hours logging UI in the volunteer frontend contributor notes
- record the new behavior in the project wiki change log

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ccb617a8048333bd8d10ae70dae215