### PR TITLE
feat: launch phase 4 event gallery

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ Onkur is a mobile-first volunteering platform rooted in sustainability and commu
 - Downloadable event reports summarizing signups, attendance percentage, and total volunteer hours.
 - Notification suite for publish confirmations, assignment notices, reminders, and post-event acknowledgements.
 
+### Phase 4 – Event Gallery (Complete)
+- Mobile-first gallery grid with lightbox viewer backed by infinite scroll so visitors can relive event stories quickly.
+- Volunteer and event manager upload flow with EXIF-stripped image processing, tag selection for volunteers/sponsors/communities, and moderation email notices.
+- Admin moderation queue to approve or reject submissions, capturing decision latency metrics and sponsor mentions automatically.
+- Public `/gallery` showcase that spotlights approved events, tracks per-event views, and celebrates tagged sponsors alongside community highlights.
+- MinIO/S3-backed storage with graceful inline fallback plus transactional emails to notify contributors and sponsors when galleries go live.
+
 Consult the living [product wiki](docs/Wiki.md) for design rationale, API schemas, and rollout notes for each phase.
 
 ---

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -13,11 +13,13 @@
         "cors": "^2.8.5",
         "dotenv": "^17.2.2",
         "express": "^5.1.0",
+        "file-type": "^19.5.0",
         "jsonwebtoken": "^9.0.2",
         "minio": "^8.0.6",
         "multer": "^2.0.2",
         "nodemailer": "^6.10.1",
         "pg": "^8.16.3",
+        "sharp": "^0.33.4",
         "winston": "^3.17.0"
       },
       "devDependencies": {
@@ -542,6 +544,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@borewit/text-codec": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.1.1.tgz",
+      "integrity": "sha512-5L/uBxmjaCIX5h8Z+uu+kA9BQLkc/Wl06UGR5ajNRxu+/XjonB5i8JpgFMrPj3LXTCPA0pv8yxUvbUi+QthGGA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/@colors/colors": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
@@ -560,6 +572,377 @@
         "colorspace": "1.1.x",
         "enabled": "2.0.x",
         "kuler": "^2.0.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.5.0.tgz",
+      "integrity": "sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
+      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.0.5"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
+      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
+      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.2.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
+      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -931,6 +1314,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "license": "MIT"
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -957,6 +1346,12 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1988,6 +2383,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.0.tgz",
+      "integrity": "sha512-vEtk+OcP7VBRtQZ1EJ3bdgzSfBjgnEalLTp5zjJrS+2Z1w2KZly4SBdac/WDU3hhsNAZ9E8SC96ME4Ey8MZ7cg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -2332,6 +2736,52 @@
       "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
       "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
       "license": "MIT"
+    },
+    "node_modules/file-type": {
+      "version": "19.6.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-19.6.0.tgz",
+      "integrity": "sha512-VZR5I7k5wkD0HgFnMsq5hOsSc710MJMu5Nc5QYsbe38NN5iPV/XTObYLc/cpttRTf6lX538+5uO1ZQRhYibiZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-stream": "^9.0.1",
+        "strtok3": "^9.0.1",
+        "token-types": "^6.0.0",
+        "uint8array-extras": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
+    "node_modules/file-type/node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/file-type/node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -2711,6 +3161,26 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore-by-default": {
       "version": "1.0.1",
@@ -4520,6 +4990,19 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/peek-readable": {
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-5.4.2.tgz",
+      "integrity": "sha512-peBp3qZyuS6cNIJ2akRNG1uo1WJ1d0wTxg/fxMdZ0BqCVhx242bSFHM9eNqflfJVS9SsgkzgT/1UgnsurBOTMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/pg": {
       "version": "8.16.3",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
@@ -5226,6 +5709,76 @@
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
     },
+    "node_modules/sharp": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
+      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.3",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.33.5",
+        "@img/sharp-darwin-x64": "0.33.5",
+        "@img/sharp-libvips-darwin-arm64": "1.0.4",
+        "@img/sharp-libvips-darwin-x64": "1.0.4",
+        "@img/sharp-libvips-linux-arm": "1.0.5",
+        "@img/sharp-libvips-linux-arm64": "1.0.4",
+        "@img/sharp-libvips-linux-s390x": "1.0.4",
+        "@img/sharp-libvips-linux-x64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
+        "@img/sharp-linux-arm": "0.33.5",
+        "@img/sharp-linux-arm64": "0.33.5",
+        "@img/sharp-linux-s390x": "0.33.5",
+        "@img/sharp-linux-x64": "0.33.5",
+        "@img/sharp-linuxmusl-arm64": "0.33.5",
+        "@img/sharp-linuxmusl-x64": "0.33.5",
+        "@img/sharp-wasm32": "0.33.5",
+        "@img/sharp-win32-ia32": "0.33.5",
+        "@img/sharp-win32-x64": "0.33.5"
+      }
+    },
+    "node_modules/sharp/node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
+    "node_modules/sharp/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/sharp/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -5572,6 +6125,23 @@
       ],
       "license": "MIT"
     },
+    "node_modules/strtok3": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-9.1.1.tgz",
+      "integrity": "sha512-FhwotcEqjr241ZbjFzjlIYg6c5/L/s4yBGWSMvJ9UoExiSqL+FnFA/CaeZx17WGaZMS/4SOZp8wH18jSS4R4lw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "peek-readable": "^5.3.1"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -5657,6 +6227,24 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/token-types": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.1.tgz",
+      "integrity": "sha512-kh9LVIWH5CnL63Ipf0jhlBIy0UsrMj/NJDfpsy1SqOXlLKEVyXXYrnFxFT1yOOYVGBSApeVnjPw/sBz5BfEjAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@borewit/text-codec": "^0.1.0",
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/touch": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.1.tgz",
@@ -5675,6 +6263,13 @@
       "engines": {
         "node": ">= 14.0.0"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/type-detect": {
       "version": "4.0.8",
@@ -5718,6 +6313,18 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
       "license": "MIT"
+    },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/undefsafe": {
       "version": "2.0.5",

--- a/backend/package.json
+++ b/backend/package.json
@@ -24,8 +24,10 @@
     "jsonwebtoken": "^9.0.2",
     "minio": "^8.0.6",
     "multer": "^2.0.2",
+    "file-type": "^19.5.0",
     "nodemailer": "^6.10.1",
     "pg": "^8.16.3",
+    "sharp": "^0.33.4",
     "winston": "^3.17.0"
   },
   "devDependencies": {

--- a/backend/src/features/event-gallery/AGENTS.md
+++ b/backend/src/features/event-gallery/AGENTS.md
@@ -1,0 +1,7 @@
+# Event Gallery Backend Guidelines
+
+These notes apply to files within `backend/src/features/event-gallery/`.
+
+- Keep media moderation logic in the service layer so routes stay focused on validation and response shaping.
+- Sanitize and validate upload inputs in the service before persisting them; repositories should assume normalized payloads.
+- Whenever storage access is optional, log structured warnings via the shared logger so deployments can diagnose missing buckets without breaking uploads.

--- a/backend/src/features/event-gallery/eventGallery.repository.js
+++ b/backend/src/features/event-gallery/eventGallery.repository.js
@@ -1,0 +1,472 @@
+const { randomUUID } = require('crypto');
+const pool = require('../common/db');
+
+const VALID_STATUSES = ['PENDING', 'APPROVED', 'REJECTED'];
+
+function toIso(value) {
+  if (!value) {
+    return null;
+  }
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  return date.toISOString();
+}
+
+function mapMediaRow(row) {
+  if (!row) {
+    return null;
+  }
+  return {
+    id: row.id,
+    eventId: row.event_id,
+    uploaderId: row.uploader_id,
+    storageKey: row.storage_key,
+    url: row.url,
+    mimeType: row.mime_type,
+    fileSize: Number(row.file_size || 0),
+    width: row.width ? Number(row.width) : null,
+    height: row.height ? Number(row.height) : null,
+    caption: row.caption || '',
+    tags: Array.isArray(row.tags) || typeof row.tags === 'object' ? row.tags : [],
+    status: row.status,
+    rejectionReason: row.rejection_reason || null,
+    createdAt: toIso(row.created_at),
+    updatedAt: toIso(row.updated_at),
+    approvedAt: toIso(row.approved_at),
+    approvedBy: row.approved_by || null,
+    moderationTimeMs: row.moderation_time_ms ? Number(row.moderation_time_ms) : null,
+    sponsorMentions: row.sponsor_mentions ? Number(row.sponsor_mentions) : 0,
+  };
+}
+
+const schemaPromise = (async () => {
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS event_media (
+      id UUID PRIMARY KEY,
+      event_id UUID NOT NULL REFERENCES events(id) ON DELETE CASCADE,
+      uploader_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      storage_key TEXT NOT NULL,
+      url TEXT NOT NULL,
+      mime_type TEXT NOT NULL,
+      file_size INTEGER NOT NULL,
+      width INTEGER NULL,
+      height INTEGER NULL,
+      caption TEXT NULL,
+      tags JSONB NOT NULL DEFAULT '[]'::JSONB,
+      status TEXT NOT NULL DEFAULT 'PENDING',
+      rejection_reason TEXT NULL,
+      sponsor_mentions INTEGER NOT NULL DEFAULT 0,
+      moderation_time_ms BIGINT NULL,
+      approved_at TIMESTAMPTZ NULL,
+      approved_by UUID NULL REFERENCES users(id) ON DELETE SET NULL,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `);
+
+  await pool.query(`CREATE INDEX IF NOT EXISTS idx_event_media_event ON event_media (event_id)`);
+  await pool.query(`CREATE INDEX IF NOT EXISTS idx_event_media_status ON event_media (status)`);
+  await pool.query(`ALTER TABLE event_media ADD COLUMN IF NOT EXISTS rejection_reason TEXT NULL`);
+  await pool.query(`ALTER TABLE event_media ADD COLUMN IF NOT EXISTS sponsor_mentions INTEGER NOT NULL DEFAULT 0`);
+  await pool.query(`ALTER TABLE event_media ADD COLUMN IF NOT EXISTS moderation_time_ms BIGINT NULL`);
+  await pool.query(`ALTER TABLE event_media ADD COLUMN IF NOT EXISTS approved_at TIMESTAMPTZ NULL`);
+  await pool.query(`ALTER TABLE event_media ADD COLUMN IF NOT EXISTS approved_by UUID NULL REFERENCES users(id) ON DELETE SET NULL`);
+  await pool.query(`ALTER TABLE event_media ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()`);
+  await pool.query(`ALTER TABLE event_media ALTER COLUMN tags SET DATA TYPE JSONB USING tags::JSONB`);
+  await pool.query(`
+    ALTER TABLE event_media
+    DROP CONSTRAINT IF EXISTS event_media_status_check
+  `);
+  await pool.query(`
+    ALTER TABLE event_media
+    ADD CONSTRAINT event_media_status_check
+    CHECK (status = ANY(ARRAY['PENDING','APPROVED','REJECTED']::TEXT[]))
+  `);
+
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS event_gallery_metrics (
+      event_id UUID PRIMARY KEY REFERENCES events(id) ON DELETE CASCADE,
+      view_count BIGINT NOT NULL DEFAULT 0,
+      last_viewed_at TIMESTAMPTZ NULL,
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `);
+})();
+
+async function ensureSchema() {
+  await schemaPromise;
+}
+
+async function createMedia({
+  eventId,
+  uploaderId,
+  storageKey,
+  url,
+  mimeType,
+  fileSize,
+  width = null,
+  height = null,
+  caption = '',
+  tags = [],
+  status = 'PENDING',
+  sponsorMentions = 0,
+}) {
+  await ensureSchema();
+  if (!VALID_STATUSES.includes(status)) {
+    throw Object.assign(new Error('Invalid media status'), { statusCode: 400 });
+  }
+  const id = randomUUID();
+  const result = await pool.query(
+    `
+      INSERT INTO event_media (
+        id,
+        event_id,
+        uploader_id,
+        storage_key,
+        url,
+        mime_type,
+        file_size,
+        width,
+        height,
+        caption,
+        tags,
+        status,
+        sponsor_mentions
+      )
+      VALUES (
+        $1,
+        $2,
+        $3,
+        $4,
+        $5,
+        $6,
+        $7,
+        $8,
+        $9,
+        $10,
+        $11,
+        $12,
+        $13
+      )
+      RETURNING *
+    `,
+    [
+      id,
+      eventId,
+      uploaderId,
+      storageKey,
+      url,
+      mimeType,
+      fileSize,
+      width,
+      height,
+      caption,
+      JSON.stringify(tags || []),
+      status,
+      sponsorMentions,
+    ],
+  );
+  return mapMediaRow(result.rows[0]);
+}
+
+async function findMediaById(mediaId) {
+  await ensureSchema();
+  const result = await pool.query(
+    `
+      SELECT *
+      FROM event_media
+      WHERE id = $1
+    `,
+    [mediaId],
+  );
+  return mapMediaRow(result.rows[0]);
+}
+
+async function listApprovedMediaForEvent(eventId, { page = 1, pageSize = 20 } = {}) {
+  await ensureSchema();
+  const limit = Math.max(1, Math.min(Number(pageSize) || 20, 48));
+  const currentPage = Math.max(1, Number(page) || 1);
+  const offset = (currentPage - 1) * limit;
+
+  const [itemsResult, countResult] = await Promise.all([
+    pool.query(
+      `
+        SELECT *
+        FROM event_media
+        WHERE event_id = $1 AND status = 'APPROVED'
+        ORDER BY approved_at DESC NULLS LAST, created_at DESC
+        LIMIT $2 OFFSET $3
+      `,
+      [eventId, limit, offset],
+    ),
+    pool.query(
+      `
+        SELECT COUNT(*)::BIGINT AS total
+        FROM event_media
+        WHERE event_id = $1 AND status = 'APPROVED'
+      `,
+      [eventId],
+    ),
+  ]);
+
+  const total = Number(countResult.rows[0]?.total || 0);
+  const media = itemsResult.rows.map(mapMediaRow);
+  const hasMore = offset + media.length < total;
+
+  return {
+    media,
+    page: currentPage,
+    pageSize: limit,
+    total,
+    hasMore,
+  };
+}
+
+async function listPendingMedia({ page = 1, pageSize = 20 } = {}) {
+  await ensureSchema();
+  const limit = Math.max(1, Math.min(Number(pageSize) || 20, 50));
+  const currentPage = Math.max(1, Number(page) || 1);
+  const offset = (currentPage - 1) * limit;
+
+  const [itemsResult, countResult] = await Promise.all([
+    pool.query(
+      `
+        SELECT *
+        FROM event_media
+        WHERE status = 'PENDING'
+        ORDER BY created_at ASC
+        LIMIT $1 OFFSET $2
+      `,
+      [limit, offset],
+    ),
+    pool.query(
+      `
+        SELECT COUNT(*)::BIGINT AS total
+        FROM event_media
+        WHERE status = 'PENDING'
+      `,
+    ),
+  ]);
+
+  const total = Number(countResult.rows[0]?.total || 0);
+  const media = itemsResult.rows.map(mapMediaRow);
+  const hasMore = offset + media.length < total;
+
+  return {
+    media,
+    page: currentPage,
+    pageSize: limit,
+    total,
+    hasMore,
+  };
+}
+
+async function updateMediaStatus(mediaId, { status, approvedBy = null, rejectionReason = null }) {
+  await ensureSchema();
+  if (!VALID_STATUSES.includes(status)) {
+    throw Object.assign(new Error('Invalid media status'), { statusCode: 400 });
+  }
+  const fields = ['status = $2', 'updated_at = NOW()'];
+  const values = [mediaId, status];
+  if (status === 'APPROVED') {
+    fields.push('approved_at = NOW()');
+    if (approvedBy) {
+      fields.push('approved_by = $' + (values.length + 1));
+      values.push(approvedBy);
+    } else {
+      fields.push('approved_by = NULL');
+    }
+    fields.push('rejection_reason = NULL');
+  }
+  if (status === 'REJECTED') {
+    fields.push('approved_at = NULL');
+    fields.push('approved_by = NULL');
+    fields.push('rejection_reason = $' + (values.length + 1));
+    values.push(rejectionReason || '');
+  }
+  const media = await findMediaById(mediaId);
+  if (!media) {
+    throw Object.assign(new Error('Media not found'), { statusCode: 404 });
+  }
+  const moderationFields = [];
+  if (media.status === 'PENDING' && status !== 'PENDING') {
+    moderationFields.push('moderation_time_ms = EXTRACT(EPOCH FROM (NOW() - created_at)) * 1000');
+  }
+  const sql = `
+    UPDATE event_media
+    SET ${fields.concat(moderationFields).join(', ')}
+    WHERE id = $1
+    RETURNING *
+  `;
+  const result = await pool.query(sql, values);
+  return mapMediaRow(result.rows[0]);
+}
+
+async function updateSponsorMentions(mediaId, sponsorMentions) {
+  await ensureSchema();
+  const result = await pool.query(
+    `
+      UPDATE event_media
+      SET sponsor_mentions = $2, updated_at = NOW()
+      WHERE id = $1
+      RETURNING *
+    `,
+    [mediaId, Number(sponsorMentions) || 0],
+  );
+  return mapMediaRow(result.rows[0]);
+}
+
+async function incrementGalleryView(eventId) {
+  await ensureSchema();
+  await pool.query(
+    `
+      INSERT INTO event_gallery_metrics (event_id, view_count, last_viewed_at)
+      VALUES ($1, 1, NOW())
+      ON CONFLICT (event_id)
+      DO UPDATE SET view_count = event_gallery_metrics.view_count + 1, last_viewed_at = NOW(), updated_at = NOW()
+    `,
+    [eventId],
+  );
+}
+
+async function getGalleryMetrics(eventId) {
+  await ensureSchema();
+  const result = await pool.query(
+    `
+      SELECT view_count, last_viewed_at
+      FROM event_gallery_metrics
+      WHERE event_id = $1
+    `,
+    [eventId],
+  );
+  const row = result.rows[0] || null;
+  if (!row) {
+    return { viewCount: 0, lastViewedAt: null };
+  }
+  return {
+    viewCount: Number(row.view_count || 0),
+    lastViewedAt: toIso(row.last_viewed_at),
+  };
+}
+
+async function listGalleryEvents({ page = 1, pageSize = 12 } = {}) {
+  await ensureSchema();
+  const limit = Math.max(1, Math.min(Number(pageSize) || 12, 24));
+  const currentPage = Math.max(1, Number(page) || 1);
+  const offset = (currentPage - 1) * limit;
+  const [itemsResult, countResult] = await Promise.all([
+    pool.query(
+      `
+        SELECT e.id, e.title, e.date_start, e.date_end, e.location, e.location_state_code, e.location_city_slug,
+               e.category, e.theme,
+               COUNT(em.id)::INT AS media_count,
+               MAX(em.approved_at) AS last_media_at
+        FROM events e
+        JOIN event_media em ON em.event_id = e.id AND em.status = 'APPROVED'
+        GROUP BY e.id
+        ORDER BY last_media_at DESC NULLS LAST, e.date_start DESC NULLS LAST
+        LIMIT $1 OFFSET $2
+      `,
+      [limit, offset],
+    ),
+    pool.query(
+      `
+        SELECT COUNT(*)::BIGINT AS total
+        FROM (
+          SELECT 1
+          FROM events e
+          JOIN event_media em ON em.event_id = e.id AND em.status = 'APPROVED'
+          GROUP BY e.id
+        ) counted
+      `,
+    ),
+  ]);
+
+  const total = Number(countResult.rows[0]?.total || 0);
+  const events = itemsResult.rows.map((row) => ({
+    id: row.id,
+    title: row.title,
+    dateStart: toIso(row.date_start),
+    dateEnd: toIso(row.date_end),
+    location: row.location,
+    stateCode: row.location_state_code || null,
+    citySlug: row.location_city_slug || null,
+    category: row.category || null,
+    theme: row.theme || null,
+    mediaCount: Number(row.media_count || 0),
+    lastMediaAt: toIso(row.last_media_at),
+  }));
+  const hasMore = offset + events.length < total;
+  return {
+    events,
+    page: currentPage,
+    pageSize: limit,
+    total,
+    hasMore,
+  };
+}
+
+async function listEventVolunteers(eventId) {
+  await ensureSchema();
+  const result = await pool.query(
+    `
+      SELECT u.id, u.name, u.email
+      FROM event_signups es
+      JOIN users u ON u.id = es.user_id
+      WHERE es.event_id = $1
+      ORDER BY u.name ASC
+    `,
+    [eventId],
+  );
+  return result.rows.map((row) => ({
+    id: row.id,
+    name: row.name,
+    email: row.email,
+  }));
+}
+
+async function isVolunteerForEvent(eventId, userId) {
+  await ensureSchema();
+  const result = await pool.query(
+    `SELECT 1 FROM event_signups WHERE event_id = $1 AND user_id = $2 LIMIT 1`,
+    [eventId, userId],
+  );
+  return Boolean(result.rows[0]);
+}
+
+async function listSponsors() {
+  await ensureSchema();
+  const result = await pool.query(
+    `
+      SELECT DISTINCT u.id, u.name, u.email
+      FROM users u
+      JOIN user_roles ur ON ur.user_id = u.id
+      WHERE ur.role = 'SPONSOR'
+      ORDER BY u.name ASC
+    `,
+  );
+  return result.rows.map((row) => ({
+    id: row.id,
+    name: row.name,
+    email: row.email,
+  }));
+}
+
+module.exports = {
+  ensureSchema,
+  createMedia,
+  findMediaById,
+  listApprovedMediaForEvent,
+  listPendingMedia,
+  updateMediaStatus,
+  updateSponsorMentions,
+  incrementGalleryView,
+  getGalleryMetrics,
+  listGalleryEvents,
+  listEventVolunteers,
+  isVolunteerForEvent,
+  listSponsors,
+};

--- a/backend/src/features/event-gallery/eventGallery.route.js
+++ b/backend/src/features/event-gallery/eventGallery.route.js
@@ -1,0 +1,128 @@
+const express = require('express');
+const multer = require('multer');
+const { authenticate, authorizeRoles } = require('../auth/auth.middleware');
+const {
+  uploadMediaForEvent,
+  getEventGallery,
+  listEventsWithGalleries,
+  getModerationQueue,
+  moderateMedia,
+  getTagOptions,
+} = require('./eventGallery.service');
+
+const router = express.Router();
+const authOnly = authenticate();
+const adminOnly = authorizeRoles('ADMIN');
+const upload = multer({ storage: multer.memoryStorage(), limits: { fileSize: 10 * 1024 * 1024 } });
+const uuidPattern = /^[0-9a-fA-F-]{36}$/;
+
+router.get('/events/:eventId/media', async (req, res) => {
+  try {
+    const { eventId } = req.params;
+    if (!uuidPattern.test(eventId)) {
+      return res.status(400).json({ error: 'Invalid event identifier' });
+    }
+    const page = req.query.page ? Number(req.query.page) : undefined;
+    const pageSize = req.query.pageSize ? Number(req.query.pageSize) : undefined;
+    const gallery = await getEventGallery({ eventId, page, pageSize });
+    res.json(gallery);
+  } catch (error) {
+    const status = error.statusCode || 500;
+    res.status(status).json({ error: error.message });
+  }
+});
+
+router.get('/events/:eventId/media/tags', authOnly, async (req, res) => {
+  try {
+    const { eventId } = req.params;
+    if (!uuidPattern.test(eventId)) {
+      return res.status(400).json({ error: 'Invalid event identifier' });
+    }
+    const options = await getTagOptions(eventId);
+    res.json(options);
+  } catch (error) {
+    const status = error.statusCode || 500;
+    res.status(status).json({ error: error.message });
+  }
+});
+
+router.post('/events/:eventId/media', authOnly, upload.single('file'), async (req, res) => {
+  try {
+    const { eventId } = req.params;
+    if (!uuidPattern.test(eventId)) {
+      return res.status(400).json({ error: 'Invalid event identifier' });
+    }
+    if (!req.file) {
+      return res.status(400).json({ error: 'A photo file is required' });
+    }
+    const media = await uploadMediaForEvent({
+      eventId,
+      file: req.file,
+      caption: req.body?.caption,
+      tags: req.body?.tags,
+      user: req.user,
+    });
+    res.status(201).json({ media });
+  } catch (error) {
+    const status = error.statusCode || 500;
+    res.status(status).json({ error: error.message });
+  }
+});
+
+router.get('/media/events', async (req, res) => {
+  try {
+    const page = req.query.page ? Number(req.query.page) : undefined;
+    const pageSize = req.query.pageSize ? Number(req.query.pageSize) : undefined;
+    const events = await listEventsWithGalleries({ page, pageSize });
+    res.json(events);
+  } catch (error) {
+    const status = error.statusCode || 500;
+    res.status(status).json({ error: error.message });
+  }
+});
+
+router.get('/media/moderation', authOnly, adminOnly, async (req, res) => {
+  try {
+    const page = req.query.page ? Number(req.query.page) : undefined;
+    const pageSize = req.query.pageSize ? Number(req.query.pageSize) : undefined;
+    const queue = await getModerationQueue({ page, pageSize });
+    res.json(queue);
+  } catch (error) {
+    const status = error.statusCode || 500;
+    res.status(status).json({ error: error.message });
+  }
+});
+
+router.post('/media/:mediaId/approve', authOnly, adminOnly, async (req, res) => {
+  try {
+    const { mediaId } = req.params;
+    if (!uuidPattern.test(mediaId)) {
+      return res.status(400).json({ error: 'Invalid media identifier' });
+    }
+    const media = await moderateMedia({ mediaId, action: 'approve', moderatorId: req.user.id });
+    res.json({ media });
+  } catch (error) {
+    const status = error.statusCode || 500;
+    res.status(status).json({ error: error.message });
+  }
+});
+
+router.post('/media/:mediaId/reject', authOnly, adminOnly, async (req, res) => {
+  try {
+    const { mediaId } = req.params;
+    if (!uuidPattern.test(mediaId)) {
+      return res.status(400).json({ error: 'Invalid media identifier' });
+    }
+    const reason = req.body?.reason ? String(req.body.reason).trim() : '';
+    const media = await moderateMedia({ mediaId, action: 'reject', moderatorId: req.user.id, reason });
+    res.json({ media });
+  } catch (error) {
+    const status = error.statusCode || 500;
+    res.status(status).json({ error: error.message });
+  }
+});
+
+module.exports = {
+  basePath: '/api',
+  router,
+};

--- a/backend/src/features/event-gallery/eventGallery.service.js
+++ b/backend/src/features/event-gallery/eventGallery.service.js
@@ -1,0 +1,511 @@
+const { randomUUID } = require('crypto');
+const sharp = require('sharp');
+const { fileTypeFromBuffer } = require('file-type');
+const config = require('../../config');
+const logger = require('../../utils/logger');
+const minioClient = require('../common/minio');
+const { findUserById } = require('../auth/auth.repository');
+const { findEventById } = require('../event-management/eventManagement.repository');
+const { sendTemplatedEmail } = require('../email/email.service');
+const {
+  createMedia,
+  listApprovedMediaForEvent,
+  listPendingMedia,
+  updateMediaStatus,
+  incrementGalleryView,
+  getGalleryMetrics,
+  listGalleryEvents,
+  listEventVolunteers,
+  isVolunteerForEvent,
+  listSponsors,
+  findMediaById,
+} = require('./eventGallery.repository');
+
+const MAX_UPLOAD_BYTES = 10 * 1024 * 1024; // 10MB
+const ALLOWED_MIME_TYPES = new Map([
+  ['image/jpeg', 'jpg'],
+  ['image/png', 'png'],
+  ['image/webp', 'webp'],
+  ['image/heic', 'heic'],
+]);
+
+function resolveAppBaseUrl() {
+  const base =
+    (config.app && config.app.baseUrl) ||
+    config.corsOrigin ||
+    'http://localhost:3000';
+  return String(base).replace(/\/$/, '');
+}
+
+function toTitleCase(value) {
+  return String(value || '')
+    .toLowerCase()
+    .split(' ')
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+function toSlug(value) {
+  return String(value || '')
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function parseTagsInput(input) {
+  if (!input) {
+    return [];
+  }
+  if (Array.isArray(input)) {
+    return input;
+  }
+  if (typeof input === 'string') {
+    try {
+      const parsed = JSON.parse(input);
+      return Array.isArray(parsed) ? parsed : [];
+    } catch (error) {
+      throw Object.assign(new Error('Tags must be valid JSON'), { statusCode: 400 });
+    }
+  }
+  throw Object.assign(new Error('Tags must be provided as an array'), { statusCode: 400 });
+}
+
+function normalizeCaption(value) {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  const caption = String(value).trim();
+  if (caption.length > 400) {
+    throw Object.assign(new Error('Caption must be 400 characters or fewer'), { statusCode: 400 });
+  }
+  return caption;
+}
+
+async function ensureEvent(eventId) {
+  const event = await findEventById(eventId);
+  if (!event) {
+    throw Object.assign(new Error('Event not found'), { statusCode: 404 });
+  }
+  return event;
+}
+
+function resolveRoles(user) {
+  if (!user) {
+    return new Set();
+  }
+  const roles = Array.isArray(user.roles) && user.roles.length ? user.roles : [];
+  if (user.role && !roles.includes(user.role)) {
+    roles.push(user.role);
+  }
+  return new Set(roles);
+}
+
+async function ensureUploaderIsParticipant({ event, user }) {
+  const roles = resolveRoles(user);
+  if (roles.has('ADMIN')) {
+    return true;
+  }
+  if (event.createdBy && event.createdBy === user.id) {
+    return true;
+  }
+  const isVolunteer = await isVolunteerForEvent(event.id, user.id);
+  if (isVolunteer) {
+    return true;
+  }
+  throw Object.assign(new Error('Only event participants can upload media'), { statusCode: 403 });
+}
+
+async function processImageBuffer(file) {
+  if (!file || !file.buffer || !file.buffer.length) {
+    throw Object.assign(new Error('A photo file is required'), { statusCode: 400 });
+  }
+
+  if (file.buffer.length > MAX_UPLOAD_BYTES) {
+    throw Object.assign(new Error('Photo must be 10MB or smaller'), { statusCode: 400 });
+  }
+
+  const detected = await fileTypeFromBuffer(file.buffer);
+  if (!detected || !ALLOWED_MIME_TYPES.has(detected.mime)) {
+    throw Object.assign(new Error('Only JPEG, PNG, WebP, or HEIC images are supported'), { statusCode: 415 });
+  }
+
+  const extension = ALLOWED_MIME_TYPES.get(detected.mime);
+  const baseImage = sharp(file.buffer, { failOn: 'warning' }).rotate();
+  const metadata = await baseImage.metadata();
+  const processed = await baseImage
+    .clone()
+    .resize({ width: 2048, height: 2048, fit: 'inside', withoutEnlargement: true })
+    .jpeg({ quality: 82, chromaSubsampling: '4:4:4', progressive: true })
+    .toBuffer();
+
+  if (processed.length > MAX_UPLOAD_BYTES) {
+    throw Object.assign(new Error('Optimized photo exceeds the maximum size'), { statusCode: 400 });
+  }
+
+  return {
+    buffer: processed,
+    size: processed.length,
+    width: metadata.width || null,
+    height: metadata.height || null,
+    mimeType: 'image/jpeg',
+    extension: 'jpg',
+  };
+}
+
+function buildStorageUrl({ bucket, key }) {
+  const { endPoint, port, useSSL } = config.minio || {};
+  if (!endPoint || !bucket) {
+    return null;
+  }
+  const protocol = useSSL ? 'https' : 'http';
+  const portPart = port && ![80, 443].includes(Number(port)) ? `:${port}` : '';
+  return `${protocol}://${endPoint}${portPart}/${bucket}/${key}`;
+}
+
+async function storeImage({ eventId, buffer, mimeType, extension }) {
+  const { bucket, endPoint, accessKey, secretKey } = config.minio || {};
+  const storageKey = `events/${eventId}/media/${randomUUID()}.${extension}`;
+
+  if (!bucket || !endPoint || !accessKey || !secretKey) {
+    logger.warn('Media upload stored inline because MinIO/S3 is not configured', {
+      bucketConfigured: Boolean(bucket),
+      endPointConfigured: Boolean(endPoint),
+    });
+    const inlineUrl = `data:${mimeType};base64,${buffer.toString('base64')}`;
+    return { storageKey: `inline://${storageKey}`, url: inlineUrl, provider: 'inline' };
+  }
+
+  try {
+    await minioClient.putObject(bucket, storageKey, buffer, buffer.length, {
+      'Content-Type': mimeType,
+      'Cache-Control': 'public, max-age=31536000, immutable',
+    });
+    const url = buildStorageUrl({ bucket, key: storageKey }) || storageKey;
+    return { storageKey, url, provider: 'object-store' };
+  } catch (error) {
+    logger.warn('Falling back to inline media storage after MinIO upload failed', {
+      error: error.message,
+      storageKey,
+    });
+    const inlineUrl = `data:${mimeType};base64,${buffer.toString('base64')}`;
+    return { storageKey: `inline://${storageKey}`, url: inlineUrl, provider: 'inline' };
+  }
+}
+
+function buildCommunityTags(event) {
+  const tags = [];
+  if (event.cityName) {
+    tags.push({ type: 'COMMUNITY', id: `city:${event.citySlug || toSlug(event.cityName)}`, label: event.cityName });
+  }
+  if (event.stateName) {
+    tags.push({ type: 'COMMUNITY', id: `state:${event.stateCode || toSlug(event.stateName)}`, label: event.stateName });
+  }
+  if (event.theme) {
+    tags.push({ type: 'COMMUNITY', id: `theme:${toSlug(event.theme)}`, label: toTitleCase(event.theme) });
+  }
+  return tags;
+}
+
+function sanitizeTags(rawTags, { volunteers, sponsors, event }) {
+  const volunteersById = new Map((volunteers || []).map((vol) => [vol.id, vol]));
+  const sponsorsById = new Map((sponsors || []).map((sponsor) => [sponsor.id, sponsor]));
+  const sanitized = [];
+  const seen = new Set();
+
+  for (const raw of rawTags.slice(0, 12)) {
+    if (!raw || typeof raw !== 'object') {
+      continue;
+    }
+    const type = String(raw.type || '').toUpperCase();
+    const id = raw.id ? String(raw.id) : '';
+    const label = String(raw.label || '').trim();
+
+    if (!type) {
+      continue;
+    }
+
+    if (type === 'VOLUNTEER') {
+      if (!id || !volunteersById.has(id)) {
+        throw Object.assign(new Error('Volunteer tags must reference registered participants'), { statusCode: 400 });
+      }
+      const volunteer = volunteersById.get(id);
+      const key = `${type}:${id}`;
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      sanitized.push({ type, id, label: volunteer.name || 'Volunteer' });
+      continue;
+    }
+
+    if (type === 'SPONSOR') {
+      if (!id || !sponsorsById.has(id)) {
+        throw Object.assign(new Error('Sponsor tags must reference active sponsors'), { statusCode: 400 });
+      }
+      const sponsor = sponsorsById.get(id);
+      const key = `${type}:${id}`;
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      sanitized.push({ type, id, label: sponsor.name || sponsor.email || 'Sponsor' });
+      continue;
+    }
+
+    if (type === 'COMMUNITY') {
+      const slug = id ? String(id) : toSlug(label);
+      if (!slug) {
+        continue;
+      }
+      const key = `${type}:${slug}`;
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      sanitized.push({ type, id: slug, label: label || toTitleCase(slug.replace(/-/g, ' ')) });
+    }
+  }
+
+  const defaults = buildCommunityTags(event);
+  for (const tag of defaults) {
+    const key = `${tag.type}:${tag.id}`;
+    if (!seen.has(key)) {
+      sanitized.push(tag);
+      seen.add(key);
+    }
+  }
+
+  return sanitized;
+}
+
+async function sendSubmissionEmail({ media, event, uploader }) {
+  if (!uploader?.email) {
+    return;
+  }
+  const baseUrl = resolveAppBaseUrl();
+  const galleryUrl = `${baseUrl}/app/gallery?event=${event.id}`;
+  try {
+    await sendTemplatedEmail({
+      to: uploader.email,
+      subject: 'Your gallery submission is pending review',
+      heading: 'We received your event gallery submission',
+      previewText: 'Moderators will review your media shortly.',
+      bodyLines: [
+        `Thanks for sharing memories from <strong>${event.title}</strong>. Our moderators will review the photo soon.`,
+        'You will get an email once it is approved or if we need any changes.',
+      ],
+      cta: {
+        url: galleryUrl,
+        label: 'View event gallery',
+      },
+    });
+  } catch (error) {
+    logger.warn('Failed to send gallery submission email', { mediaId: media.id, error: error.message });
+  }
+}
+
+async function sendModerationEmail({ media, event, uploader, outcome, reason }) {
+  if (!uploader?.email) {
+    return;
+  }
+  const baseUrl = resolveAppBaseUrl();
+  const galleryUrl = `${baseUrl}/app/gallery?event=${event.id}`;
+  const approved = outcome === 'APPROVED';
+  const heading = approved
+    ? 'Your gallery submission is live!'
+    : 'Your gallery submission needs attention';
+  const subject = approved
+    ? 'Your gallery submission was approved'
+    : 'Your gallery submission was rejected';
+  const bodyLines = approved
+    ? [
+        `Your photo for <strong>${event.title}</strong> is now visible in the event gallery.`,
+        'Thanks for helping us tell a richer story of the day.',
+      ]
+    : [
+        `We had to reject your photo for <strong>${event.title}</strong>.`,
+        reason ? `Moderator note: ${reason}` : 'Please review the guidelines and try uploading again.',
+      ];
+  try {
+    await sendTemplatedEmail({
+      to: uploader.email,
+      subject,
+      heading,
+      previewText: bodyLines[0],
+      bodyLines,
+      cta: approved
+        ? {
+            url: galleryUrl,
+            label: 'Open gallery',
+          }
+        : undefined,
+    });
+  } catch (error) {
+    logger.warn('Failed to send gallery moderation email', { mediaId: media.id, error: error.message, outcome });
+  }
+}
+
+async function notifySponsors({ media, event, sponsors }) {
+  if (!Array.isArray(sponsors) || !sponsors.length) {
+    return;
+  }
+  const baseUrl = resolveAppBaseUrl();
+  const galleryUrl = `${baseUrl}/app/gallery?event=${event.id}`;
+  await Promise.all(
+    sponsors.map(async (sponsor) => {
+      if (!sponsor.email) {
+        return;
+      }
+      try {
+        await sendTemplatedEmail({
+          to: sponsor.email,
+          subject: `You were spotlighted in the ${event.title} gallery`,
+          heading: `${event.title} just highlighted your support`,
+          previewText: 'Dive in to see how your sponsorship made a difference.',
+          bodyLines: [
+            `${sponsor.name || 'Sponsor'}, your logo or name was tagged in the latest gallery update for <strong>${event.title}</strong>.`,
+            'Take a look and share it with your community!',
+          ],
+          cta: {
+            url: galleryUrl,
+            label: 'View the gallery',
+          },
+        });
+      } catch (error) {
+        logger.warn('Failed to send sponsor gallery notification', {
+          mediaId: media.id,
+          sponsorId: sponsor.id,
+          error: error.message,
+        });
+      }
+    }),
+  );
+}
+
+async function uploadMediaForEvent({ eventId, file, caption, tags, user }) {
+  const event = await ensureEvent(eventId);
+  await ensureUploaderIsParticipant({ event, user });
+
+  const volunteers = await listEventVolunteers(eventId);
+  const sponsors = await listSponsors();
+  const parsedTags = parseTagsInput(tags);
+  const sanitizedTags = sanitizeTags(parsedTags, { volunteers, sponsors, event });
+
+  const processed = await processImageBuffer(file);
+  const stored = await storeImage({
+    eventId,
+    buffer: processed.buffer,
+    mimeType: processed.mimeType,
+    extension: processed.extension,
+  });
+
+  const media = await createMedia({
+    eventId,
+    uploaderId: user.id,
+    storageKey: stored.storageKey,
+    url: stored.url,
+    mimeType: processed.mimeType,
+    fileSize: processed.size,
+    width: processed.width,
+    height: processed.height,
+    caption: normalizeCaption(caption),
+    tags: sanitizedTags,
+    sponsorMentions: sanitizedTags.filter((tag) => tag.type === 'SPONSOR').length,
+  });
+
+  sendSubmissionEmail({ media, event, uploader: user }).catch((error) => {
+    logger.warn('Failed to queue gallery submission email', { mediaId: media.id, error: error.message });
+  });
+
+  return media;
+}
+
+async function getEventGallery({ eventId, page, pageSize }) {
+  const event = await ensureEvent(eventId);
+  const pagination = await listApprovedMediaForEvent(eventId, { page, pageSize });
+  await incrementGalleryView(eventId);
+  const metrics = await getGalleryMetrics(eventId);
+  return {
+    event,
+    ...pagination,
+    metrics,
+  };
+}
+
+async function listEventsWithGalleries({ page, pageSize }) {
+  const result = await listGalleryEvents({ page, pageSize });
+  return result;
+}
+
+async function getModerationQueue({ page, pageSize }) {
+  return listPendingMedia({ page, pageSize });
+}
+
+async function moderateMedia({ mediaId, action, moderatorId, reason }) {
+  const outcome = action === 'approve' ? 'APPROVED' : action === 'reject' ? 'REJECTED' : null;
+  if (!outcome) {
+    throw Object.assign(new Error('Unsupported moderation action'), { statusCode: 400 });
+  }
+  const media = await updateMediaStatus(mediaId, {
+    status: outcome,
+    approvedBy: outcome === 'APPROVED' ? moderatorId : null,
+    rejectionReason: outcome === 'REJECTED' ? String(reason || '').trim() : null,
+  });
+
+  const event = await ensureEvent(media.eventId);
+  const uploader = await findUserById(media.uploaderId);
+
+  sendModerationEmail({ media, event, uploader, outcome: media.status, reason: media.rejectionReason }).catch((error) => {
+    logger.warn('Failed to send moderation outcome email', { mediaId: media.id, error: error.message, outcome: media.status });
+  });
+
+  if (media.status === 'APPROVED') {
+    const sponsorTags = (media.tags || []).filter((tag) => tag.type === 'SPONSOR');
+    if (sponsorTags.length) {
+      const sponsors = await listSponsors();
+      const sponsorMap = new Map(sponsors.map((sponsor) => [sponsor.id, sponsor]));
+      const notified = sponsorTags
+        .map((tag) => sponsorMap.get(tag.id))
+        .filter((sponsor) => sponsor && sponsor.email);
+      notifySponsors({ media, event, sponsors: notified }).catch((error) => {
+        logger.warn('Failed to notify sponsors after approval', { mediaId: media.id, error: error.message });
+      });
+    }
+  }
+
+  return media;
+}
+
+async function fetchMediaDetails(mediaId) {
+  const media = await findMediaById(mediaId);
+  if (!media) {
+    throw Object.assign(new Error('Media not found'), { statusCode: 404 });
+  }
+  return media;
+}
+
+async function getTagOptions(eventId) {
+  const event = await ensureEvent(eventId);
+  const [volunteers, sponsors] = await Promise.all([
+    listEventVolunteers(eventId),
+    listSponsors(),
+  ]);
+  const communities = buildCommunityTags(event);
+  return {
+    volunteers,
+    sponsors,
+    communities,
+  };
+}
+
+module.exports = {
+  uploadMediaForEvent,
+  getEventGallery,
+  listEventsWithGalleries,
+  getModerationQueue,
+  moderateMedia,
+  fetchMediaDetails,
+  getTagOptions,
+};

--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -125,4 +125,9 @@
 - **Change:** Added a `DELETE /api/events/:eventId/signup` endpoint that uses a transactional `cancelEventSignup` helper to remove assignments, attendance, and logged hours before emailing the event manager via the branded template. The volunteer dashboard and events hub now surface "Leave event" actions with inline feedback and refresh all summary panels after success.
 - **Impact:** Volunteers can bow out of commitments at any time, their impact totals drop to zero for that event, and managers receive immediate notice to rebalance coverage.
 
+## Phase 4 gallery storytelling
+- **Date:** 2025-09-29
+- **Change:** Introduced an end-to-end event gallery system: uploads pass through a moderated pipeline with EXIF-stripping image processing, MinIO/S3 storage, role-aware tagging, sponsor/community notifications, public `/gallery` browsing, infinite-scroll viewing, and an admin moderation queue. Dashboard gallery tooling now lets participants submit photos, review approved stories, and admins oversee queues.
+- **Impact:** Onkur can showcase event impact through rich, mobile-first visuals. Volunteers and managers highlight participants and sponsors, admins guard quality, sponsors are alerted when featured, and visitors explore live galleries with quick load times.
+
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,12 +8,14 @@ import ProtectedRoute from './features/auth/ProtectedRoute';
 import PublicOnlyRoute from './features/auth/PublicOnlyRoute';
 import DashboardRouter from './features/dashboard/DashboardRouter';
 import HomePage from './features/landing/HomePage';
+import PublicGalleryPage from './features/event-gallery/PublicGalleryPage';
 
 function App() {
   return (
     <AppLayout>
       <Routes>
         <Route path="/" element={<HomePage />} />
+        <Route path="/gallery" element={<PublicGalleryPage />} />
         <Route
           path="/app/*"
           element={

--- a/frontend/src/features/event-gallery/AGENTS.md
+++ b/frontend/src/features/event-gallery/AGENTS.md
@@ -1,0 +1,7 @@
+# Event Gallery Frontend Guidelines
+
+These notes apply to files within `frontend/src/features/event-gallery/`.
+
+- Keep uploads optimistic by surfacing inline status and avoid blocking the UI while awaiting moderation responses.
+- Implement infinite scrolling with an `IntersectionObserver` sentinel so galleries stay performant on mobile devices.
+- Reuse the shared green branding tokens (`text-brand-forest`, `bg-brand-sand`) for chips and lightbox chrome to stay on theme.

--- a/frontend/src/features/event-gallery/EventGalleryViewer.jsx
+++ b/frontend/src/features/event-gallery/EventGalleryViewer.jsx
@@ -1,0 +1,202 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import GalleryLightbox from './GalleryLightbox';
+import { fetchEventGallery } from './galleryApi';
+
+function MediaCard({ media, onSelect }) {
+  const tags = Array.isArray(media.tags) ? media.tags : [];
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className="group flex flex-col gap-3 rounded-3xl border border-brand-forest/10 bg-white shadow-sm transition hover:-translate-y-1 hover:shadow-lg"
+    >
+      <div className="relative aspect-[4/3] w-full overflow-hidden rounded-3xl bg-brand-sand">
+        <img
+          src={media.url}
+          alt={media.caption || 'Event gallery media'}
+          loading="lazy"
+          className="h-full w-full object-cover transition duration-500 group-hover:scale-[1.03]"
+        />
+      </div>
+      <div className="flex flex-col gap-2 px-4 pb-4 text-left">
+        {media.caption ? (
+          <p className="m-0 line-clamp-3 text-sm text-brand-muted">{media.caption}</p>
+        ) : (
+          <p className="m-0 text-xs uppercase tracking-[0.22em] text-brand-muted">Tap to view</p>
+        )}
+        {tags.length ? (
+          <div className="flex flex-wrap gap-2">
+            {tags.slice(0, 3).map((tag) => (
+              <span
+                key={`${tag.type}-${tag.id}`}
+                className="rounded-full bg-brand-sand px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-brand-forest"
+              >
+                {tag.label || tag.type}
+              </span>
+            ))}
+            {tags.length > 3 ? (
+              <span className="rounded-full bg-brand-sand px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-brand-forest">
+                +{tags.length - 3}
+              </span>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+    </button>
+  );
+}
+
+function GalleryGrid({ items, onSelect, isLoading }) {
+  if (!items.length && isLoading) {
+    return (
+      <div className="flex flex-col items-center gap-4 rounded-3xl border border-dashed border-brand-forest/20 bg-white/70 p-10 text-center">
+        <span className="text-4xl">✨</span>
+        <p className="m-0 text-sm text-brand-muted">Loading gallery moments…</p>
+      </div>
+    );
+  }
+  if (!items.length) {
+    return (
+      <div className="flex flex-col items-center gap-4 rounded-3xl border border-dashed border-brand-forest/20 bg-white/70 p-10 text-center">
+        <span className="text-4xl">📸</span>
+        <p className="m-0 text-sm text-brand-muted">No approved media yet. Be the first to share impact from this event.</p>
+      </div>
+    );
+  }
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+      {items.map((media, index) => (
+        <MediaCard key={media.id} media={media} onSelect={() => onSelect(index)} />
+      ))}
+    </div>
+  );
+}
+
+export default function EventGalleryViewer({ eventId, token, refreshSignal = 0 }) {
+  const [items, setItems] = useState([]);
+  const [eventInfo, setEventInfo] = useState(null);
+  const [metrics, setMetrics] = useState({ viewCount: 0, lastViewedAt: null });
+  const [page, setPage] = useState(0);
+  const [hasMore, setHasMore] = useState(true);
+  const [status, setStatus] = useState('idle');
+  const [error, setError] = useState('');
+  const [selectedIndex, setSelectedIndex] = useState(null);
+  const observerRef = useRef(null);
+  const sentinelRef = useRef(null);
+
+  useEffect(() => {
+    setItems([]);
+    setEventInfo(null);
+    setMetrics({ viewCount: 0, lastViewedAt: null });
+    setPage(0);
+    setHasMore(true);
+    setStatus('idle');
+    setError('');
+    setSelectedIndex(null);
+  }, [eventId, refreshSignal]);
+
+  const loadPage = useCallback(
+    async (nextPage) => {
+      if (!eventId || status === 'loading') {
+        return;
+      }
+      setStatus('loading');
+      setError('');
+      try {
+        const response = await fetchEventGallery(eventId, {
+          page: nextPage,
+          pageSize: 12,
+          token,
+        });
+        setItems((prev) => (nextPage === 1 ? response.media || [] : [...prev, ...(response.media || [])]));
+        setEventInfo(response.event || null);
+        setMetrics(response.metrics || { viewCount: 0, lastViewedAt: null });
+        setHasMore(Boolean(response.hasMore));
+        setPage(response.page || nextPage);
+        setStatus('success');
+      } catch (err) {
+        setError(err.message || 'Unable to load gallery');
+        setStatus('error');
+      }
+    },
+    [eventId, status, token],
+  );
+
+  useEffect(() => {
+    if (!eventId) {
+      return;
+    }
+    if (page === 0 && status !== 'loading') {
+      loadPage(1);
+    }
+  }, [eventId, loadPage, page, status]);
+
+  useEffect(() => {
+    if (!hasMore) {
+      return;
+    }
+    if (!sentinelRef.current) {
+      return;
+    }
+    if (observerRef.current) {
+      observerRef.current.disconnect();
+    }
+    observerRef.current = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          loadPage(page + 1);
+        }
+      });
+    }, { threshold: 1 });
+    observerRef.current.observe(sentinelRef.current);
+    return () => {
+      observerRef.current?.disconnect();
+    };
+  }, [hasMore, loadPage, page]);
+
+  const activeMedia = useMemo(() => {
+    if (selectedIndex === null || selectedIndex < 0 || selectedIndex >= items.length) {
+      return null;
+    }
+    return items[selectedIndex];
+  }, [items, selectedIndex]);
+
+  if (!eventId) {
+    return (
+      <div className="rounded-3xl border border-brand-forest/10 bg-white/80 p-8 text-center text-brand-muted">
+        Choose an event to explore its gallery.
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      {eventInfo ? (
+        <header className="flex flex-col gap-2">
+          <h3 className="m-0 text-lg font-semibold text-brand-forest">{eventInfo.title}</h3>
+          <p className="m-0 text-xs uppercase tracking-[0.28em] text-brand-muted">
+            {metrics.viewCount ? `${metrics.viewCount} views · ` : ''}
+            {eventInfo.category ? `${eventInfo.category} · ` : ''}
+            {eventInfo.theme || 'Gallery story'}
+          </p>
+        </header>
+      ) : null}
+      {status === 'error' ? (
+        <div className="rounded-3xl border border-red-200 bg-red-50 p-4 text-sm text-red-700">{error}</div>
+      ) : null}
+      <GalleryGrid items={items} onSelect={(index) => setSelectedIndex(index)} isLoading={status === 'loading' && !items.length} />
+      {hasMore ? (
+        <div ref={sentinelRef} className="h-1 w-full" aria-hidden="true" />
+      ) : null}
+      {status === 'loading' ? (
+        <p className="text-center text-sm text-brand-muted">Loading more moments…</p>
+      ) : null}
+      <GalleryLightbox
+        media={activeMedia}
+        onClose={() => setSelectedIndex(null)}
+        onPrev={() => setSelectedIndex((prev) => (prev === null ? null : Math.max(0, prev - 1)))}
+        onNext={() => setSelectedIndex((prev) => (prev === null ? null : Math.min(items.length - 1, prev + 1)))}
+      />
+    </div>
+  );
+}

--- a/frontend/src/features/event-gallery/GalleryLightbox.jsx
+++ b/frontend/src/features/event-gallery/GalleryLightbox.jsx
@@ -1,0 +1,90 @@
+import { useEffect } from 'react';
+
+function TagChip({ tag }) {
+  if (!tag) return null;
+  const tone = tag.type === 'SPONSOR' ? 'bg-white text-brand-forest' : 'bg-brand-sand text-brand-forest';
+  const label = tag.label || tag.type;
+  return (
+    <span className={`rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-[0.16em] ${tone}`}>
+      {label}
+    </span>
+  );
+}
+
+export default function GalleryLightbox({ media, onClose, onPrev, onNext }) {
+  useEffect(() => {
+    function handleKey(event) {
+      if (event.key === 'Escape') {
+        onClose?.();
+      }
+      if (event.key === 'ArrowLeft') {
+        onPrev?.();
+      }
+      if (event.key === 'ArrowRight') {
+        onNext?.();
+      }
+    }
+    window.addEventListener('keydown', handleKey);
+    return () => {
+      window.removeEventListener('keydown', handleKey);
+    };
+  }, [onClose, onNext, onPrev]);
+
+  if (!media) {
+    return null;
+  }
+
+  const tags = Array.isArray(media.tags) ? media.tags : [];
+
+  return (
+    <div
+      className="fixed inset-0 z-40 flex flex-col bg-black/80 p-4 sm:p-8"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Gallery lightbox"
+    >
+      <div className="flex justify-between text-white">
+        <button
+          type="button"
+          onClick={onClose}
+          className="rounded-full border border-white/40 bg-white/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em]"
+        >
+          Close
+        </button>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={onPrev}
+            className="rounded-full border border-white/40 bg-white/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em]"
+          >
+            Prev
+          </button>
+          <button
+            type="button"
+            onClick={onNext}
+            className="rounded-full border border-white/40 bg-white/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em]"
+          >
+            Next
+          </button>
+        </div>
+      </div>
+      <div className="mt-4 flex grow flex-col items-center overflow-y-auto">
+        <img
+          src={media.url}
+          alt={media.caption || 'Event gallery media'}
+          className="max-h-[60vh] w-full max-w-4xl rounded-3xl object-contain shadow-2xl"
+        />
+        <div className="mt-6 flex w-full max-w-3xl flex-col gap-3 rounded-3xl bg-white/95 p-5 text-brand-forest">
+          {media.caption ? <p className="m-0 text-sm sm:text-base">{media.caption}</p> : null}
+          {tags.length ? (
+            <div className="flex flex-wrap gap-2">
+              {tags.map((tag) => (
+                <TagChip key={`${tag.type}-${tag.id}`} tag={tag} />
+              ))}
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/event-gallery/MediaUploadForm.jsx
+++ b/frontend/src/features/event-gallery/MediaUploadForm.jsx
@@ -1,0 +1,283 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { fetchTagOptions, uploadEventMedia } from './galleryApi';
+
+function SelectField({ label, children }) {
+  return (
+    <label className="flex flex-col gap-2 text-sm text-brand-forest">
+      <span className="font-semibold uppercase tracking-[0.22em] text-brand-muted">{label}</span>
+      {children}
+    </label>
+  );
+}
+
+function TagCheckboxList({ options, selected, onChange }) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {options.map((option) => {
+        const id = `${option.type}-${option.id}`;
+        const isChecked = selected.some((tag) => tag.id === option.id && tag.type === option.type);
+        return (
+          <label
+            key={id}
+            className={`cursor-pointer rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] ${
+              isChecked ? 'border-brand-forest bg-brand-sand text-brand-forest' : 'border-brand-forest/20 text-brand-muted'
+            }`}
+          >
+            <input
+              type="checkbox"
+              checked={isChecked}
+              onChange={(event) => {
+                if (event.target.checked) {
+                  onChange([...selected, option]);
+                } else {
+                  onChange(selected.filter((tag) => !(tag.id === option.id && tag.type === option.type)));
+                }
+              }}
+              className="sr-only"
+            />
+            {option.label}
+          </label>
+        );
+      })}
+    </div>
+  );
+}
+
+function CommunityTagEditor({ communityTags, onAdd, onRemove }) {
+  const [value, setValue] = useState('');
+
+  const handleAdd = () => {
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    onAdd(trimmed);
+    setValue('');
+  };
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center gap-2">
+        <input
+          type="text"
+          value={value}
+          onChange={(event) => setValue(event.target.value)}
+          placeholder="Add a community or neighborhood"
+          className="w-full rounded-2xl border border-brand-forest/30 bg-white px-3 py-2 text-sm text-brand-forest focus:border-brand-forest focus:outline-none"
+        />
+        <button
+          type="button"
+          onClick={handleAdd}
+          className="rounded-full bg-brand-forest px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-white"
+        >
+          Add
+        </button>
+      </div>
+      {communityTags.length ? (
+        <div className="flex flex-wrap gap-2">
+          {communityTags.map((tag) => (
+            <button
+              key={tag.id}
+              type="button"
+              onClick={() => onRemove(tag.id)}
+              className="rounded-full bg-brand-sand px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-brand-forest"
+            >
+              {tag.label} ✕
+            </button>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export default function MediaUploadForm({ token, events = [], onUploaded }) {
+  const [selectedEvent, setSelectedEvent] = useState('');
+  const [caption, setCaption] = useState('');
+  const [file, setFile] = useState(null);
+  const fileInputRef = useRef(null);
+  const [volunteerTags, setVolunteerTags] = useState([]);
+  const [sponsorTags, setSponsorTags] = useState([]);
+  const [communityTags, setCommunityTags] = useState([]);
+  const [options, setOptions] = useState({ volunteers: [], sponsors: [], communities: [] });
+  const [status, setStatus] = useState('idle');
+  const [message, setMessage] = useState('');
+
+  const eventOptions = useMemo(() => events.filter(Boolean), [events]);
+
+  useEffect(() => {
+    if (!selectedEvent || !token) {
+      setOptions({ volunteers: [], sponsors: [], communities: [] });
+      setVolunteerTags([]);
+      setSponsorTags([]);
+      setCommunityTags([]);
+      return;
+    }
+    let isMounted = true;
+    (async () => {
+      try {
+        const response = await fetchTagOptions(selectedEvent, token);
+        if (!isMounted) return;
+        setOptions({
+          volunteers: response.volunteers || [],
+          sponsors: response.sponsors || [],
+          communities: response.communities || [],
+        });
+        setVolunteerTags([]);
+        setSponsorTags([]);
+        setCommunityTags(response.communities || []);
+      } catch (error) {
+        if (isMounted) {
+          setOptions({ volunteers: [], sponsors: [], communities: [] });
+          setVolunteerTags([]);
+          setSponsorTags([]);
+          setCommunityTags([]);
+          setMessage(error.message || 'Unable to load tag options');
+        }
+      }
+    })();
+    return () => {
+      isMounted = false;
+    };
+  }, [selectedEvent, token]);
+
+  const canSubmit = useMemo(() => selectedEvent && file && status !== 'loading', [file, selectedEvent, status]);
+
+  const handleFileChange = useCallback((event) => {
+    const selected = event.target.files?.[0];
+    if (!selected) {
+      setFile(null);
+      return;
+    }
+    setFile(selected);
+  }, []);
+
+  const handleAddCommunity = useCallback(
+    (label) => {
+      const id = `community:${label.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`;
+      if (communityTags.some((tag) => tag.id === id)) {
+        return;
+      }
+      setCommunityTags([...communityTags, { type: 'COMMUNITY', id, label }]);
+    },
+    [communityTags],
+  );
+
+  const handleRemoveCommunity = useCallback(
+    (id) => {
+      setCommunityTags((prev) => prev.filter((tag) => tag.id !== id));
+    },
+    [],
+  );
+
+  const handleSubmit = useCallback(
+    async (event) => {
+      event.preventDefault();
+      if (!canSubmit) {
+        return;
+      }
+      setStatus('loading');
+      setMessage('Uploading photo for review…');
+      try {
+        const tags = [...volunteerTags, ...sponsorTags, ...communityTags];
+        const response = await uploadEventMedia(
+          selectedEvent,
+          {
+            file,
+            caption,
+            tags,
+          },
+          token,
+        );
+        setStatus('success');
+        setMessage('Photo submitted for moderation. You will get an email when it is reviewed.');
+        setCaption('');
+        setFile(null);
+        if (fileInputRef.current) {
+          fileInputRef.current.value = '';
+        }
+        if (typeof onUploaded === 'function' && response.media) {
+          onUploaded(response.media);
+        }
+      } catch (error) {
+        setStatus('error');
+        setMessage(error.message || 'Upload failed. Please try again.');
+      }
+    },
+    [canSubmit, caption, communityTags, file, onUploaded, selectedEvent, sponsorTags, token, volunteerTags],
+  );
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-5 rounded-3xl border border-brand-forest/10 bg-white/90 p-5">
+      <header className="flex flex-col gap-1">
+        <h3 className="m-0 text-lg font-semibold text-brand-forest">Share your impact story</h3>
+        <p className="m-0 text-sm text-brand-muted">Upload photos from events you attended so moderators can spotlight them.</p>
+      </header>
+      <SelectField label="Event">
+        <select
+          value={selectedEvent}
+          onChange={(event) => setSelectedEvent(event.target.value)}
+          className="w-full rounded-2xl border border-brand-forest/30 bg-white px-3 py-2 text-sm text-brand-forest focus:border-brand-forest focus:outline-none"
+        >
+          <option value="">Select an event</option>
+          {eventOptions.map((option) => (
+            <option key={option.id} value={option.id}>
+              {option.title}
+            </option>
+          ))}
+        </select>
+      </SelectField>
+      <SelectField label="Photo">
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/*"
+          onChange={handleFileChange}
+          className="w-full rounded-2xl border border-brand-forest/30 bg-white px-3 py-2 text-sm text-brand-forest file:mr-3 file:rounded-full file:border-0 file:bg-brand-forest file:px-4 file:py-2 file:text-xs file:font-semibold file:uppercase file:tracking-[0.2em] file:text-white focus:border-brand-forest focus:outline-none"
+        />
+      </SelectField>
+      <SelectField label="Caption">
+        <textarea
+          value={caption}
+          onChange={(event) => setCaption(event.target.value.slice(0, 400))}
+          rows={3}
+          placeholder="Describe the moment, the impact, or a quote from participants (max 400 characters)."
+          className="w-full rounded-2xl border border-brand-forest/30 bg-white px-3 py-2 text-sm text-brand-forest focus:border-brand-forest focus:outline-none"
+        />
+      </SelectField>
+      {options.volunteers.length ? (
+        <SelectField label="Tag volunteers">
+          <TagCheckboxList
+            options={options.volunteers.map((item) => ({ ...item, type: 'VOLUNTEER' }))}
+            selected={volunteerTags}
+            onChange={setVolunteerTags}
+          />
+        </SelectField>
+      ) : null}
+      {options.sponsors.length ? (
+        <SelectField label="Tag sponsors">
+          <TagCheckboxList
+            options={options.sponsors.map((item) => ({ ...item, type: 'SPONSOR' }))}
+            selected={sponsorTags}
+            onChange={setSponsorTags}
+          />
+        </SelectField>
+      ) : null}
+      <SelectField label="Communities celebrated">
+        <CommunityTagEditor
+          communityTags={communityTags}
+          onAdd={handleAddCommunity}
+          onRemove={handleRemoveCommunity}
+        />
+      </SelectField>
+      <button
+        type="submit"
+        disabled={!canSubmit}
+        className="mt-2 inline-flex items-center justify-center rounded-full bg-brand-forest px-6 py-3 text-sm font-semibold uppercase tracking-[0.2em] text-white disabled:cursor-not-allowed disabled:bg-brand-muted"
+      >
+        {status === 'loading' ? 'Uploading…' : 'Submit for review'}
+      </button>
+      {message ? (
+        <p className={`m-0 text-sm ${status === 'error' ? 'text-red-600' : 'text-brand-forest'}`}>{message}</p>
+      ) : null}
+    </form>
+  );
+}

--- a/frontend/src/features/event-gallery/ModerationQueue.jsx
+++ b/frontend/src/features/event-gallery/ModerationQueue.jsx
@@ -1,0 +1,120 @@
+import { useCallback, useEffect, useState } from 'react';
+import { approveMedia, fetchModerationQueue, rejectMedia } from './galleryApi';
+
+function ModerationCard({ item, onApprove, onReject }) {
+  const [reason, setReason] = useState('');
+
+  return (
+    <article className="flex flex-col gap-4 rounded-3xl border border-brand-forest/10 bg-white/95 p-4 shadow-sm">
+      <div className="flex gap-3">
+        <img
+          src={item.url}
+          alt={item.caption || 'Pending media'}
+          className="h-24 w-24 rounded-2xl object-cover"
+        />
+        <div className="flex flex-1 flex-col gap-2 text-sm text-brand-forest">
+          <p className="m-0 font-semibold">{item.caption || 'No caption provided'}</p>
+          <p className="m-0 text-xs uppercase tracking-[0.24em] text-brand-muted">Uploaded {new Date(item.createdAt).toLocaleString()}</p>
+        </div>
+      </div>
+      <div className="flex flex-col gap-2">
+        <textarea
+          value={reason}
+          onChange={(event) => setReason(event.target.value)}
+          placeholder="Optional rejection note"
+          className="w-full rounded-2xl border border-brand-forest/20 px-3 py-2 text-sm text-brand-forest focus:border-brand-forest focus:outline-none"
+          rows={2}
+        />
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={() => onApprove(item.id)}
+            className="rounded-full bg-brand-forest px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-white"
+          >
+            Approve
+          </button>
+          <button
+            type="button"
+            onClick={() => onReject(item.id, reason)}
+            className="rounded-full border border-red-400 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-red-500"
+          >
+            Reject
+          </button>
+        </div>
+      </div>
+    </article>
+  );
+}
+
+export default function ModerationQueue({ token }) {
+  const [items, setItems] = useState([]);
+  const [status, setStatus] = useState('idle');
+  const [message, setMessage] = useState('');
+
+  const loadQueue = useCallback(async () => {
+    if (!token) {
+      return;
+    }
+    setStatus('loading');
+    setMessage('');
+    try {
+      const response = await fetchModerationQueue({}, token);
+      setItems(response.media || []);
+      setStatus('success');
+    } catch (error) {
+      setStatus('error');
+      setMessage(error.message || 'Unable to load moderation queue');
+    }
+  }, [token]);
+
+  useEffect(() => {
+    loadQueue();
+  }, [loadQueue]);
+
+  const handleApprove = useCallback(
+    async (mediaId) => {
+      try {
+        await approveMedia(mediaId, token);
+        setItems((prev) => prev.filter((item) => item.id !== mediaId));
+      } catch (error) {
+        setMessage(error.message || 'Approval failed');
+      }
+    },
+    [token],
+  );
+
+  const handleReject = useCallback(
+    async (mediaId, reason) => {
+      try {
+        await rejectMedia(mediaId, reason, token);
+        setItems((prev) => prev.filter((item) => item.id !== mediaId));
+      } catch (error) {
+        setMessage(error.message || 'Rejection failed');
+      }
+    },
+    [token],
+  );
+
+  if (!token) {
+    return null;
+  }
+
+  return (
+    <section className="flex flex-col gap-4 rounded-3xl border border-brand-forest/10 bg-brand-sand/40 p-5">
+      <header className="flex flex-col gap-1">
+        <h3 className="m-0 text-lg font-semibold text-brand-forest">Moderation queue</h3>
+        <p className="m-0 text-sm text-brand-muted">Approve or reject pending uploads so galleries stay safe and inspiring.</p>
+      </header>
+      {status === 'loading' ? <p className="text-sm text-brand-muted">Reviewing submissions…</p> : null}
+      {status === 'error' ? <p className="text-sm text-red-600">{message}</p> : null}
+      {items.length === 0 && status === 'success' ? (
+        <p className="text-sm text-brand-muted">All clear! New submissions will appear here for review.</p>
+      ) : null}
+      <div className="flex flex-col gap-3">
+        {items.map((item) => (
+          <ModerationCard key={item.id} item={item} onApprove={handleApprove} onReject={handleReject} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/features/event-gallery/PublicGalleryPage.jsx
+++ b/frontend/src/features/event-gallery/PublicGalleryPage.jsx
@@ -1,0 +1,80 @@
+import { useEffect, useMemo, useState } from 'react';
+import useDocumentTitle from '../../lib/useDocumentTitle';
+import { fetchGalleryEvents } from './galleryApi';
+import EventGalleryViewer from './EventGalleryViewer';
+
+export default function PublicGalleryPage() {
+  const [events, setEvents] = useState([]);
+  const [status, setStatus] = useState('idle');
+  const [error, setError] = useState('');
+  const [selectedEventId, setSelectedEventId] = useState('');
+
+  useDocumentTitle('Onkur | Event galleries');
+
+  useEffect(() => {
+    let isMounted = true;
+    (async () => {
+      setStatus('loading');
+      try {
+        const response = await fetchGalleryEvents({ pageSize: 18 });
+        if (!isMounted) return;
+        const list = response.events || [];
+        setEvents(list);
+        if (list.length) {
+          setSelectedEventId(list[0].id);
+        }
+        setStatus('success');
+      } catch (err) {
+        if (!isMounted) return;
+        setStatus('error');
+        setError(err.message || 'Unable to load galleries');
+      }
+    })();
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const selectedEvent = useMemo(() => events.find((event) => event.id === selectedEventId) || null, [events, selectedEventId]);
+
+  return (
+    <div className="mx-auto flex w-full max-w-6xl flex-col gap-10 px-4 py-10 sm:px-6 lg:px-8">
+      <header className="flex flex-col gap-3 text-center">
+        <h1 className="m-0 font-display text-3xl font-semibold text-brand-forest sm:text-4xl">Impact in full color</h1>
+        <p className="m-0 text-base text-brand-muted sm:text-lg">
+          Browse approved galleries from recent Onkur events. Every story highlights volunteers, sponsors, and communities
+          thriving together.
+        </p>
+      </header>
+      {status === 'error' ? (
+        <div className="rounded-3xl border border-red-200 bg-red-50 p-4 text-sm text-red-600">{error}</div>
+      ) : null}
+      <section className="flex flex-col gap-4">
+        <h2 className="m-0 text-lg font-semibold text-brand-forest">Featured galleries</h2>
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {events.map((event) => (
+            <button
+              type="button"
+              key={event.id}
+              onClick={() => setSelectedEventId(event.id)}
+              className={`flex flex-col gap-3 rounded-3xl border px-4 py-5 text-left shadow-sm transition ${
+                selectedEventId === event.id
+                  ? 'border-brand-forest bg-brand-sand/70 shadow-lg'
+                  : 'border-brand-forest/20 bg-white hover:border-brand-forest/40'
+              }`}
+            >
+              <h3 className="m-0 text-base font-semibold text-brand-forest">{event.title}</h3>
+              <p className="m-0 text-xs uppercase tracking-[0.24em] text-brand-muted">
+                {event.mediaCount} photos · {event.theme || 'Community impact'}
+              </p>
+              <p className="m-0 text-sm text-brand-muted">{event.location || 'Across our communities'}</p>
+            </button>
+          ))}
+        </div>
+      </section>
+      <section className="flex flex-col gap-6">
+        <EventGalleryViewer eventId={selectedEvent?.id} token={null} />
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/features/event-gallery/galleryApi.js
+++ b/frontend/src/features/event-gallery/galleryApi.js
@@ -1,0 +1,108 @@
+import { API_BASE } from '../../lib/apiClient';
+
+function buildHeaders(token, extra = {}) {
+  const headers = { ...extra };
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  return headers;
+}
+
+async function handleResponse(response) {
+  const contentType = response.headers.get('content-type') || '';
+  const isJson = contentType.includes('application/json');
+  const payload = isJson ? await response.json() : await response.text();
+  if (!response.ok) {
+    const message = isJson && payload && payload.error ? payload.error : 'Request failed';
+    const error = new Error(message);
+    error.status = response.status;
+    error.payload = payload;
+    throw error;
+  }
+  return payload;
+}
+
+export async function fetchEventGallery(eventId, { page = 1, pageSize = 12, token } = {}) {
+  const params = new URLSearchParams();
+  if (page) params.set('page', page);
+  if (pageSize) params.set('pageSize', pageSize);
+  const response = await fetch(`${API_BASE}/api/events/${eventId}/media?${params.toString()}`, {
+    headers: buildHeaders(token),
+  });
+  return handleResponse(response);
+}
+
+export async function fetchGalleryEvents({ page = 1, pageSize = 12 } = {}) {
+  const params = new URLSearchParams();
+  if (page) params.set('page', page);
+  if (pageSize) params.set('pageSize', pageSize);
+  const response = await fetch(`${API_BASE}/api/media/events?${params.toString()}`);
+  return handleResponse(response);
+}
+
+export async function uploadEventMedia(eventId, { file, caption, tags }, token) {
+  if (!token) {
+    throw new Error('Authentication required');
+  }
+  const formData = new FormData();
+  formData.append('file', file);
+  if (caption) {
+    formData.append('caption', caption);
+  }
+  if (tags && tags.length) {
+    formData.append('tags', JSON.stringify(tags));
+  }
+  const response = await fetch(`${API_BASE}/api/events/${eventId}/media`, {
+    method: 'POST',
+    headers: buildHeaders(token),
+    body: formData,
+  });
+  return handleResponse(response);
+}
+
+export async function fetchTagOptions(eventId, token) {
+  if (!token) {
+    throw new Error('Authentication required');
+  }
+  const response = await fetch(`${API_BASE}/api/events/${eventId}/media/tags`, {
+    headers: buildHeaders(token),
+  });
+  return handleResponse(response);
+}
+
+export async function fetchModerationQueue({ page = 1, pageSize = 20 } = {}, token) {
+  if (!token) {
+    throw new Error('Authentication required');
+  }
+  const params = new URLSearchParams();
+  if (page) params.set('page', page);
+  if (pageSize) params.set('pageSize', pageSize);
+  const response = await fetch(`${API_BASE}/api/media/moderation?${params.toString()}`, {
+    headers: buildHeaders(token),
+  });
+  return handleResponse(response);
+}
+
+export async function approveMedia(mediaId, token) {
+  if (!token) {
+    throw new Error('Authentication required');
+  }
+  const response = await fetch(`${API_BASE}/api/media/${mediaId}/approve`, {
+    method: 'POST',
+    headers: buildHeaders(token, { 'Content-Type': 'application/json' }),
+    body: JSON.stringify({}),
+  });
+  return handleResponse(response);
+}
+
+export async function rejectMedia(mediaId, reason, token) {
+  if (!token) {
+    throw new Error('Authentication required');
+  }
+  const response = await fetch(`${API_BASE}/api/media/${mediaId}/reject`, {
+    method: 'POST',
+    headers: buildHeaders(token, { 'Content-Type': 'application/json' }),
+    body: JSON.stringify({ reason }),
+  });
+  return handleResponse(response);
+}


### PR DESCRIPTION
## Summary
- add backend event gallery feature module with upload, moderation, tagging, metrics, and object storage support
- expose public and dashboard gallery experiences including upload form, infinite-scroll viewer, moderation queue, and sponsor notifications
- refresh roadmap and wiki with Phase 4 details and document the new gallery workflow

## Testing
- npm test (backend)
- npm run build (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68ccca0d62bc8333bf3fbeb101748c15