### PR TITLE
Allow volunteers to leave events and notify managers

### DIFF
--- a/backend/src/features/volunteer-journey/AGENTS.md
+++ b/backend/src/features/volunteer-journey/AGENTS.md
@@ -10,3 +10,4 @@ These instructions apply to files within `backend/src/features/volunteer-journey
 - When adding or updating routes, remember the router mounts at `/api`; define paths like `/me/profile` rather than duplicating the prefix.
 - When expanding profile metadata, keep the lookup seeding in `profile.bootstrap.js` in sync so startups continue to populate reference data without manual SQL.
 - Keep schema bootstrap logic idempotent—check for existing constraints and indexes before adding them so repeated server starts do not crash.
+- If you adjust event signup flows, reuse `createEventSignup`/`cancelEventSignup` so assignments, attendance, and volunteer hours stay consistent when volunteers join or leave.

--- a/backend/src/features/volunteer-journey/volunteerJourney.route.js
+++ b/backend/src/features/volunteer-journey/volunteerJourney.route.js
@@ -7,6 +7,7 @@ const {
   getCitiesForState,
   browseEvents,
   signupForEvent,
+  leaveEvent,
   listMySignups,
   recordVolunteerHours,
   getVolunteerHours,
@@ -114,6 +115,20 @@ router.post('/events/:eventId/signup', authOnly, async (req, res) => {
     }
     const result = await signupForEvent({ eventId, user: req.user });
     res.status(201).json(result);
+  } catch (error) {
+    const status = error.statusCode || 500;
+    res.status(status).json({ error: error.message });
+  }
+});
+
+router.delete('/events/:eventId/signup', authOnly, async (req, res) => {
+  try {
+    const { eventId } = req.params;
+    if (!uuidPattern.test(eventId)) {
+      return res.status(400).json({ error: 'Invalid event identifier' });
+    }
+    const result = await leaveEvent({ eventId, user: req.user });
+    res.json(result);
   } catch (error) {
     const status = error.statusCode || 500;
     res.status(status).json({ error: error.message });

--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -114,3 +114,8 @@
 - **Change:** Fixed the event creation repository insert statement to provide parameter placeholders for every column so the database receives the required availability and creator values alongside the draft status default.
 - **Impact:** Event managers can save drafts without encountering the "INSERT has more target columns than expressions" error.
 
+## Volunteer event departures reset impact
+- **Date:** 2025-09-28
+- **Change:** Added a `DELETE /api/events/:eventId/signup` endpoint that uses a transactional `cancelEventSignup` helper to remove assignments, attendance, and logged hours before emailing the event manager via the branded template. The volunteer dashboard and events hub now surface "Leave event" actions with inline feedback and refresh all summary panels after success.
+- **Impact:** Volunteers can bow out of commitments at any time, their impact totals drop to zero for that event, and managers receive immediate notice to rebalance coverage.
+

--- a/frontend/src/features/dashboard/AGENTS.md
+++ b/frontend/src/features/dashboard/AGENTS.md
@@ -8,3 +8,4 @@ These notes apply to files within `frontend/src/features/dashboard/`.
 - Do not reintroduce event discovery feeds on the volunteer dashboard; direct volunteers to the dedicated events hub for browsing opportunities.
 - Keep the profile completion call-to-action lightweight and motivational; only surface it when the dashboard API reports missing profile fields and link the button to `/app/profile`.
 - Use the shared `ProfileCompletionCallout` component alongside `profileProgress` helpers so every role stays visually consistent while tailoring their motivation copy.
+- Upcoming commitment cards should offer leave actions with inline success/error copy while continuing to refresh dashboard, signups, and hours summaries through the shared helpers.

--- a/frontend/src/features/dashboard/EventsPage.jsx
+++ b/frontend/src/features/dashboard/EventsPage.jsx
@@ -3,7 +3,7 @@ import { useEffect, useMemo, useState } from 'react';
 import useDocumentTitle from '../../lib/useDocumentTitle';
 import { useAuth } from '../auth/AuthContext';
 import EventDiscovery from '../volunteer/EventDiscovery';
-import { fetchEvents, signupForEvent } from '../volunteer/api';
+import { fetchEvents, signupForEvent, leaveEvent } from '../volunteer/api';
 import DashboardCard from './DashboardCard';
 import { determinePrimaryRole } from './roleUtils';
 
@@ -92,6 +92,15 @@ export default function EventsPage({ role, roles = [] }) {
     return result;
   };
 
+  const handleLeave = async (eventId) => {
+    if (!token) {
+      throw new Error('You need to be signed in to manage your event signups.');
+    }
+    const result = await leaveEvent(token, eventId);
+    setFilters((previous) => ({ ...previous }));
+    return result;
+  };
+
   const isLoading = status.phase === 'loading';
 
   return (
@@ -114,6 +123,7 @@ export default function EventsPage({ role, roles = [] }) {
           isLoading={isLoading}
           onFilterChange={handleFilterChange}
           onSignup={handleSignup}
+          onLeave={handleLeave}
         />
       </DashboardCard>
     </div>

--- a/frontend/src/features/volunteer/AGENTS.md
+++ b/frontend/src/features/volunteer/AGENTS.md
@@ -10,3 +10,4 @@ These notes apply to files under `frontend/src/features/volunteer/`.
 - Use `btn-primary` for forward actions that add or save volunteer profile data so the calls-to-action stand out.
 - Hours logging UI should hide mutation forms when there are no eligible events and instead guide volunteers to join an event first.
 - When surfacing guidance CTAs (like the events hub link), apply `self-start` alongside `btn-primary` so the button keeps its standard width instead of stretching edge-to-edge.
+- Provide "Leave event" affordances alongside signup actions, keep them styled as bordered secondary buttons, and surface inline feedback that clears when new data loads.

--- a/frontend/src/features/volunteer/api.js
+++ b/frontend/src/features/volunteer/api.js
@@ -46,6 +46,10 @@ export function signupForEvent(token, eventId) {
   return apiRequest(`/api/events/${eventId}/signup`, { method: 'POST', token });
 }
 
+export function leaveEvent(token, eventId) {
+  return apiRequest(`/api/events/${eventId}/signup`, { method: 'DELETE', token });
+}
+
 export function fetchMySignups(token) {
   return apiRequest('/api/me/signups', { token });
 }


### PR DESCRIPTION
## Summary
- add a transactional cancelEventSignup helper and DELETE /api/events/:eventId/signup route that clears assignments, attendance, and volunteer hours before emailing the manager
- surface leave actions in the volunteer dashboard and events hub with inline feedback that refreshes hours, signups, and dashboard data
- document the new flow and refresh volunteer/frontend agent guidelines for handling leave buttons

## Testing
- npm run test:connections *(fails: Postgres connection refused in container)*
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ccc70f75e88333bc8a2abd0afdc865