### PR TITLE
Send async event launch emails

### DIFF
--- a/backend/src/features/event-management/AGENTS.md
+++ b/backend/src/features/event-management/AGENTS.md
@@ -7,6 +7,8 @@ These instructions apply to files within `backend/src/features/event-management/
   connections internally for simple operations.
 - When emitting emails, reuse the shared `sendTemplatedEmail` helper and guard failures so that the primary request still
   succeeds while logging the error.
+- Event creation should continue to schedule notification emails asynchronously via `scheduleEventCreationEmails` so request
+  latency stays low and future updates centralize personalization logic there.
 - Prefer ISO 8601 strings in API responses; convert database timestamps using `toISOString()` before returning them.
 - Keep event metadata normalized: categories live in `event_categories` and locations reference the Indian state/city tables,
   so persist both the lookup value and any human-readable label when adjusting schemas or business rules.

--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -99,3 +99,8 @@
 - **Change:** Adjusted the volunteer hours tracker events hub link to use a self-starting primary button so the CTA renders at its standard width instead of stretching across the card. Added the expectation to the volunteer frontend guidelines.
 - **Impact:** Volunteers see a tidy guidance card that matches other dashboard buttons while still drawing attention to the events hub when they need to join an opportunity before logging hours.
 
+## Event launch outreach automation
+- **Date:** 2025-09-26
+- **Change:** Event creation now schedules branded emails to every volunteer and sponsor in the background, tailoring the message, CTA, and impact notes when their profile skills, interests, availability, or location align with the opportunity.
+- **Impact:** Event managers publish without waiting on email dispatch while volunteers and sponsors receive timely, personalized nudges that highlight why the event matters to them.
+


### PR DESCRIPTION
## Summary
- add a repository helper to fetch volunteers and sponsors along with their profile context
- schedule event creation emails to go out asynchronously with personalized copy and CTAs for volunteers and sponsors
- capture the automation expectations in the event-management guidelines and wiki

## Testing
- npm test -- --runTestsByPath tests/auth.service.test.js
- npm test -- --runTestsByPath tests/volunteerJourney.service.test.js

------
https://chatgpt.com/codex/tasks/task_e_68ccbce77f608333b6aeda519f020b41