### PR TITLE
Notify event managers when volunteers join events

### DIFF
--- a/backend/src/features/volunteer-journey/AGENTS.md
+++ b/backend/src/features/volunteer-journey/AGENTS.md
@@ -10,3 +10,4 @@ These instructions apply to files within `backend/src/features/volunteer-journey
 - When adding or updating routes, remember the router mounts at `/api`; define paths like `/me/profile` rather than duplicating the prefix.
 - When expanding profile metadata, keep the lookup seeding in `profile.bootstrap.js` in sync so startups continue to populate reference data without manual SQL.
 - Keep schema bootstrap logic idempotent—check for existing constraints and indexes before adding them so repeated server starts do not crash.
+- Event signup flows must notify event managers via `sendTemplatedEmail` when an event has a creator, but failures should be logged and never block the volunteer confirmation.

--- a/backend/src/features/volunteer-journey/volunteerJourney.repository.js
+++ b/backend/src/features/volunteer-journey/volunteerJourney.repository.js
@@ -640,7 +640,7 @@ async function createEventSignup({ eventId, userId }) {
 
     const eventResult = await client.query(
       `
-        SELECT id, title, date_start, date_end, location, capacity, status
+        SELECT id, title, date_start, date_end, location, capacity, status, created_by
         FROM events
         WHERE id = $1
         FOR UPDATE

--- a/backend/src/features/volunteer-journey/volunteerJourney.service.js
+++ b/backend/src/features/volunteer-journey/volunteerJourney.service.js
@@ -1,5 +1,6 @@
 const logger = require('../../utils/logger');
 const { sendTemplatedEmail } = require('../email/email.service');
+const { findUserById } = require('../auth/auth.repository');
 const {
   getVolunteerProfile,
   upsertVolunteerProfile,
@@ -437,7 +438,21 @@ async function signupForEvent({ eventId, user }) {
   }
   const { event, signup } = await createEventSignup({ eventId, userId: user.id });
 
+  let manager = null;
+  if (event.created_by) {
+    try {
+      manager = await findUserById(event.created_by);
+    } catch (error) {
+      logger.error('Failed to load event manager for signup notification', {
+        error: error.message,
+        eventId,
+        managerId: event.created_by,
+      });
+    }
+  }
+
   let emailDispatched = false;
+  let managerEmailDispatched = false;
   try {
     await sendTemplatedEmail({
       to: user.email,
@@ -463,10 +478,48 @@ async function signupForEvent({ eventId, user }) {
   }
 
   const freshEvent = await findEventById(eventId);
+
+  if (manager && manager.email) {
+    const volunteerName = user.name ? user.name.split(' ')[0] : 'A volunteer';
+    const managerName = manager.name ? manager.name.split(' ')[0] : 'there';
+    const bodyLines = [
+      `Hi ${managerName},`,
+      `${volunteerName} just joined <strong>${event.title}</strong>.`,
+      `When: ${formatEventDateRange(freshEvent || event)}`,
+    ];
+    if (event.location) {
+      bodyLines.push(`Where: ${event.location}`);
+    }
+    if (freshEvent && typeof freshEvent.signup_count === 'number') {
+      bodyLines.push(`Total registered volunteers: ${freshEvent.signup_count}`);
+    }
+    bodyLines.push('Review the roster and assignments from your event workspace.');
+
+    try {
+      await sendTemplatedEmail({
+        to: manager.email,
+        subject: `${volunteerName} just joined ${event.title}`,
+        heading: 'A new volunteer is on board',
+        bodyLines,
+        cta: null,
+        previewText: `${volunteerName} joined ${event.title}`,
+      });
+      managerEmailDispatched = true;
+    } catch (error) {
+      logger.error('Failed to send manager signup notification email', {
+        error: error.message,
+        userId: user.id,
+        managerId: manager.id,
+        eventId,
+      });
+    }
+  }
+
   logger.info('Volunteer signed up for event', {
     userId: user.id,
     eventId,
     emailDispatched,
+    managerEmailDispatched,
   });
 
   return {
@@ -478,6 +531,7 @@ async function signupForEvent({ eventId, user }) {
     },
     event: mapEventRow({ ...freshEvent, is_registered: true }),
     emailDispatched,
+    managerEmailDispatched,
   };
 }
 

--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -114,3 +114,8 @@
 - **Change:** Fixed the event creation repository insert statement to provide parameter placeholders for every column so the database receives the required availability and creator values alongside the draft status default.
 - **Impact:** Event managers can save drafts without encountering the "INSERT has more target columns than expressions" error.
 
+## Manager notifications on volunteer signups
+- **Date:** 2025-09-28
+- **Change:** Updated the volunteer signup service to look up an event's manager and send them a branded notification email whenever a volunteer registers, while preserving the primary confirmation flow if the manager email fails.
+- **Impact:** Event managers now receive timely awareness of new volunteers joining their events, letting them review rosters and plan assignments without monitoring the dashboard constantly.
+


### PR DESCRIPTION
## Summary
- load the event creator when a volunteer signs up and alert them with a branded notification email
- track and log manager email delivery alongside the existing volunteer confirmation response
- document the new notification rule in the volunteer journey guidelines and wiki changelog

## Testing
- npm test -- --runTestsByPath tests/volunteerJourney.service.test.js

------
https://chatgpt.com/codex/tasks/task_e_68ccc4f6b0a88333a2393a93727c0e3c