### PR TITLE
Refine mobile header and relocate logout

### DIFF
--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -137,4 +137,10 @@
 - **Impact:** Backend containers boot cleanly again, keeping gallery moderation, uploads, and notifications online for admins and event teams.
 
 
+## Mobile header compaction
+- **Date:** 2025-09-30
+- **Change:** Slimmed the authenticated dashboard header with tighter spacing, hid the subtitle on mobile, and relocated the logout action to the sticky bottom navigation.
+- **Impact:** Mobile users regain vertical space for content while still accessing logout from the persistent footer, and desktop retains the prominent logout control.
+
+
 

--- a/frontend/src/features/layout/AGENTS.md
+++ b/frontend/src/features/layout/AGENTS.md
@@ -5,3 +5,4 @@ These notes apply to files within `frontend/src/features/layout/`.
 - Keep shared navigation data in `navConfig.js` so the desktop and mobile menus stay synchronized.
 - When updating header or navigation spacing, verify both mobile (bottom navigation) and desktop (header navigation) breakpoints remain accessible.
 - Prefer declarative `Link` components from `react-router-dom` over `button` elements for navigation interactions.
+- The mobile bottom navigation hosts the logout action; keep the dedicated button accessible and visually balanced alongside the nav items when adjusting the bar.

--- a/frontend/src/features/layout/AppLayout.jsx
+++ b/frontend/src/features/layout/AppLayout.jsx
@@ -45,51 +45,66 @@ export default function AppLayout({ children }) {
   return (
     <div className="flex min-h-screen flex-col bg-gradient-to-b from-brand-green/10 via-brand-sand to-brand-sand">
       <header className="sticky top-0 z-10 bg-brand-green text-white shadow-[0_8px_16px_rgba(47,133,90,0.25)]">
-        <div className="mx-auto flex w-full max-w-4xl flex-col gap-4 px-6 py-5 sm:flex-row sm:items-center sm:justify-between">
-          <div className="flex flex-col gap-2 text-center sm:text-left">
-            <h1 className="m-0 text-2xl font-semibold tracking-tight text-white">
-              <Link
-                to="/"
-                className="inline-flex items-center gap-1.5 font-display text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-white/80"
-                aria-label="Go to the Onkur home page"
-              >
-                Onkur
-              </Link>
-            </h1>
-            <p className="m-0 text-sm text-white/85 sm:text-base">{headerSubtitle}</p>
-          </div>
-          {user ? (
-            <div className="flex w-full flex-col items-center gap-2 text-sm sm:w-auto sm:items-end">
-              <span className="text-base font-medium">{user.name}</span>
-              {formattedRoles.length ? (
-                <span className="rounded-full bg-white/20 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em]">
-                  {formattedRoles.join(' • ')}
-                </span>
-              ) : null}
-              <button
-                type="button"
-                className="rounded-md border border-white/30 bg-white/10 px-4 py-2 text-sm font-semibold text-white transition hover:bg-white/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/70"
-                onClick={logout}
-              >
-                Log out
-              </button>
+        <div className="mx-auto w-full max-w-4xl px-5 py-3 sm:px-6 sm:py-5">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex flex-col gap-1">
+              <div className="flex items-center justify-between gap-3 sm:justify-start">
+                <h1 className="m-0 text-2xl font-semibold tracking-tight text-white">
+                  <Link
+                    to="/"
+                    className="inline-flex items-center gap-1.5 font-display text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-white/80"
+                    aria-label="Go to the Onkur home page"
+                  >
+                    Onkur
+                  </Link>
+                </h1>
+                {user ? (
+                  <div className="flex items-center gap-2 text-xs font-medium text-white sm:hidden">
+                    <span className="max-w-[140px] truncate">{user.name}</span>
+                    {formattedRoles.length ? (
+                      <span className="rounded-full bg-white/20 px-2 py-1 uppercase tracking-[0.14em]">
+                        {formattedRoles[0]}
+                      </span>
+                    ) : null}
+                  </div>
+                ) : null}
+              </div>
+              <p className="hidden text-sm text-white/85 sm:block sm:text-base">{headerSubtitle}</p>
             </div>
-          ) : (
-            <nav className="flex w-full items-center justify-center gap-3 pt-2 sm:w-auto sm:justify-end">
-              <Link
-                to="/login"
-                className="rounded-md border border-white/50 bg-white/10 px-4 py-2 text-sm font-semibold text-white shadow-[0_10px_24px_rgba(15,63,37,0.15)] transition hover:-translate-y-0.5 hover:bg-white/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/70"
-              >
-                Sign in
-              </Link>
-              <Link
-                to="/signup"
-                className="rounded-md border border-white bg-white px-4 py-2 text-sm font-semibold text-brand-green shadow-[0_14px_30px_rgba(12,58,33,0.28)] transition hover:-translate-y-0.5 hover:bg-white/95 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/70"
-              >
-                Join Onkur
-              </Link>
-            </nav>
-          )}
+            {user ? (
+              <div className="hidden flex-col items-end gap-2 text-sm sm:flex">
+                <span className="text-base font-medium">{user.name}</span>
+                {formattedRoles.length ? (
+                  <span className="rounded-full bg-white/20 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em]">
+                    {formattedRoles.join(' • ')}
+                  </span>
+                ) : null}
+                <button
+                  type="button"
+                  className="inline-flex items-center gap-2 rounded-md border border-white/30 bg-white/10 px-4 py-2 text-sm font-semibold text-white transition hover:bg-white/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/70"
+                  onClick={logout}
+                >
+                  <span aria-hidden="true">⏻</span>
+                  Log out
+                </button>
+              </div>
+            ) : (
+              <nav className="flex w-full items-center justify-center gap-3 sm:w-auto sm:justify-end">
+                <Link
+                  to="/login"
+                  className="rounded-md border border-white/50 bg-white/10 px-4 py-2 text-sm font-semibold text-white shadow-[0_10px_24px_rgba(15,63,37,0.15)] transition hover:-translate-y-0.5 hover:bg-white/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/70"
+                >
+                  Sign in
+                </Link>
+                <Link
+                  to="/signup"
+                  className="rounded-md border border-white bg-white px-4 py-2 text-sm font-semibold text-brand-green shadow-[0_14px_30px_rgba(12,58,33,0.28)] transition hover:-translate-y-0.5 hover:bg-white/95 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/70"
+                >
+                  Join Onkur
+                </Link>
+              </nav>
+            )}
+          </div>
         </div>
         {isAuthenticated ? <DesktopNav active={activeNav} /> : null}
       </header>

--- a/frontend/src/features/layout/BottomNav.jsx
+++ b/frontend/src/features/layout/BottomNav.jsx
@@ -1,11 +1,14 @@
 import { Link } from 'react-router-dom';
 
+import { useAuth } from '../auth/AuthContext';
 import { NAV_ITEMS } from './navConfig';
 
 export default function BottomNav({ active }) {
+  const { logout } = useAuth();
+
   return (
     <nav
-      className="sticky bottom-0 left-0 right-0 grid grid-cols-4 gap-2 border-t border-brand-green/15 bg-white/95 px-3 py-2 shadow-[0_-6px_18px_rgba(47,133,90,0.12)] backdrop-blur-sm md:hidden"
+      className="sticky bottom-0 left-0 right-0 grid grid-cols-5 gap-2 border-t border-brand-green/15 bg-white/95 px-3 py-2 shadow-[0_-6px_18px_rgba(47,133,90,0.12)] backdrop-blur-sm md:hidden"
       aria-label="Primary"
     >
       {NAV_ITEMS.map((item) => {
@@ -28,6 +31,16 @@ export default function BottomNav({ active }) {
           </Link>
         );
       })}
+      <button
+        type="button"
+        className="flex flex-col items-center gap-1 rounded-md px-2 py-1.5 text-xs font-semibold text-brand-muted transition hover:text-brand-green focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-green/60"
+        onClick={logout}
+      >
+        <span aria-hidden="true" className="text-base">
+          ⏻
+        </span>
+        Log out
+      </button>
     </nav>
   );
 }


### PR DESCRIPTION
## Summary
- tighten the authenticated mobile header spacing and hide the tagline on small screens for a more compact layout
- surface key user details inline while keeping the desktop logout control available at larger breakpoints
- move the logout action into the mobile bottom navigation and document the expectation in the layout guidelines, updating the wiki change log

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ccd375e2fc833382b85064967751fe