### PR TITLE
Fix event constraint bootstrap collisions

### DIFF
--- a/backend/src/features/volunteer-journey/AGENTS.md
+++ b/backend/src/features/volunteer-journey/AGENTS.md
@@ -9,3 +9,4 @@ These instructions apply to files within `backend/src/features/volunteer-journey
 - Keep reminder scheduler changes behind the `NODE_ENV!=='test'` guard. When adjusting intervals, ensure timers call `unref()` so background jobs do not block Node process shutdown.
 - When adding or updating routes, remember the router mounts at `/api`; define paths like `/me/profile` rather than duplicating the prefix.
 - When expanding profile metadata, keep the lookup seeding in `profile.bootstrap.js` in sync so startups continue to populate reference data without manual SQL.
+- Keep schema bootstrap logic idempotent—check for existing constraints and indexes before adding them so repeated server starts do not crash.

--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -104,3 +104,8 @@
 - **Change:** Event creation now schedules branded emails to every volunteer and sponsor in the background, tailoring the message, CTA, and impact notes when their profile skills, interests, availability, or location align with the opportunity.
 - **Impact:** Event managers publish without waiting on email dispatch while volunteers and sponsors receive timely, personalized nudges that highlight why the event matters to them.
 
+## Idempotent event lookup constraints
+- **Date:** 2025-09-27
+- **Change:** Hardened the volunteer journey bootstrapper to check for foreign key constraints before adding them to the `events` table so schema setup can run multiple times without raising duplicate constraint errors.
+- **Impact:** Local development and container restarts no longer crash during startup when the lookup seeding runs after the schema has already been upgraded.
+


### PR DESCRIPTION
## Summary
- ensure the volunteer journey schema bootstrapper only creates event foreign key constraints when they are missing
- document the idempotent schema requirement for the volunteer journey feature area
- record the bootstrap hardening in the shared wiki

## Testing
- npm run test:connections *(fails: Postgres connection not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ccbff9ace88333904c98e49145a55f