### PR TITLE
Add lookup-driven event logging for managers

### DIFF
--- a/backend/src/features/event-management/AGENTS.md
+++ b/backend/src/features/event-management/AGENTS.md
@@ -8,3 +8,5 @@ These instructions apply to files within `backend/src/features/event-management/
 - When emitting emails, reuse the shared `sendTemplatedEmail` helper and guard failures so that the primary request still
   succeeds while logging the error.
 - Prefer ISO 8601 strings in API responses; convert database timestamps using `toISOString()` before returning them.
+- Keep event metadata normalized: categories live in `event_categories` and locations reference the Indian state/city tables,
+  so persist both the lookup value and any human-readable label when adjusting schemas or business rules.

--- a/backend/src/features/event-management/eventManagement.route.js
+++ b/backend/src/features/event-management/eventManagement.route.js
@@ -14,6 +14,8 @@ const {
   getEventSignups,
   buildReport,
   getEventOverview,
+  getEventLookups,
+  createEventCategory,
 } = require('./eventManagement.service');
 
 const router = express.Router();
@@ -22,6 +24,30 @@ const managerOnly = authorizeRoles('EVENT_MANAGER', 'ADMIN');
 const uuidPattern = /^[0-9a-fA-F-]{36}$/;
 
 router.use(authOnly, managerOnly);
+
+router.get('/events/lookups', async (req, res) => {
+  try {
+    const lookups = await getEventLookups();
+    res.json(lookups);
+  } catch (error) {
+    const status = error.statusCode || 500;
+    res.status(status).json({ error: error.message });
+  }
+});
+
+router.post('/events/categories', async (req, res) => {
+  try {
+    const label = String(req.body?.label || '').trim();
+    if (!label) {
+      return res.status(400).json({ error: 'Category label is required' });
+    }
+    const category = await createEventCategory(label);
+    res.status(201).json({ category });
+  } catch (error) {
+    const status = error.statusCode || 500;
+    res.status(status).json({ error: error.message });
+  }
+});
 
 router.get('/events', async (req, res) => {
   try {

--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -82,3 +82,8 @@
 - **Date:** 2025-09-25
 - **Change:** Promoted the custom skill and interest buttons on the volunteer profile editor to use the primary button style and documented the expectation in the volunteer frontend guidelines.
 - **Impact:** The calls-to-action to add new skills or interests now stand out visually, guiding members to enrich their profiles without hunting for the controls.
+
+## Event manager lookup-driven event logging
+- **Date:** 2025-09-26
+- **Change:** Event drafting now relies on reference data: categories persist to a new `event_categories` table, state/city fields reference the Indian lookup tables, an `isOnline` flag drives mode-specific validation, and optional skill/interest/availability arrays capture ideal volunteers. The manager workspace fetches these lookups, offers inline category creation, and reshapes the form/UI to surface online mode and location chips.
+- **Impact:** Managers log events with consistent taxonomy, can flag virtual sessions, and share richer expectations with volunteers without duplicating reference data or free-form text.

--- a/frontend/src/features/event-manager/AGENTS.md
+++ b/frontend/src/features/event-manager/AGENTS.md
@@ -6,3 +6,5 @@ These notes apply to files within `frontend/src/features/event-manager/`.
 - Favor lightweight composable components; prefer colocated hooks for data fetching tied to this feature instead of global state.
 - Forms should be mobile-first with stacked inputs and accessible labels; use inline status badges for success/error feedback.
 - When surfacing metrics, accompany numeric values with short descriptive labels for clarity on small screens.
+- Source event creation lookups (categories, skills, interests, availability, state/city cascades) from the dedicated manager
+  endpoints so options stay in sync with backend seeds—avoid hard-coded lists.


### PR DESCRIPTION
## Summary
- normalize event metadata around lookup tables, adding category, state/city, online, and requirement columns
- expose manager lookups and category creation endpoints while updating validation and email content
- refresh the manager workspace form to use lookup selectors, inline category creation, and display requirement chips

## Testing
- npm test (backend)
- npm run build (frontend)

------
https://chatgpt.com/codex/tasks/task_e_68ccb7738b088333bb26dfac9b81a47b