### PR TITLE
Adjust volunteer events CTA width

### DIFF
--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -87,3 +87,8 @@
 - **Date:** 2025-09-25
 - **Change:** Updated the volunteer hours tracker to hide the logging form when a volunteer has not joined any events, replacing it with guidance to explore the events hub. Documented the pattern in the volunteer frontend guidelines.
 - **Impact:** Volunteers understand they must RSVP to an event before logging time and are directed to the appropriate place to do so, preventing empty submissions.
+
+## Volunteer events CTA width refinement
+- **Date:** 2025-09-25
+- **Change:** Adjusted the volunteer hours tracker events hub link to use a self-starting primary button so the CTA renders at its standard width instead of stretching across the card. Added the expectation to the volunteer frontend guidelines.
+- **Impact:** Volunteers see a tidy guidance card that matches other dashboard buttons while still drawing attention to the events hub when they need to join an opportunity before logging hours.

--- a/frontend/src/features/volunteer/AGENTS.md
+++ b/frontend/src/features/volunteer/AGENTS.md
@@ -9,3 +9,4 @@ These notes apply to files under `frontend/src/features/volunteer/`.
 - The profile editor relies on lookup APIs for skills, interests, availability, and location; extend those selectors instead of reverting to free-form inputs so members benefit from the curated choices.
 - Use `btn-primary` for forward actions that add or save volunteer profile data so the calls-to-action stand out.
 - Hours logging UI should hide mutation forms when there are no eligible events and instead guide volunteers to join an event first.
+- When surfacing guidance CTAs (like the events hub link), apply `self-start` alongside `btn-primary` so the button keeps its standard width instead of stretching edge-to-edge.

--- a/frontend/src/features/volunteer/HoursTracker.jsx
+++ b/frontend/src/features/volunteer/HoursTracker.jsx
@@ -150,7 +150,7 @@ export default function HoursTracker({ summary, signups, onLogHours }) {
             <p className="m-0">
               Join an event to log your time. Head to the events hub to browse opportunities and RSVP.
             </p>
-            <a className="btn-primary w-full text-center sm:w-auto" href="/app/events">
+            <a className="btn-primary self-start" href="/app/events">
               Explore events
             </a>
           </div>


### PR DESCRIPTION
## Summary
- keep the volunteer hours tracker events hub button to its standard size by anchoring the primary button with self-start styling
- document the CTA width guideline in the volunteer frontend AGENTS file for future contributors
- log the dashboard refinement in the project wiki for visibility

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ccb878f06883338b5d584b7420ba25