### PR TITLE
Refresh theme with earthy brown palette

### DIFF
--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -143,4 +143,10 @@
 - **Impact:** Mobile users regain vertical space for content while still accessing logout from the persistent footer, and desktop retains the prominent logout control.
 
 
+## Earthy brown branding refresh
+- **Date:** 2025-09-30
+- **Change:** Recolored the shared Tailwind palette and home page theme styles to center on earthy browns and ambers, updating gradients, shadows, and button treatments to match the new direction.
+- **Impact:** The web experience now carries a cohesive warm visual identity that aligns with the refreshed Onkur brand guidelines without disrupting existing layout structure.
+
+
 

--- a/frontend/src/features/event-gallery/AGENTS.md
+++ b/frontend/src/features/event-gallery/AGENTS.md
@@ -4,4 +4,4 @@ These notes apply to files within `frontend/src/features/event-gallery/`.
 
 - Keep uploads optimistic by surfacing inline status and avoid blocking the UI while awaiting moderation responses.
 - Implement infinite scrolling with an `IntersectionObserver` sentinel so galleries stay performant on mobile devices.
-- Reuse the shared green branding tokens (`text-brand-forest`, `bg-brand-sand`) for chips and lightbox chrome to stay on theme.
+- Reuse the shared earthy branding tokens (`text-brand-forest`, `text-brand-green`, `bg-brand-sand`) for chips and lightbox chrome to stay on theme.

--- a/frontend/src/styles/theme.css
+++ b/frontend/src/styles/theme.css
@@ -6,11 +6,11 @@
 
 @layer base {
   :root {
-    --green-primary: #2f855a;
-    --green-secondary: #68d391;
-    --earth-brown: #8b5e3c;
-    --sky-blue: #38b2ac;
-    --sun-yellow: #ecc94b;
+    --earth-primary: #6b4f33;
+    --earth-secondary: #a47148;
+    --earth-rich: #5c4033;
+    --earth-sage: #c2b280;
+    --sun-amber: #d4a373;
   }
 
   body {
@@ -24,7 +24,7 @@
 
 @layer components {
   .btn-primary {
-    @apply inline-flex items-center justify-center rounded-md border border-transparent bg-brand-yellow px-4 py-2.5 text-base font-semibold text-brand-brown shadow-[0_6px_12px_rgba(236,201,75,0.3)] transition-transform focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-green/50 disabled:cursor-not-allowed disabled:opacity-70;
+    @apply inline-flex items-center justify-center rounded-md border border-transparent bg-brand-yellow px-4 py-2.5 text-base font-semibold text-brand-brown shadow-[0_6px_12px_rgba(212,163,115,0.3)] transition-transform focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-green/50 disabled:cursor-not-allowed disabled:opacity-70;
   }
 
   .btn-primary:hover {
@@ -32,7 +32,7 @@
   }
 
   .btn-secondary {
-    @apply inline-flex items-center justify-center rounded-md border border-white/60 bg-white/10 px-4 py-2.5 text-base font-semibold text-white shadow-[0_10px_24px_rgba(15,63,37,0.15)] transition-transform focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/70;
+    @apply inline-flex items-center justify-center rounded-md border border-white/60 bg-white/10 px-4 py-2.5 text-base font-semibold text-white shadow-[0_10px_24px_rgba(47,36,25,0.15)] transition-transform focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/70;
   }
 
   .btn-secondary:hover {
@@ -44,15 +44,15 @@
   }
 
   .home-hero {
-    @apply relative grid gap-8 overflow-hidden rounded-[20px] bg-[linear-gradient(135deg,rgba(47,133,90,0.12),rgba(56,178,172,0.08))] p-8 shadow-[0_24px_48px_rgba(47,133,90,0.18)];
+    @apply relative grid gap-8 overflow-hidden rounded-[20px] bg-[linear-gradient(135deg,rgba(107,79,51,0.12),rgba(194,178,128,0.08))] p-8 shadow-[0_24px_48px_rgba(107,79,51,0.18)];
   }
 
   .home-hero::after {
     content: '';
     position: absolute;
     inset: 0;
-    background: radial-gradient(circle at 20% 20%, rgba(236, 201, 75, 0.25), transparent 55%),
-      radial-gradient(circle at 80% 80%, rgba(104, 211, 145, 0.3), transparent 60%);
+    background: radial-gradient(circle at 20% 20%, rgba(212, 163, 115, 0.25), transparent 55%),
+      radial-gradient(circle at 80% 80%, rgba(164, 113, 72, 0.3), transparent 60%);
     z-index: 0;
     pointer-events: none;
   }
@@ -94,7 +94,7 @@
   }
 
   .hero-badge {
-    @apply flex max-w-xs items-center gap-3 rounded-[14px] bg-white/90 p-5 shadow-[0_16px_32px_rgba(31,41,51,0.12)];
+    @apply flex max-w-xs items-center gap-3 rounded-[14px] bg-white/90 p-5 shadow-[0_16px_32px_rgba(47,36,25,0.12)];
   }
 
   .hero-badge span {
@@ -114,7 +114,7 @@
   }
 
   .home-highlight {
-    @apply flex flex-col gap-6 rounded-[20px] bg-white p-8 shadow-[0_18px_40px_rgba(47,133,90,0.12)];
+    @apply flex flex-col gap-6 rounded-[20px] bg-white p-8 shadow-[0_18px_40px_rgba(107,79,51,0.12)];
   }
 
   .home-highlight h3,
@@ -156,7 +156,7 @@
   }
 
   .role-card {
-    @apply relative flex flex-col gap-4 overflow-hidden rounded-[20px] bg-white p-7 shadow-[0_16px_36px_rgba(31,41,51,0.08)];
+    @apply relative flex flex-col gap-4 overflow-hidden rounded-[20px] bg-white p-7 shadow-[0_16px_36px_rgba(47,36,25,0.08)];
   }
 
   .role-card::after {
@@ -164,7 +164,7 @@
     position: absolute;
     inset: 0;
     opacity: 0.6;
-    background: linear-gradient(135deg, transparent 55%, rgba(56, 178, 172, 0.2));
+    background: linear-gradient(135deg, transparent 55%, rgba(194, 178, 128, 0.2));
     pointer-events: none;
   }
 
@@ -195,19 +195,19 @@
   }
 
   .role-card--leaf::before {
-    background: var(--green-secondary);
+    background: var(--earth-secondary);
   }
 
   .role-card--sun::before {
-    background: var(--sun-yellow);
+    background: var(--sun-amber);
   }
 
   .role-card--wave::before {
-    background: var(--sky-blue);
+    background: var(--earth-sage);
   }
 
   .role-card--roots::before {
-    background: var(--earth-brown);
+    background: var(--earth-rich);
   }
 
   .home-journey {
@@ -215,7 +215,7 @@
   }
 
   .home-journey__card {
-    @apply flex flex-col gap-4 rounded-[20px] bg-white p-8 shadow-[0_20px_44px_rgba(47,133,90,0.16)];
+    @apply flex flex-col gap-4 rounded-[20px] bg-white p-8 shadow-[0_20px_44px_rgba(107,79,51,0.16)];
   }
 
   .home-journey__card ul {
@@ -231,7 +231,7 @@
   }
 
   .home-cta {
-    @apply flex flex-col gap-6 rounded-[20px] bg-[linear-gradient(120deg,rgba(47,133,90,0.92),rgba(56,178,172,0.85))] p-8 text-white shadow-[0_24px_48px_rgba(31,41,51,0.2)];
+    @apply flex flex-col gap-6 rounded-[20px] bg-[linear-gradient(120deg,rgba(92,64,51,0.92),rgba(164,113,72,0.85))] p-8 text-white shadow-[0_24px_48px_rgba(47,36,25,0.2)];
   }
 
   .home-cta h3 {
@@ -247,7 +247,7 @@
   }
 
   .home-cta .btn-primary {
-    @apply border border-white/50 bg-white/20 text-white shadow-[0_18px_42px_rgba(15,63,37,0.28)];
+    @apply border border-white/50 bg-white/20 text-white shadow-[0_18px_42px_rgba(47,36,25,0.28)];
   }
 
   .home-cta .btn-primary:hover {

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -4,14 +4,14 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-        'brand-green': '#2f855a',
-        'brand-green-soft': '#68d391',
-        'brand-brown': '#8b5e3c',
-        'brand-sky': '#38b2ac',
-        'brand-sand': '#f7faf5',
-        'brand-yellow': '#ecc94b',
-        'brand-forest': '#1f2933',
-        'brand-muted': '#4a5568',
+        'brand-green': '#6b4f33',
+        'brand-green-soft': '#a47148',
+        'brand-brown': '#5c4033',
+        'brand-sky': '#c2b280',
+        'brand-sand': '#f4ede1',
+        'brand-yellow': '#d4a373',
+        'brand-forest': '#2f2419',
+        'brand-muted': '#6e5849',
       },
       fontFamily: {
         sans: ['Inter', 'Open Sans', 'sans-serif'],


### PR DESCRIPTION
## Summary
- retune the Tailwind brand colors to a warm earthy brown palette
- adjust global theme gradients, shadows, and accents to match the new colors
- update gallery guidelines and wiki changelog to note the branding refresh

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd3bced2948333a1cf2d52e4435690