### PR TITLE
Fix event creation insert placeholders

### DIFF
--- a/backend/src/features/event-management/eventManagement.repository.js
+++ b/backend/src/features/event-management/eventManagement.repository.js
@@ -124,8 +124,10 @@ async function createEvent({
         $13,
         $14,
         $15,
+        $16,
+        $17,
         'DRAFT',
-        $16
+        $18
       )
       RETURNING *
     `,

--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -109,3 +109,8 @@
 - **Change:** Hardened the volunteer journey bootstrapper to check for foreign key constraints before adding them to the `events` table so schema setup can run multiple times without raising duplicate constraint errors.
 - **Impact:** Local development and container restarts no longer crash during startup when the lookup seeding runs after the schema has already been upgraded.
 
+## Event creation placeholder alignment
+- **Date:** 2025-09-27
+- **Change:** Fixed the event creation repository insert statement to provide parameter placeholders for every column so the database receives the required availability and creator values alongside the draft status default.
+- **Impact:** Event managers can save drafts without encountering the "INSERT has more target columns than expressions" error.
+


### PR DESCRIPTION
## Summary
- align the event creation INSERT statement placeholders with the column list so required availability and created by values persist correctly
- document the fix in the change log wiki entry

## Testing
- not run (database-dependent tests unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68ccc1f8fdf88333babc644c19b4a669