### PR TITLE
Add role journey landing pages and signup deep links

### DIFF
--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -1,5 +1,13 @@
 # Onkur Change Log
 
+## Role journey landing guides
+- **Date:** 2025-09-27
+- **Change:** Added dedicated `/journeys/:role` pages that expand the pre-login "Discover their journey" call-to-action with
+  role-specific stories, feature highlights, and direct signup prompts. The signup form now honors an optional `role`
+  query parameter to preselect the suggested role.
+- **Impact:** Prospective volunteers, event managers, sponsors, and admins can explore how Onkur supports their workflows
+  and jump straight into registration paths tuned to their interests.
+
 ## Desktop navigation parity
 - **Date:** 2025-09-18
 - **Change:** Introduced a desktop header navigation that mirrors the mobile bottom menu, centralized the navigation config, and wired menu items to new `/app/events`, `/app/gallery`, and `/app/profile` routes.

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,12 +8,14 @@ import ProtectedRoute from './features/auth/ProtectedRoute';
 import PublicOnlyRoute from './features/auth/PublicOnlyRoute';
 import DashboardRouter from './features/dashboard/DashboardRouter';
 import HomePage from './features/landing/HomePage';
+import JourneyDetailsPage from './features/landing/JourneyDetailsPage';
 
 function App() {
   return (
     <AppLayout>
       <Routes>
         <Route path="/" element={<HomePage />} />
+        <Route path="/journeys/:role" element={<JourneyDetailsPage />} />
         <Route
           path="/app/*"
           element={

--- a/frontend/src/features/auth/SignupPage.jsx
+++ b/frontend/src/features/auth/SignupPage.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import useDocumentTitle from '../../lib/useDocumentTitle';
 import { useAuth } from './AuthContext';
 import { getConfiguredSupportEmail } from './supportEmail';
@@ -20,6 +20,7 @@ export default function SignupPage() {
   const [success, setSuccess] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [selectedRoles, setSelectedRoles] = useState([]);
+  const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   useDocumentTitle('Onkur | Join the Onkur movement');
   const configuredSupportEmail = useMemo(() => getConfiguredSupportEmail(), []);
@@ -29,18 +30,31 @@ export default function SignupPage() {
     [availableRoles]
   );
 
+  const roleQuery = searchParams.get('role');
+
   useEffect(() => {
     if (!selectableRoles.length) {
       setSelectedRoles([]);
       return;
     }
+
+    if (roleQuery && selectableRoles.includes(roleQuery)) {
+      setSelectedRoles((prev) => {
+        if (prev.length === 1 && prev[0] === roleQuery) {
+          return prev;
+        }
+        return [roleQuery];
+      });
+      return;
+    }
+
     setSelectedRoles((prev) => {
       if (prev.length) {
         return prev.filter((role) => selectableRoles.includes(role));
       }
       return [selectableRoles[0]];
     });
-  }, [selectableRoles]);
+  }, [selectableRoles, roleQuery]);
 
   const ROLE_DETAILS = useMemo(
     () => ({

--- a/frontend/src/features/landing/AGENTS.md
+++ b/frontend/src/features/landing/AGENTS.md
@@ -1,0 +1,7 @@
+# Landing Experience Guidelines
+
+These notes apply to files within `frontend/src/features/landing/`.
+
+- Keep role journey copy centralized in `JourneyDetailsPage.jsx` so the landing cards and details stay in sync.
+- Prefer expressive, human-centered language that reflects Onkur's community tone when editing marketing content.
+- When adding new public routes, update `App.jsx` and ensure there is a clear call-to-action guiding visitors to `/signup` or `/login`.

--- a/frontend/src/features/landing/HomePage.jsx
+++ b/frontend/src/features/landing/HomePage.jsx
@@ -26,24 +26,28 @@ const HIGHLIGHTS = [
 const ROLE_CARDS = [
   {
     role: 'Volunteers',
+    slug: 'volunteers',
     blurb:
       'Discover events that match your skills, register instantly, and collect hours, certificates, and stories of impact.',
     accent: 'leaf',
   },
   {
     role: 'Event Managers',
+    slug: 'event-managers',
     blurb:
       'Plan meaningful gatherings, assign tasks, track attendance, and publish galleries that showcase every milestone.',
     accent: 'sun',
   },
   {
     role: 'Sponsors',
+    slug: 'sponsors',
     blurb:
       'Champion local change with funding or resources and receive beautiful, data-rich reports on how you made a difference.',
     accent: 'wave',
   },
   {
     role: 'Admins',
+    slug: 'admins',
     blurb:
       'Steward the platform, approve initiatives, moderate galleries, and ensure everyone experiences Onkur at its best.',
     accent: 'roots',
@@ -135,7 +139,7 @@ export default function HomePage() {
               <h4>{role.role}</h4>
               <p>{role.blurb}</p>
               <div className="role-card__cta">
-                <span>Discover their journey →</span>
+                <Link to={`/journeys/${role.slug}`}>Discover their journey →</Link>
               </div>
             </article>
           ))}

--- a/frontend/src/features/landing/JourneyDetailsPage.jsx
+++ b/frontend/src/features/landing/JourneyDetailsPage.jsx
@@ -1,0 +1,206 @@
+import { Link, Navigate, useParams } from 'react-router-dom';
+import useDocumentTitle from '../../lib/useDocumentTitle';
+
+const JOURNEY_CONTENT = {
+  volunteers: {
+    title: 'Volunteer journey',
+    intro:
+      'Follow a day-in-the-life of an Onkur volunteer—from finding opportunities to celebrating the difference you make.',
+    heroHighlight: 'Create momentum with hands-on action and a story worth sharing.',
+    experience: [
+      {
+        label: 'Discover events you love',
+        description:
+          'Browse curated events aligned to your skills and availability, and RSVP instantly from any device.',
+      },
+      {
+        label: 'Show up prepared',
+        description:
+          'Get gentle reminders, task outlines, and local insights so you arrive confident and ready to make an impact.',
+      },
+      {
+        label: 'Reflect and grow',
+        description:
+          'Log your hours, earn eco-badges, and capture photo memories that prove the change you helped create.',
+      },
+    ],
+    features: [
+      'Personalized event recommendations tailored to your interests.',
+      'One-tap check-ins, attendance tracking, and digital certificates.',
+      'Eco-journals that celebrate every badge, milestone, and story.',
+    ],
+    cta: {
+      label: 'Register as a volunteer',
+      roleQuery: 'VOLUNTEER',
+    },
+  },
+  'event-managers': {
+    title: 'Event manager journey',
+    intro:
+      'See how event managers orchestrate smooth gatherings, empower volunteers, and report back with confidence.',
+    heroHighlight: 'Craft experiences that energize your community and honor every contribution.',
+    experience: [
+      {
+        label: 'Design meaningful events',
+        description:
+          'Create immersive programs with location lookups, skill tags, and role assignments that stay organized.',
+      },
+      {
+        label: 'Coordinate in the field',
+        description:
+          'Track attendance live, broadcast updates, and upload gallery-ready photos without leaving the event.',
+      },
+      {
+        label: 'Report the ripple effect',
+        description:
+          'Share dashboards, automate impact summaries, and celebrate sponsors with transparent outcomes.',
+      },
+    ],
+    features: [
+      'Collaborative task boards for every milestone.',
+      'Attendance and hour logs that sync automatically with volunteer profiles.',
+      'Sponsor-ready reports that highlight outcomes and gratitude.',
+    ],
+    cta: {
+      label: 'Register as an event manager',
+      roleQuery: 'EVENT_MANAGER',
+    },
+  },
+  sponsors: {
+    title: 'Sponsor journey',
+    intro:
+      'Experience how partners stay connected to the impact they fund and the communities they uplift.',
+    heroHighlight: 'Invest with clarity, celebrate stories, and inspire continued generosity.',
+    experience: [
+      {
+        label: 'Discover initiatives that align',
+        description:
+          'Review verified projects with transparent budgets, timelines, and needs that match your mission.',
+      },
+      {
+        label: 'Stay present throughout',
+        description:
+          'Receive live updates, gallery previews, and gratitude messages while events are still unfolding.',
+      },
+      {
+        label: 'Measure the outcomes',
+        description:
+          'Download ROI dashboards, share testimonials, and see the lasting change your contribution unlocked.',
+      },
+    ],
+    features: [
+      'Impact dashboards that translate numbers into narratives.',
+      'Curated gallery takeovers for brand alignment and recognition.',
+      'Automated gratitude packages for your teams and stakeholders.',
+    ],
+    cta: {
+      label: 'Become an Onkur sponsor',
+      roleQuery: 'SPONSOR',
+    },
+  },
+  admins: {
+    title: 'Admin journey',
+    intro:
+      'Understand how administrators steward Onkur—keeping communities safe, content vibrant, and systems humming.',
+    heroHighlight: 'Empower every role while safeguarding the movement behind the scenes.',
+    experience: [
+      {
+        label: 'Curate trusted memberships',
+        description:
+          'Verify new members, assign roles, and maintain clarity across teams without heavy manual work.',
+      },
+      {
+        label: 'Elevate the story',
+        description:
+          'Moderate galleries, spotlight impact, and keep the platform feeling warm, inclusive, and actionable.',
+      },
+      {
+        label: 'Steer strategic insight',
+        description:
+          'Monitor platform health, respond to support needs, and share insights that guide future initiatives.',
+      },
+    ],
+    features: [
+      'Role management with intuitive approvals and safeguards.',
+      'Content moderation flows that balance safety with celebration.',
+      'Unified analytics for memberships, events, and sponsorships.',
+    ],
+    cta: {
+      label: 'Connect with the Onkur team',
+      roleQuery: null,
+    },
+  },
+};
+
+export default function JourneyDetailsPage() {
+  const { role } = useParams();
+  const journey = JOURNEY_CONTENT[role];
+
+  if (!journey) {
+    return <Navigate to="/" replace />;
+  }
+
+  useDocumentTitle(`Onkur | ${journey.title}`);
+
+  const signupLink = journey.cta.roleQuery ? `/signup?role=${journey.cta.roleQuery}` : '/signup';
+
+  return (
+    <div className="journey-page">
+      <section className="journey-hero">
+        <div className="journey-hero__content">
+          <p className="journey-hero__eyebrow">Tailored Onkur experiences</p>
+          <h1>{journey.title}</h1>
+          <p className="journey-hero__intro">{journey.intro}</p>
+          <p className="journey-hero__highlight">{journey.heroHighlight}</p>
+          <div className="journey-hero__actions">
+            <Link className="btn-primary" to={signupLink}>
+              {journey.cta.label}
+            </Link>
+            <Link className="btn-secondary" to="/">
+              Explore all journeys
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <section className="journey-experience">
+        <h2>Your path with Onkur</h2>
+        <div className="journey-experience__list">
+          {journey.experience.map((step) => (
+            <article key={step.label}>
+              <h3>{step.label}</h3>
+              <p>{step.description}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="journey-features">
+        <h2>Why this journey shines</h2>
+        <ul>
+          {journey.features.map((feature) => (
+            <li key={feature}>{feature}</li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="journey-cta">
+        <div className="journey-cta__card">
+          <h2>Bring this journey to life</h2>
+          <p>
+            Ready to experience the full suite of tools built for this role? Join Onkur and start collaborating with a community
+            that cares deeply about regenerative change.
+          </p>
+          <div className="journey-cta__actions">
+            <Link className="btn-primary" to={signupLink}>
+              {journey.cta.label}
+            </Link>
+            <Link className="btn-secondary" to="/login">
+              Already registered? Sign in
+            </Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/styles/theme.css
+++ b/frontend/src/styles/theme.css
@@ -180,6 +180,10 @@
     @apply mt-auto font-semibold text-brand-green;
   }
 
+  .role-card__cta a {
+    @apply inline-flex items-center gap-1 text-current no-underline transition hover:text-brand-forest hover:underline;
+  }
+
   .role-card--leaf::before,
   .role-card--sun::before,
   .role-card--wave::before,


### PR DESCRIPTION
## Summary
- add `/journeys/:role` role-detail pages that expand the pre-login journeys with storytelling and targeted calls-to-action
- link the landing role cards to the new journey pages and style the CTA links for accessibility
- let the signup flow honor an optional `role` query parameter so journeys can preselect a suggested role and document the update

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ccbe8da21c8333ba27ffa99ed57f05