### PR TITLE
Fix event gallery file-type import for Node 20

### DIFF
--- a/backend/src/features/event-gallery/eventGallery.service.js
+++ b/backend/src/features/event-gallery/eventGallery.service.js
@@ -1,6 +1,6 @@
 const { randomUUID } = require('crypto');
 const sharp = require('sharp');
-const { fileTypeFromBuffer } = require('file-type');
+let fileTypeModulePromise;
 const config = require('../../config');
 const logger = require('../../utils/logger');
 const minioClient = require('../common/minio');
@@ -126,6 +126,10 @@ async function processImageBuffer(file) {
     throw Object.assign(new Error('Photo must be 10MB or smaller'), { statusCode: 400 });
   }
 
+  if (!fileTypeModulePromise) {
+    fileTypeModulePromise = import('file-type');
+  }
+  const { fileTypeFromBuffer } = await fileTypeModulePromise;
   const detected = await fileTypeFromBuffer(file.buffer);
   if (!detected || !ALLOWED_MIME_TYPES.has(detected.mime)) {
     throw Object.assign(new Error('Only JPEG, PNG, WebP, or HEIC images are supported'), { statusCode: 415 });

--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -131,3 +131,10 @@
 - **Impact:** Onkur can showcase event impact through rich, mobile-first visuals. Volunteers and managers highlight participants and sponsors, admins guard quality, sponsors are alerted when featured, and visitors explore live galleries with quick load times.
 
 
+## Event gallery runtime compatibility
+- **Date:** 2025-09-29
+- **Change:** Updated the gallery upload service to lazy-load the `file-type` detector through an ES module import so Node 20 resolves the dependency without triggering the "No exports main defined" error during startup.
+- **Impact:** Backend containers boot cleanly again, keeping gallery moderation, uploads, and notifications online for admins and event teams.
+
+
+


### PR DESCRIPTION
## Summary
- lazily import the file-type helper so the event gallery service works in Node 20
- document the runtime compatibility fix in the project wiki

## Testing
- `npm run lint` *(fails: Missing script "lint")*
- `npm start` *(fails: requires JWT_SECRET to be configured)*

------
https://chatgpt.com/codex/tasks/task_e_68ccd080bf148333a9ca301f9a712dbe