### PR TITLE
Implement sponsor phase workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ Onkur is a mobile-first volunteering platform rooted in sustainability and commu
 - Public `/gallery` showcase that spotlights approved events, tracks per-event views, and celebrates tagged sponsors alongside community highlights.
 - MinIO/S3-backed storage with graceful inline fallback plus transactional emails to notify contributors and sponsors when galleries go live.
 
+### Phase 5 – Sponsor Partnerships (Complete)
+- Sponsor registration and approval workflow that promotes verified organizations into the sponsor role.
+- Sponsor dashboard to manage organization profiles, pledge funds or in-kind support, and review live sponsorships.
+- Event and gallery experiences that surface approved sponsor logos and contributions for every supported event.
+- Automated impact reports summarizing volunteer hours, gallery views, and ROI metrics delivered to sponsor inboxes.
+
 Consult the living [product wiki](docs/Wiki.md) for design rationale, API schemas, and rollout notes for each phase.
 
 ---

--- a/backend/src/features/auth/auth.service.js
+++ b/backend/src/features/auth/auth.service.js
@@ -24,6 +24,7 @@ const { sortRolesByPriority, determinePrimaryRole } = require('./role.helpers');
 const {
   getProfile: getVolunteerProfileForUser,
 } = require('../volunteer-journey/volunteerJourney.service');
+const { findSponsorProfile } = require('../sponsors/sponsor.repository');
 
 const config = require('../../config');
 
@@ -83,9 +84,15 @@ async function toPublicUserWithProfile(user) {
   if (!baseUser || !user?.id) {
     return baseUser;
   }
-
-  const profile = await getVolunteerProfileForUser(user.id);
-  return { ...baseUser, profile };
+  const [volunteerProfile, sponsorProfile] = await Promise.all([
+    getVolunteerProfileForUser(user.id),
+    findSponsorProfile(user.id).catch(() => null),
+  ]);
+  return {
+    ...baseUser,
+    profile: volunteerProfile,
+    sponsorProfile,
+  };
 }
 
 function createHttpError(statusCode, message) {

--- a/backend/src/features/sponsors/AGENTS.md
+++ b/backend/src/features/sponsors/AGENTS.md
@@ -1,0 +1,8 @@
+# Sponsor Feature Backend Guidelines
+
+These instructions apply to files within `backend/src/features/sponsors/`.
+
+- Keep sponsorship workflow logic in the service layer so routes remain focused on validation, auth, and shaping responses.
+- Normalize sponsor and sponsorship statuses to the uppercase enum values (`PENDING`, `APPROVED`, `DECLINED`) before persisting or comparing.
+- When computing impact reports, rely on existing event metrics tables (`event_reports`, `event_gallery_metrics`) before issuing fresh aggregate queries.
+- Email notifications must flow through `sendTemplatedEmail` and log soft failures with the shared Winston logger without aborting the primary request.

--- a/backend/src/features/sponsors/sponsor.repository.js
+++ b/backend/src/features/sponsors/sponsor.repository.js
@@ -1,0 +1,468 @@
+const { randomUUID } = require('crypto');
+const pool = require('../common/db');
+
+const VALID_PROFILE_STATUSES = ['PENDING', 'APPROVED', 'DECLINED'];
+const VALID_SPONSORSHIP_TYPES = ['FUNDS', 'IN_KIND'];
+const VALID_SPONSORSHIP_STATUSES = ['PENDING', 'APPROVED', 'DECLINED'];
+
+function normalizeJson(value, fallback = {}) {
+  if (!value) {
+    return fallback;
+  }
+  if (typeof value === 'object') {
+    try {
+      return JSON.parse(JSON.stringify(value));
+    } catch (error) {
+      return fallback;
+    }
+  }
+  try {
+    return JSON.parse(value);
+  } catch (error) {
+    return fallback;
+  }
+}
+
+function toIso(value) {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  return date.toISOString();
+}
+
+function mapProfileRow(row) {
+  if (!row) return null;
+  return {
+    userId: row.user_id,
+    orgName: row.org_name,
+    logoUrl: row.logo_url || null,
+    website: row.website || null,
+    contactName: row.contact_name || null,
+    contactEmail: row.contact_email || null,
+    contactPhone: row.contact_phone || null,
+    brandAssets: normalizeJson(row.brand_assets || {}),
+    status: row.status,
+    approvedAt: toIso(row.approved_at),
+    lastReportSentAt: toIso(row.last_report_sent_at),
+    createdAt: toIso(row.created_at),
+    updatedAt: toIso(row.updated_at),
+  };
+}
+
+function mapSponsorshipRow(row) {
+  if (!row) return null;
+  return {
+    id: row.id,
+    sponsorId: row.sponsor_id,
+    eventId: row.event_id,
+    type: row.type,
+    amount: row.amount === null || row.amount === undefined ? null : Number(row.amount),
+    notes: row.notes || null,
+    status: row.status,
+    approvedAt: toIso(row.approved_at),
+    pledgedAt: toIso(row.pledged_at),
+    createdAt: toIso(row.created_at),
+    updatedAt: toIso(row.updated_at),
+    reportSnapshot: normalizeJson(row.report_snapshot || {}),
+  };
+}
+
+const schemaPromise = (async () => {
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS sponsor_profiles (
+      user_id UUID PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+      org_name TEXT NOT NULL,
+      logo_url TEXT NULL,
+      website TEXT NULL,
+      contact_name TEXT NULL,
+      contact_email TEXT NULL,
+      contact_phone TEXT NULL,
+      brand_assets JSONB NOT NULL DEFAULT '{}'::JSONB,
+      status TEXT NOT NULL DEFAULT 'PENDING' CHECK (status = ANY(ARRAY['PENDING','APPROVED','DECLINED']::TEXT[])),
+      approved_at TIMESTAMPTZ NULL,
+      last_report_sent_at TIMESTAMPTZ NULL,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `);
+
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS sponsorships (
+      id UUID PRIMARY KEY,
+      sponsor_id UUID NOT NULL REFERENCES sponsor_profiles(user_id) ON DELETE CASCADE,
+      event_id UUID NOT NULL REFERENCES events(id) ON DELETE CASCADE,
+      type TEXT NOT NULL CHECK (type = ANY(ARRAY['FUNDS','IN_KIND']::TEXT[])),
+      amount NUMERIC(12,2) NULL,
+      notes TEXT NULL,
+      status TEXT NOT NULL DEFAULT 'PENDING' CHECK (status = ANY(ARRAY['PENDING','APPROVED','DECLINED']::TEXT[])),
+      approved_at TIMESTAMPTZ NULL,
+      pledged_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      report_snapshot JSONB NOT NULL DEFAULT '{}'::JSONB,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `);
+
+  await pool.query(`CREATE INDEX IF NOT EXISTS idx_sponsorships_event ON sponsorships (event_id)`);
+  await pool.query(`CREATE INDEX IF NOT EXISTS idx_sponsorships_sponsor ON sponsorships (sponsor_id)`);
+  await pool.query(`CREATE INDEX IF NOT EXISTS idx_sponsor_profiles_status ON sponsor_profiles (status)`);
+})();
+
+async function ensureSchema() {
+  await schemaPromise;
+}
+
+function sanitizeStatus(status, allowed) {
+  if (!status) return null;
+  const value = String(status).trim().toUpperCase();
+  return allowed.includes(value) ? value : null;
+}
+
+function sanitizeType(type) {
+  if (!type) return null;
+  const value = String(type).trim().toUpperCase();
+  return VALID_SPONSORSHIP_TYPES.includes(value) ? value : null;
+}
+
+async function applySponsorProfile({
+  userId,
+  orgName,
+  logoUrl = null,
+  website = null,
+  contactName = null,
+  contactEmail = null,
+  contactPhone = null,
+  brandAssets = {},
+}) {
+  await ensureSchema();
+  const normalizedAssets = normalizeJson(brandAssets, {});
+  const result = await pool.query(
+    `
+      INSERT INTO sponsor_profiles (
+        user_id,
+        org_name,
+        logo_url,
+        website,
+        contact_name,
+        contact_email,
+        contact_phone,
+        brand_assets,
+        status,
+        approved_at
+      )
+      VALUES ($1,$2,$3,$4,$5,$6,$7,$8,'PENDING',NULL)
+      ON CONFLICT (user_id)
+      DO UPDATE SET
+        org_name = EXCLUDED.org_name,
+        logo_url = EXCLUDED.logo_url,
+        website = EXCLUDED.website,
+        contact_name = EXCLUDED.contact_name,
+        contact_email = EXCLUDED.contact_email,
+        contact_phone = EXCLUDED.contact_phone,
+        brand_assets = EXCLUDED.brand_assets,
+        status = 'PENDING',
+        approved_at = NULL,
+        updated_at = NOW()
+      RETURNING *
+    `,
+    [
+      userId,
+      orgName,
+      logoUrl,
+      website,
+      contactName,
+      contactEmail,
+      contactPhone,
+      JSON.stringify(normalizedAssets),
+    ],
+  );
+  return mapProfileRow(result.rows[0]);
+}
+
+async function updateSponsorProfile(userId, updates = {}) {
+  await ensureSchema();
+  const fields = [];
+  const values = [];
+  const columns = new Map([
+    ['orgName', 'org_name'],
+    ['logoUrl', 'logo_url'],
+    ['website', 'website'],
+    ['contactName', 'contact_name'],
+    ['contactEmail', 'contact_email'],
+    ['contactPhone', 'contact_phone'],
+  ]);
+
+  for (const [key, column] of columns.entries()) {
+    if (Object.prototype.hasOwnProperty.call(updates, key)) {
+      fields.push(`${column} = $${fields.length + 1}`);
+      values.push(updates[key]);
+    }
+  }
+
+  if (Object.prototype.hasOwnProperty.call(updates, 'brandAssets')) {
+    fields.push(`brand_assets = $${fields.length + 1}`);
+    values.push(JSON.stringify(normalizeJson(updates.brandAssets, {})));
+  }
+
+  if (!fields.length) {
+    const existing = await findSponsorProfile(userId);
+    if (!existing) {
+      throw Object.assign(new Error('Sponsor profile not found'), { statusCode: 404 });
+    }
+    return existing;
+  }
+
+  values.push(userId);
+  const result = await pool.query(
+    `
+      UPDATE sponsor_profiles
+      SET ${fields.join(', ')}, updated_at = NOW()
+      WHERE user_id = $${values.length}
+      RETURNING *
+    `,
+    values,
+  );
+
+  if (!result.rows[0]) {
+    throw Object.assign(new Error('Sponsor profile not found'), { statusCode: 404 });
+  }
+
+  return mapProfileRow(result.rows[0]);
+}
+
+async function findSponsorProfile(userId) {
+  await ensureSchema();
+  const result = await pool.query(
+    `SELECT * FROM sponsor_profiles WHERE user_id = $1`,
+    [userId],
+  );
+  return mapProfileRow(result.rows[0]);
+}
+
+async function listSponsorProfiles({ statuses } = {}) {
+  await ensureSchema();
+  let where = '';
+  const values = [];
+  if (Array.isArray(statuses) && statuses.length) {
+    const normalized = statuses
+      .map((status) => sanitizeStatus(status, VALID_PROFILE_STATUSES))
+      .filter(Boolean);
+    if (normalized.length) {
+      values.push(normalized);
+      where = `WHERE status = ANY($${values.length}::TEXT[])`;
+    }
+  }
+  const result = await pool.query(
+    `SELECT * FROM sponsor_profiles ${where} ORDER BY created_at DESC`,
+    values,
+  );
+  return result.rows.map(mapProfileRow);
+}
+
+async function setSponsorStatus({ userId, status }) {
+  await ensureSchema();
+  const normalized = sanitizeStatus(status, VALID_PROFILE_STATUSES);
+  if (!normalized) {
+    throw Object.assign(new Error('Invalid sponsor status'), { statusCode: 400 });
+  }
+  const result = await pool.query(
+    `
+      UPDATE sponsor_profiles
+      SET status = $2,
+          approved_at = CASE WHEN $2 = 'APPROVED' THEN NOW() ELSE NULL END,
+          updated_at = NOW()
+      WHERE user_id = $1
+      RETURNING *
+    `,
+    [userId, normalized],
+  );
+  if (!result.rows[0]) {
+    throw Object.assign(new Error('Sponsor profile not found'), { statusCode: 404 });
+  }
+  if (normalized !== 'APPROVED') {
+    await pool.query(
+      `
+        UPDATE sponsorships
+        SET status = $3,
+            approved_at = CASE WHEN $3 = 'APPROVED' THEN NOW() ELSE NULL END,
+            updated_at = NOW()
+        WHERE sponsor_id = $1 AND status <> $3
+      `,
+      [userId, normalized, normalized],
+    );
+  }
+  return mapProfileRow(result.rows[0]);
+}
+
+async function createSponsorship({ sponsorId, eventId, type, amount = null, notes = null, status = 'PENDING' }) {
+  await ensureSchema();
+  const normalizedType = sanitizeType(type);
+  if (!normalizedType) {
+    throw Object.assign(new Error('Invalid sponsorship type'), { statusCode: 400 });
+  }
+  const normalizedStatus = sanitizeStatus(status, VALID_SPONSORSHIP_STATUSES) || 'PENDING';
+  const id = randomUUID();
+  const result = await pool.query(
+    `
+      INSERT INTO sponsorships (
+        id, sponsor_id, event_id, type, amount, notes, status, approved_at
+      )
+      VALUES ($1,$2,$3,$4,$5,$6,$7, CASE WHEN $7 = 'APPROVED' THEN NOW() ELSE NULL END)
+      RETURNING *
+    `,
+    [id, sponsorId, eventId, normalizedType, amount, notes, normalizedStatus],
+  );
+  return mapSponsorshipRow(result.rows[0]);
+}
+
+async function listSponsorshipsForSponsor(sponsorId) {
+  await ensureSchema();
+  const result = await pool.query(
+    `
+      SELECT s.*, e.title AS event_title, e.date_start, e.date_end, e.location
+      FROM sponsorships s
+      JOIN events e ON e.id = s.event_id
+      WHERE s.sponsor_id = $1
+      ORDER BY s.created_at DESC
+    `,
+    [sponsorId],
+  );
+  return result.rows.map((row) => ({
+    ...mapSponsorshipRow(row),
+    event: {
+      id: row.event_id,
+      title: row.event_title,
+      dateStart: toIso(row.date_start),
+      dateEnd: toIso(row.date_end),
+      location: row.location,
+    },
+  }));
+}
+
+async function listApprovedEventSponsors(eventIds = []) {
+  await ensureSchema();
+  if (!Array.isArray(eventIds) || !eventIds.length) {
+    return new Map();
+  }
+  const result = await pool.query(
+    `
+      SELECT s.event_id, sp.user_id, sp.org_name, sp.logo_url, sp.website, s.type, s.amount
+      FROM sponsorships s
+      JOIN sponsor_profiles sp ON sp.user_id = s.sponsor_id
+      WHERE s.event_id = ANY($1::UUID[])
+        AND sp.status = 'APPROVED'
+        AND s.status = 'APPROVED'
+      ORDER BY sp.org_name ASC
+    `,
+    [eventIds],
+  );
+  const map = new Map();
+  for (const row of result.rows) {
+    if (!map.has(row.event_id)) {
+      map.set(row.event_id, []);
+    }
+    map.get(row.event_id).push({
+      sponsorId: row.user_id,
+      orgName: row.org_name,
+      logoUrl: row.logo_url || null,
+      website: row.website || null,
+      type: row.type,
+      amount: row.amount === null || row.amount === undefined ? null : Number(row.amount),
+    });
+  }
+  return map;
+}
+
+async function listEventSponsorshipsForSponsor({ sponsorId, eventIds = [] }) {
+  await ensureSchema();
+  if (!Array.isArray(eventIds) || !eventIds.length) {
+    return new Map();
+  }
+  const result = await pool.query(
+    `
+      SELECT *
+      FROM sponsorships
+      WHERE sponsor_id = $1 AND event_id = ANY($2::UUID[])
+      ORDER BY created_at DESC
+    `,
+    [sponsorId, eventIds],
+  );
+  const map = new Map();
+  for (const row of result.rows) {
+    map.set(row.event_id, mapSponsorshipRow(row));
+  }
+  return map;
+}
+
+async function updateSponsorshipStatus({ sponsorshipId, status }) {
+  await ensureSchema();
+  const normalized = sanitizeStatus(status, VALID_SPONSORSHIP_STATUSES);
+  if (!normalized) {
+    throw Object.assign(new Error('Invalid sponsorship status'), { statusCode: 400 });
+  }
+  const result = await pool.query(
+    `
+      UPDATE sponsorships
+      SET status = $2,
+          approved_at = CASE WHEN $2 = 'APPROVED' THEN NOW() ELSE NULL END,
+          updated_at = NOW()
+      WHERE id = $1
+      RETURNING *
+    `,
+    [sponsorshipId, normalized],
+  );
+  if (!result.rows[0]) {
+    throw Object.assign(new Error('Sponsorship not found'), { statusCode: 404 });
+  }
+  return mapSponsorshipRow(result.rows[0]);
+}
+
+async function upsertReportSnapshot({ sponsorshipId, snapshot }) {
+  await ensureSchema();
+  const result = await pool.query(
+    `
+      UPDATE sponsorships
+      SET report_snapshot = $2::JSONB,
+          updated_at = NOW()
+      WHERE id = $1
+      RETURNING *
+    `,
+    [sponsorshipId, JSON.stringify(normalizeJson(snapshot, {}))],
+  );
+  if (!result.rows[0]) {
+    throw Object.assign(new Error('Sponsorship not found'), { statusCode: 404 });
+  }
+  return mapSponsorshipRow(result.rows[0]);
+}
+
+async function markReportDelivered({ sponsorId }) {
+  await ensureSchema();
+  const result = await pool.query(
+    `
+      UPDATE sponsor_profiles
+      SET last_report_sent_at = NOW(), updated_at = NOW()
+      WHERE user_id = $1
+      RETURNING *
+    `,
+    [sponsorId],
+  );
+  return mapProfileRow(result.rows[0]);
+}
+
+module.exports = {
+  ensureSchema,
+  applySponsorProfile,
+  updateSponsorProfile,
+  findSponsorProfile,
+  listSponsorProfiles,
+  setSponsorStatus,
+  createSponsorship,
+  listSponsorshipsForSponsor,
+  listApprovedEventSponsors,
+  listEventSponsorshipsForSponsor,
+  updateSponsorshipStatus,
+  upsertReportSnapshot,
+  markReportDelivered,
+};

--- a/backend/src/features/sponsors/sponsor.route.js
+++ b/backend/src/features/sponsors/sponsor.route.js
@@ -1,0 +1,151 @@
+const express = require('express');
+const { authenticate, authorizeRoles } = require('../auth/auth.middleware');
+const {
+  applyForSponsor,
+  getSponsorProfile,
+  updateProfile,
+  listSponsorApplications,
+  updateSponsorApproval,
+  pledgeSponsorship,
+  listSponsorSponsorships,
+  updateSponsorshipApproval,
+  getSponsorDashboard,
+  getSponsorReports,
+} = require('./sponsor.service');
+
+const router = express.Router();
+const authOnly = authenticate();
+const adminOnly = authorizeRoles('ADMIN');
+const uuidPattern = /^[0-9a-fA-F-]{36}$/;
+
+router.post('/sponsors/apply', authOnly, async (req, res) => {
+  try {
+    const profile = await applyForSponsor({
+      userId: req.user.id,
+      orgName: req.body?.orgName,
+      website: req.body?.website,
+      logoUrl: req.body?.logoUrl,
+      contactName: req.body?.contactName,
+      contactEmail: req.body?.contactEmail,
+      contactPhone: req.body?.contactPhone,
+      brandAssets: req.body?.brandAssets,
+    });
+    res.status(201).json({ profile });
+  } catch (error) {
+    const status = error.statusCode || 500;
+    res.status(status).json({ error: error.message });
+  }
+});
+
+router.get('/sponsors/me', authOnly, async (req, res) => {
+  try {
+    const profile = await getSponsorProfile(req.user.id);
+    res.json({ profile });
+  } catch (error) {
+    const status = error.statusCode || 500;
+    res.status(status).json({ error: error.message });
+  }
+});
+
+router.patch('/sponsors/me', authOnly, async (req, res) => {
+  try {
+    const profile = await updateProfile({ userId: req.user.id, updates: req.body || {} });
+    res.json({ profile });
+  } catch (error) {
+    const status = error.statusCode || 500;
+    res.status(status).json({ error: error.message });
+  }
+});
+
+router.get('/sponsors/me/sponsorships', authOnly, async (req, res) => {
+  try {
+    const sponsorships = await listSponsorSponsorships(req.user.id);
+    res.json({ sponsorships });
+  } catch (error) {
+    const status = error.statusCode || 500;
+    res.status(status).json({ error: error.message });
+  }
+});
+
+router.get('/sponsors/me/dashboard', authOnly, async (req, res) => {
+  try {
+    const dashboard = await getSponsorDashboard({ sponsorId: req.user.id });
+    res.json(dashboard);
+  } catch (error) {
+    const status = error.statusCode || 500;
+    res.status(status).json({ error: error.message });
+  }
+});
+
+router.get('/sponsors/me/reports', authOnly, async (req, res) => {
+  try {
+    const reports = await getSponsorReports({ sponsorId: req.user.id });
+    res.json(reports);
+  } catch (error) {
+    const status = error.statusCode || 500;
+    res.status(status).json({ error: error.message });
+  }
+});
+
+router.post('/events/:eventId/sponsor', authOnly, async (req, res) => {
+  try {
+    const { eventId } = req.params;
+    if (!uuidPattern.test(eventId)) {
+      return res.status(400).json({ error: 'Invalid event identifier' });
+    }
+    const sponsorship = await pledgeSponsorship({
+      sponsorId: req.user.id,
+      eventId,
+      type: req.body?.type,
+      amount: req.body?.amount,
+      notes: req.body?.notes,
+    });
+    res.status(201).json({ sponsorship });
+  } catch (error) {
+    const status = error.statusCode || 500;
+    res.status(status).json({ error: error.message });
+  }
+});
+
+router.get('/sponsors/applications', authOnly, adminOnly, async (_req, res) => {
+  try {
+    const applications = await listSponsorApplications({});
+    res.json({ applications });
+  } catch (error) {
+    const status = error.statusCode || 500;
+    res.status(status).json({ error: error.message });
+  }
+});
+
+router.patch('/sponsors/:sponsorId/status', authOnly, adminOnly, async (req, res) => {
+  try {
+    const { sponsorId } = req.params;
+    if (!uuidPattern.test(sponsorId)) {
+      return res.status(400).json({ error: 'Invalid sponsor identifier' });
+    }
+    const profile = await updateSponsorApproval({ sponsorId, status: req.body?.status });
+    res.json({ profile });
+  } catch (error) {
+    const status = error.statusCode || 500;
+    res.status(status).json({ error: error.message });
+  }
+});
+
+router.patch('/sponsorships/:sponsorshipId/status', authOnly, adminOnly, async (req, res) => {
+  try {
+    const { sponsorshipId } = req.params;
+    if (!uuidPattern.test(sponsorshipId)) {
+      return res.status(400).json({ error: 'Invalid sponsorship identifier' });
+    }
+    const sponsorship = await updateSponsorshipApproval({ sponsorshipId, status: req.body?.status });
+    res.json({ sponsorship });
+  } catch (error) {
+    const status = error.statusCode || 500;
+    res.status(status).json({ error: error.message });
+  }
+});
+
+module.exports = {
+  basePath: '/api',
+  router,
+};

--- a/backend/src/features/sponsors/sponsor.service.js
+++ b/backend/src/features/sponsors/sponsor.service.js
@@ -1,0 +1,551 @@
+const logger = require('../../utils/logger');
+const config = require('../../config');
+const {
+  applySponsorProfile,
+  updateSponsorProfile,
+  findSponsorProfile,
+  listSponsorProfiles,
+  setSponsorStatus,
+  createSponsorship,
+  listSponsorshipsForSponsor,
+  listApprovedEventSponsors,
+  listEventSponsorshipsForSponsor,
+  updateSponsorshipStatus,
+  upsertReportSnapshot,
+  markReportDelivered,
+} = require('./sponsor.repository');
+const { findUserById, replaceUserRoles } = require('../auth/auth.repository');
+const { generateEventReport, findEventById } = require('../event-management/eventManagement.repository');
+const { getGalleryMetrics } = require('../event-gallery/eventGallery.repository');
+const { sendTemplatedEmail } = require('../email/email.service');
+
+const APP_BASE_URL = config.app?.baseUrl || 'https://onkur.example.com';
+
+function createHttpError(statusCode, message) {
+  const error = new Error(message);
+  error.statusCode = statusCode;
+  return error;
+}
+
+function sanitizeString(value) {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  const trimmed = String(value).trim();
+  return trimmed.length ? trimmed : null;
+}
+
+function sanitizeBrandAssets(payload) {
+  if (!payload || typeof payload !== 'object') {
+    return {};
+  }
+  const { guidelines, colors, files } = payload;
+  const result = {};
+  if (guidelines !== undefined && guidelines !== null) {
+    const text = String(guidelines).trim();
+    if (text.length) {
+      result.guidelines = text;
+    }
+  }
+  if (Array.isArray(colors)) {
+    result.colors = colors
+      .map((entry) => String(entry || '').trim())
+      .filter((entry) => entry.length);
+  }
+  if (Array.isArray(files)) {
+    result.files = files
+      .map((entry) => String(entry || '').trim())
+      .filter((entry) => entry.length);
+  }
+  return result;
+}
+
+function ensureSponsorRole(user) {
+  const roles = Array.isArray(user.roles) && user.roles.length ? [...user.roles] : user.role ? [user.role] : [];
+  if (!roles.includes('SPONSOR')) {
+    roles.push('SPONSOR');
+  }
+  return roles;
+}
+
+async function applyForSponsor({
+  userId,
+  orgName,
+  website,
+  logoUrl,
+  contactName,
+  contactEmail,
+  contactPhone,
+  brandAssets,
+}) {
+  if (!userId) {
+    throw createHttpError(401, 'Authentication required');
+  }
+  const normalizedOrgName = sanitizeString(orgName);
+  if (!normalizedOrgName) {
+    throw createHttpError(400, 'Organization name is required');
+  }
+  const user = await findUserById(userId);
+  if (!user) {
+    throw createHttpError(404, 'User not found');
+  }
+
+  const profile = await applySponsorProfile({
+    userId,
+    orgName: normalizedOrgName,
+    website: sanitizeString(website),
+    logoUrl: sanitizeString(logoUrl),
+    contactName: sanitizeString(contactName) || sanitizeString(user.name) || normalizedOrgName,
+    contactEmail: sanitizeString(contactEmail) || user.email,
+    contactPhone: sanitizeString(contactPhone),
+    brandAssets: sanitizeBrandAssets(brandAssets),
+  });
+
+  const desiredRoles = ensureSponsorRole(user);
+  if (desiredRoles.length !== (user.roles || []).length || !desiredRoles.every((role, index) => role === (user.roles || [])[index])) {
+    try {
+      await replaceUserRoles({ userId, roles: desiredRoles });
+    } catch (error) {
+      logger.warn('Failed to refresh roles while applying as sponsor', { userId, error: error.message });
+    }
+  }
+
+  logger.info('Sponsor application submitted', { userId, orgName: normalizedOrgName });
+  return profile;
+}
+
+async function getSponsorProfile(userId) {
+  if (!userId) {
+    throw createHttpError(401, 'Authentication required');
+  }
+  const profile = await findSponsorProfile(userId);
+  if (!profile) {
+    throw createHttpError(404, 'Sponsor profile not found');
+  }
+  return profile;
+}
+
+async function updateProfile({ userId, updates }) {
+  if (!userId) {
+    throw createHttpError(401, 'Authentication required');
+  }
+  const profile = await findSponsorProfile(userId);
+  if (!profile) {
+    throw createHttpError(404, 'Sponsor profile not found');
+  }
+  const user = await findUserById(userId);
+  const next = await updateSponsorProfile(userId, {
+    orgName: updates.orgName !== undefined ? sanitizeString(updates.orgName) : undefined,
+    website: updates.website !== undefined ? sanitizeString(updates.website) : undefined,
+    logoUrl: updates.logoUrl !== undefined ? sanitizeString(updates.logoUrl) : undefined,
+    contactName: updates.contactName !== undefined ? sanitizeString(updates.contactName) : undefined,
+    contactEmail:
+      updates.contactEmail !== undefined
+        ? sanitizeString(updates.contactEmail) || user?.email
+        : undefined,
+    contactPhone: updates.contactPhone !== undefined ? sanitizeString(updates.contactPhone) : undefined,
+    brandAssets: updates.brandAssets !== undefined ? sanitizeBrandAssets(updates.brandAssets) : undefined,
+  });
+  logger.info('Sponsor profile updated', { userId });
+  return next;
+}
+
+async function listSponsorApplications({ statuses }) {
+  return listSponsorProfiles({ statuses });
+}
+
+async function resolveSponsorContact(profile) {
+  if (!profile) {
+    return { email: null, name: null };
+  }
+  let user = null;
+  try {
+    user = await findUserById(profile.userId);
+  } catch (error) {
+    logger.warn('Failed to resolve sponsor user contact', { sponsorId: profile.userId, error: error.message });
+  }
+  const email = sanitizeString(profile.contactEmail) || (user ? user.email : null);
+  const name =
+    sanitizeString(profile.contactName) ||
+    (user ? sanitizeString(user.name) : null) ||
+    profile.orgName ||
+    'Sponsor';
+  return { email, name };
+}
+
+async function updateSponsorApproval({ sponsorId, status }) {
+  const profile = await setSponsorStatus({ userId: sponsorId, status });
+  const contact = await resolveSponsorContact(profile);
+  if (profile.status === 'APPROVED' && contact.email) {
+    try {
+      await sendTemplatedEmail({
+        to: contact.email,
+        subject: 'Your sponsorship workspace is live',
+        heading: 'Welcome aboard! 🌿',
+        bodyLines: [
+          `Hi ${contact.name},`,
+          'Your sponsor application has been approved. You can now pledge support to events and see your impact grow.',
+        ],
+        cta: {
+          url: `${APP_BASE_URL}/app`,
+          label: 'Open your dashboard',
+        },
+        previewText: 'Your sponsor access is unlocked',
+      });
+    } catch (error) {
+      logger.warn('Failed to send sponsor approval email', { sponsorId, error: error.message });
+    }
+  } else if (profile.status === 'DECLINED' && contact.email) {
+    try {
+      await sendTemplatedEmail({
+        to: contact.email,
+        subject: 'Sponsor application update',
+        heading: 'Thanks for applying',
+        bodyLines: [
+          `Hi ${contact.name},`,
+          'Thank you for offering to sponsor Onkur experiences. At this time we are unable to approve the application.',
+          'Reply to this email if you would like feedback or want to share updated information.',
+        ],
+        cta: null,
+        previewText: 'Sponsor application update from Onkur',
+      });
+    } catch (error) {
+      logger.warn('Failed to send sponsor decline email', { sponsorId, error: error.message });
+    }
+  }
+  return profile;
+}
+
+function normalizeSponsorshipType(type) {
+  if (!type) return null;
+  const value = String(type).trim().toUpperCase();
+  return value === 'FUNDS' || value === 'IN_KIND' ? value : null;
+}
+
+async function pledgeSponsorship({ sponsorId, eventId, type, amount, notes }) {
+  const profile = await findSponsorProfile(sponsorId);
+  if (!profile) {
+    throw createHttpError(400, 'Sponsor profile is required before pledging');
+  }
+  const event = await findEventById(eventId);
+  if (!event) {
+    throw createHttpError(404, 'Event not found');
+  }
+  if (event.status !== 'PUBLISHED' && event.status !== 'COMPLETED') {
+    throw createHttpError(400, 'Only active events can receive sponsorships');
+  }
+  const normalizedType = normalizeSponsorshipType(type);
+  if (!normalizedType) {
+    throw createHttpError(400, 'Sponsorship type must be FUNDS or IN_KIND');
+  }
+  let normalizedAmount = null;
+  if (normalizedType === 'FUNDS') {
+    const numericAmount = Number(amount);
+    if (!Number.isFinite(numericAmount) || numericAmount <= 0) {
+      throw createHttpError(400, 'Funds sponsorships require a positive amount');
+    }
+    normalizedAmount = Math.round(numericAmount * 100) / 100;
+  } else if (amount !== undefined && amount !== null) {
+    const numericAmount = Number(amount);
+    if (Number.isFinite(numericAmount) && numericAmount >= 0) {
+      normalizedAmount = Math.round(numericAmount * 100) / 100;
+    }
+  }
+
+  const sponsorship = await createSponsorship({
+    sponsorId,
+    eventId,
+    type: normalizedType,
+    amount: normalizedAmount,
+    notes: sanitizeString(notes),
+    status: profile.status === 'APPROVED' ? 'PENDING' : 'PENDING',
+  });
+
+  const contact = await resolveSponsorContact(profile);
+
+  if (contact.email) {
+    try {
+      await sendTemplatedEmail({
+        to: contact.email,
+        subject: `Thanks for pledging support for ${event.title}`,
+        heading: 'We received your pledge',
+        bodyLines: [
+        `Hi ${contact.name},`,
+        `Thank you for offering ${normalizedType === 'FUNDS' ? `₹${normalizedAmount?.toLocaleString('en-IN')}` : 'in-kind resources'} to <strong>${event.title}</strong>.`,
+        'Our team will review and confirm the sponsorship shortly.',
+        ],
+        cta: {
+          url: `${APP_BASE_URL}/app`,
+          label: 'Track your sponsorships',
+        },
+        previewText: 'We received your sponsorship pledge',
+      });
+    } catch (error) {
+      logger.warn('Failed to send sponsorship pledge email', {
+        sponsorId,
+        sponsorshipId: sponsorship.id,
+        error: error.message,
+      });
+    }
+  }
+
+  logger.info('Sponsor pledged event support', {
+    sponsorId,
+    eventId,
+    type: sponsorship.type,
+    amount: sponsorship.amount,
+  });
+
+  return sponsorship;
+}
+
+async function listSponsorSponsorships(sponsorId) {
+  return listSponsorshipsForSponsor(sponsorId);
+}
+
+async function updateSponsorshipApproval({ sponsorshipId, status }) {
+  const sponsorship = await updateSponsorshipStatus({ sponsorshipId, status });
+  const profile = await findSponsorProfile(sponsorship.sponsorId);
+  let event = null;
+  try {
+    event = await findEventById(sponsorship.eventId);
+  } catch (error) {
+    logger.warn('Unable to load event while notifying sponsorship status change', {
+      sponsorshipId,
+      eventId: sponsorship.eventId,
+      error: error.message,
+    });
+  }
+
+  if (profile) {
+    const contact = await resolveSponsorContact(profile);
+    if (contact.email && sponsorship.status === 'APPROVED') {
+      try {
+        await sendTemplatedEmail({
+          to: contact.email,
+          subject: `Your sponsorship for ${event?.title || 'an Onkur event'} is confirmed`,
+          heading: 'Sponsorship confirmed',
+          bodyLines: [
+            `Hi ${contact.name},`,
+            `Your ${sponsorship.type === 'FUNDS' ? 'financial' : 'in-kind'} sponsorship for <strong>${event?.title || 'the event'}</strong> is confirmed.`,
+            'You can expect shout-outs on the event page and gallery as soon as stories go live.',
+          ],
+          cta: {
+            url: `${APP_BASE_URL}/app`,
+            label: 'View sponsorship dashboard',
+          },
+          previewText: 'Sponsorship confirmed',
+        });
+      } catch (error) {
+        logger.warn('Failed to send sponsorship approval email', { sponsorshipId, error: error.message });
+      }
+    } else if (contact.email && sponsorship.status === 'DECLINED') {
+      try {
+        await sendTemplatedEmail({
+          to: contact.email,
+          subject: `Update on your sponsorship for ${event?.title || 'an Onkur event'}`,
+          heading: 'Sponsorship update',
+          bodyLines: [
+            `Hi ${contact.name},`,
+            'We are unable to accept this sponsorship at this time. Thank you for offering your support.',
+          ],
+          cta: null,
+          previewText: 'Update on your sponsorship',
+        });
+      } catch (error) {
+        logger.warn('Failed to send sponsorship decline email', { sponsorshipId, error: error.message });
+      }
+    }
+  }
+
+  return sponsorship;
+}
+
+async function buildEventImpact(eventId) {
+  const report = await generateEventReport(eventId);
+  const metrics = await getGalleryMetrics(eventId);
+  return {
+    event: report.event,
+    totals: report.totals,
+    storedReport: report.storedReport,
+    gallery: metrics,
+  };
+}
+
+function computeRoi({ sponsorship, totals, gallery }) {
+  const hours = Number(totals.totalHours || 0);
+  const amount = sponsorship.amount || 0;
+  const impressions = Number(gallery.viewCount || 0);
+  const roi = {
+    costPerHour: null,
+    impressionsPerHour: null,
+  };
+  if (hours > 0 && amount) {
+    roi.costPerHour = Math.round((amount / hours) * 100) / 100;
+  }
+  if (hours > 0 && impressions) {
+    roi.impressionsPerHour = Math.round((impressions / hours) * 100) / 100;
+  }
+  return roi;
+}
+
+async function getSponsorDashboard({ sponsorId }) {
+  const profile = await findSponsorProfile(sponsorId);
+  if (!profile) {
+    throw createHttpError(404, 'Sponsor profile not found');
+  }
+  const sponsorships = await listSponsorshipsForSponsor(sponsorId);
+  const approvedSponsorships = sponsorships.filter((item) => item.status === 'APPROVED');
+  const eventIds = Array.from(new Set(approvedSponsorships.map((item) => item.eventId)));
+  const impacts = new Map();
+  for (const eventId of eventIds) {
+    try {
+      impacts.set(eventId, await buildEventImpact(eventId));
+    } catch (error) {
+      logger.warn('Failed to build impact snapshot for sponsor dashboard', { sponsorId, eventId, error: error.message });
+    }
+  }
+
+  const metrics = {
+    totalApprovedSponsorships: approvedSponsorships.length,
+    totalFunds: approvedSponsorships
+      .filter((item) => item.type === 'FUNDS' && typeof item.amount === 'number')
+      .reduce((sum, item) => sum + item.amount, 0),
+    totalVolunteerHours: 0,
+    totalGalleryViews: 0,
+  };
+  for (const sponsorship of approvedSponsorships) {
+    const impact = impacts.get(sponsorship.eventId);
+    if (!impact) continue;
+    metrics.totalVolunteerHours += Number(impact.totals.totalHours || 0);
+    metrics.totalGalleryViews += Number(impact.gallery.viewCount || 0);
+  }
+  metrics.totalFunds = Math.round(metrics.totalFunds * 100) / 100;
+
+  return {
+    profile,
+    sponsorships,
+    metrics,
+  };
+}
+
+async function getSponsorReports({ sponsorId }) {
+  const profile = await findSponsorProfile(sponsorId);
+  if (!profile) {
+    throw createHttpError(404, 'Sponsor profile not found');
+  }
+  const sponsorships = await listSponsorshipsForSponsor(sponsorId);
+  const approved = sponsorships.filter((item) => item.status === 'APPROVED');
+  const reports = [];
+  for (const sponsorship of approved) {
+    try {
+      const impact = await buildEventImpact(sponsorship.eventId);
+      const roi = computeRoi({ sponsorship, totals: impact.totals, gallery: impact.gallery });
+      const snapshot = {
+        sponsorshipId: sponsorship.id,
+        event: impact.event,
+        totals: impact.totals,
+        gallery: impact.gallery,
+        contribution: {
+          type: sponsorship.type,
+          amount: sponsorship.amount,
+          notes: sponsorship.notes,
+          approvedAt: sponsorship.approvedAt,
+        },
+        roi,
+      };
+      reports.push(snapshot);
+      await upsertReportSnapshot({ sponsorshipId: sponsorship.id, snapshot });
+    } catch (error) {
+      logger.warn('Failed to compute sponsorship impact report', {
+        sponsorId,
+        sponsorshipId: sponsorship.id,
+        eventId: sponsorship.eventId,
+        error: error.message,
+      });
+    }
+  }
+
+  if (reports.length) {
+    const totalHours = reports.reduce((sum, report) => sum + Number(report.totals.totalHours || 0), 0);
+    const totalViews = reports.reduce((sum, report) => sum + Number(report.gallery.viewCount || 0), 0);
+    const totalFunds = reports
+      .filter((report) => report.contribution.type === 'FUNDS' && typeof report.contribution.amount === 'number')
+      .reduce((sum, report) => sum + report.contribution.amount, 0);
+
+    const contact = await resolveSponsorContact(profile);
+    if (contact.email) {
+      try {
+        await sendTemplatedEmail({
+          to: contact.email,
+          subject: 'Your latest Onkur impact report',
+          heading: 'Impact snapshot ready',
+          bodyLines: [
+          `Hi ${contact.name},`,
+          `Approved sponsorships covered <strong>${reports.length}</strong> event${reports.length === 1 ? '' : 's'}.`,
+          `Volunteers delivered <strong>${Math.round(totalHours * 100) / 100}</strong> hours and the galleries earned <strong>${totalViews}</strong> views.`,
+          totalFunds
+            ? `Direct funds contributed: <strong>₹${Math.round(totalFunds * 100) / 100}</strong>.`
+            : 'In-kind support amplified every moment shared in the galleries.',
+        ],
+        cta: {
+          url: `${APP_BASE_URL}/app`,
+          label: 'Review detailed reports',
+        },
+        previewText: 'Your sponsorship impact snapshot is ready',
+        });
+        await markReportDelivered({ sponsorId });
+      } catch (error) {
+        logger.warn('Failed to send sponsor impact report email', { sponsorId, error: error.message });
+      }
+    }
+  }
+
+  return { profile, reports };
+}
+
+async function attachApprovedSponsors(events = []) {
+  const ids = Array.from(new Set(events.map((event) => event.id).filter(Boolean)));
+  if (!ids.length) {
+    return events;
+  }
+  const sponsorMap = await listApprovedEventSponsors(ids);
+  return events.map((event) => ({
+    ...event,
+    sponsors: sponsorMap.get(event.id) || [],
+  }));
+}
+
+async function attachSponsorPerspective({ events = [], sponsorId }) {
+  if (!sponsorId) {
+    return events;
+  }
+  const profile = await findSponsorProfile(sponsorId);
+  if (!profile) {
+    return events;
+  }
+  const ids = Array.from(new Set(events.map((event) => event.id).filter(Boolean)));
+  if (!ids.length) {
+    return events;
+  }
+  const contributionMap = await listEventSponsorshipsForSponsor({ sponsorId, eventIds: ids });
+  return events.map((event) => ({
+    ...event,
+    mySponsorship: contributionMap.get(event.id) || null,
+  }));
+}
+
+module.exports = {
+  applyForSponsor,
+  getSponsorProfile,
+  updateProfile,
+  listSponsorApplications,
+  updateSponsorApproval,
+  pledgeSponsorship,
+  listSponsorSponsorships,
+  updateSponsorshipApproval,
+  getSponsorDashboard,
+  getSponsorReports,
+  attachApprovedSponsors,
+  attachSponsorPerspective,
+};

--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -150,3 +150,9 @@
 
 
 
+## Phase 5 sponsor partnerships
+- **Date:** 2025-10-01
+- **Change:** Introduced the sponsor workflow end to end: sponsors apply for approval, admins moderate applications, approved sponsors pledge funds or in-kind support to events, and dashboards surface live sponsorships with ROI-ready metrics and impact reports.
+- **Impact:** Sponsors gain a dedicated workspace to support events, see their logos across event and gallery experiences, and receive automated summaries of volunteer hours, attendance, and gallery visibility tied to their contributions.
+
+

--- a/frontend/src/features/dashboard/SponsorDashboard.jsx
+++ b/frontend/src/features/dashboard/SponsorDashboard.jsx
@@ -1,12 +1,29 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import DashboardCard from './DashboardCard';
 import { useAuth } from '../auth/AuthContext';
 import useDocumentTitle from '../../lib/useDocumentTitle';
 import ProfileCompletionCallout from './ProfileCompletionCallout';
 import calculateProfileProgress from './profileProgress';
+import SponsorOnboardingForm from '../sponsors/SponsorOnboardingForm';
+import SponsorSponsorshipList from '../sponsors/SponsorSponsorshipList';
+import {
+  applyForSponsor,
+  updateSponsorProfile,
+  fetchSponsorDashboard,
+  fetchSponsorReports,
+} from '../sponsors/api';
 
 export default function SponsorDashboard() {
-  const { user } = useAuth();
+  const { token, user } = useAuth();
+  const [profile, setProfile] = useState(null);
+  const [sponsorships, setSponsorships] = useState([]);
+  const [metrics, setMetrics] = useState(null);
+  const [reports, setReports] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [reportStatus, setReportStatus] = useState({ state: 'idle', message: '' });
+  const [profileSubmitting, setProfileSubmitting] = useState(false);
+
   const firstName = user?.name?.split(' ')[0] || 'sponsor';
   useDocumentTitle(`Onkur | Thank you, ${firstName} 🌍`);
 
@@ -15,15 +32,118 @@ export default function SponsorDashboard() {
     [user?.profile]
   );
 
+  useEffect(() => {
+    if (!token) {
+      setLoading(false);
+      return;
+    }
+    let active = true;
+    setLoading(true);
+    setError('');
+    (async () => {
+      try {
+        const data = await fetchSponsorDashboard(token);
+        if (!active) return;
+        setProfile(data.profile || null);
+        setSponsorships(Array.isArray(data.sponsorships) ? data.sponsorships : []);
+        setMetrics(data.metrics || null);
+      } catch (dashError) {
+        if (!active) return;
+        setError(dashError.message || 'Unable to load sponsor dashboard.');
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, [token]);
+
+  const refreshDashboard = async () => {
+    if (!token) return;
+    setError('');
+    try {
+      const data = await fetchSponsorDashboard(token);
+      setProfile(data.profile || null);
+      setSponsorships(Array.isArray(data.sponsorships) ? data.sponsorships : []);
+      setMetrics(data.metrics || null);
+    } catch (dashError) {
+      setError(dashError.message || 'Unable to refresh sponsor dashboard.');
+    }
+  };
+
+  const handleOnboardingSubmit = async (payload) => {
+    if (!token) {
+      throw new Error('Authentication required');
+    }
+    setProfileSubmitting(true);
+    try {
+      const response = await applyForSponsor(token, payload);
+      setProfile(response.profile || response?.profile || null);
+      await refreshDashboard();
+    } catch (submissionError) {
+      throw submissionError;
+    } finally {
+      setProfileSubmitting(false);
+    }
+  };
+
+  const handleProfileUpdate = async (payload) => {
+    if (!token) {
+      throw new Error('Authentication required');
+    }
+    setProfileSubmitting(true);
+    try {
+      const response = await updateSponsorProfile(token, payload);
+      setProfile(response.profile || response?.profile || null);
+      await refreshDashboard();
+    } catch (updateError) {
+      throw updateError;
+    } finally {
+      setProfileSubmitting(false);
+    }
+  };
+
+  const handleReportRefresh = async () => {
+    if (!token) {
+      throw new Error('Authentication required');
+    }
+    setReportStatus({ state: 'loading', message: '' });
+    try {
+      const data = await fetchSponsorReports(token);
+      setReports(Array.isArray(data.reports) ? data.reports : []);
+      if (data.profile) {
+        setProfile(data.profile);
+      }
+      setReportStatus({ state: 'success', message: 'Latest impact report delivered to your inbox.' });
+    } catch (reportError) {
+      setReportStatus({ state: 'error', message: reportError.message || 'Unable to refresh reports right now.' });
+    }
+  };
+
+  const statusMessage = () => {
+    if (!profile) {
+      return 'Apply to become a sponsor so the community can celebrate you on every event.';
+    }
+    switch (profile.status) {
+      case 'APPROVED':
+        return 'Your sponsorships are live and appear across event and gallery pages.';
+      case 'DECLINED':
+        return 'We could not approve the current application. Update your details to try again.';
+      default:
+        return 'Your application is under review. We will notify you once it is approved.';
+    }
+  };
+
   return (
     <div className="grid gap-5 md:[grid-template-columns:repeat(auto-fit,minmax(280px,1fr))]">
       <header className="flex flex-col gap-2 md:col-span-full">
         <h2 className="m-0 font-display text-2xl font-semibold text-brand-forest">
           Thank you, {firstName} 🌍
         </h2>
-        <p className="m-0 text-sm text-brand-muted sm:text-base">
-          Track the visibility of your contributions and stay close to the stories your support makes possible.
-        </p>
+        <p className="m-0 text-sm text-brand-muted sm:text-base">{statusMessage()}</p>
       </header>
       <ProfileCompletionCallout
         progress={profileProgress}
@@ -31,26 +151,58 @@ export default function SponsorDashboard() {
         title="Complete your profile to spotlight your mission"
         description="Introduce your organization, causes, and recognition preferences so we can celebrate your sponsorship the right way."
       />
-      <DashboardCard
-        title="Active sponsorships"
-        description="A summary of the events and initiatives you are fueling will appear here soon."
-      >
-        <span className="inline-flex items-center gap-2 rounded-full bg-brand-sky/20 px-3 py-1 text-sm font-medium text-brand-sky">
-          💚 Impact reporting under construction
-        </span>
-      </DashboardCard>
-      <DashboardCard
-        title="Recognition toolkit"
-        description="Logos, shout-outs, and gallery spotlights will be coordinated through this workspace."
-      >
-        <p className="m-0 text-sm text-brand-muted">Set preferred visibility guidelines once the toolkit unlocks.</p>
-      </DashboardCard>
-      <DashboardCard
-        title="Impact reports"
-        description="Download snapshots of volunteer hours, stories, and carbon savings tied to your sponsorship."
-      >
-        <p className="m-0 text-sm text-brand-muted">Analytics pipelines are being seeded for upcoming phases.</p>
-      </DashboardCard>
+      {error ? (
+        <p className="md:col-span-full m-0 rounded-2xl border border-red-200 bg-red-50 p-4 text-sm text-red-700">{error}</p>
+      ) : null}
+      {loading ? (
+        <p className="md:col-span-full m-0 text-sm text-brand-muted">Loading sponsor workspace…</p>
+      ) : null}
+      {(!profile || profile.status !== 'APPROVED') && !loading ? (
+        <SponsorOnboardingForm
+          initialValues={profile || {}}
+          onSubmit={profile ? handleProfileUpdate : handleOnboardingSubmit}
+          isSubmitting={profileSubmitting}
+          ctaLabel={profile ? 'Update sponsor profile' : 'Submit sponsor application'}
+        />
+      ) : null}
+      {profile && profile.status === 'APPROVED' ? (
+        <SponsorSponsorshipList sponsorships={sponsorships} metrics={metrics} />
+      ) : null}
+      {profile && profile.status === 'APPROVED' ? (
+        <DashboardCard
+          title="Impact reports"
+          description="Refresh the latest volunteer hours and gallery views tied to your sponsorships."
+        >
+          <div className="flex flex-col gap-3">
+            <button
+              type="button"
+              className="btn-primary w-full sm:w-auto"
+              onClick={handleReportRefresh}
+              disabled={reportStatus.state === 'loading'}
+            >
+              {reportStatus.state === 'loading' ? 'Refreshing…' : 'Email me an updated report'}
+            </button>
+            {reportStatus.state === 'error' ? (
+              <p className="m-0 rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-700">{reportStatus.message}</p>
+            ) : null}
+            {reportStatus.state === 'success' ? (
+              <p className="m-0 rounded-xl border border-brand-green/20 bg-brand-sand/70 p-3 text-sm text-brand-forest">
+                {reportStatus.message}
+              </p>
+            ) : null}
+            {reports.length ? (
+              <ul className="m-0 list-disc space-y-2 pl-5 text-sm text-brand-muted">
+                {reports.map((report) => (
+                  <li key={report.sponsorshipId}>
+                    {report.event?.title || 'Sponsored event'} · {report.totals?.totalHours || 0} volunteer hours ·{' '}
+                    {report.gallery?.viewCount || 0} gallery views
+                  </li>
+                ))}
+              </ul>
+            ) : null}
+          </div>
+        </DashboardCard>
+      ) : null}
     </div>
   );
 }

--- a/frontend/src/features/event-gallery/EventGalleryViewer.jsx
+++ b/frontend/src/features/event-gallery/EventGalleryViewer.jsx
@@ -179,6 +179,21 @@ export default function EventGalleryViewer({ eventId, token, refreshSignal = 0 }
             {eventInfo.category ? `${eventInfo.category} · ` : ''}
             {eventInfo.theme || 'Gallery story'}
           </p>
+          {Array.isArray(eventInfo.sponsors) && eventInfo.sponsors.length ? (
+            <div className="flex flex-wrap items-center gap-2">
+              {eventInfo.sponsors.map((sponsor) => (
+                <span
+                  key={sponsor.sponsorId || sponsor.orgName}
+                  className="inline-flex items-center gap-2 rounded-full bg-brand-sand px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-brand-forest"
+                >
+                  {sponsor.logoUrl ? (
+                    <img src={sponsor.logoUrl} alt={sponsor.orgName} className="h-5 w-5 rounded-full object-cover" />
+                  ) : null}
+                  {sponsor.orgName}
+                </span>
+              ))}
+            </div>
+          ) : null}
         </header>
       ) : null}
       {status === 'error' ? (

--- a/frontend/src/features/event-gallery/PublicGalleryPage.jsx
+++ b/frontend/src/features/event-gallery/PublicGalleryPage.jsx
@@ -68,6 +68,26 @@ export default function PublicGalleryPage() {
                 {event.mediaCount} photos · {event.theme || 'Community impact'}
               </p>
               <p className="m-0 text-sm text-brand-muted">{event.location || 'Across our communities'}</p>
+              {Array.isArray(event.sponsors) && event.sponsors.length ? (
+                <div className="flex flex-wrap items-center gap-2">
+                  {event.sponsors.slice(0, 3).map((sponsor) => (
+                    <span
+                      key={sponsor.sponsorId || sponsor.orgName}
+                      className="inline-flex items-center gap-2 rounded-full bg-brand-sand px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-brand-forest"
+                    >
+                      {sponsor.logoUrl ? (
+                        <img src={sponsor.logoUrl} alt={sponsor.orgName} className="h-5 w-5 rounded-full object-cover" />
+                      ) : null}
+                      {sponsor.orgName}
+                    </span>
+                  ))}
+                  {event.sponsors.length > 3 ? (
+                    <span className="rounded-full bg-brand-sand px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-brand-forest">
+                      +{event.sponsors.length - 3}
+                    </span>
+                  ) : null}
+                </div>
+              ) : null}
             </button>
           ))}
         </div>

--- a/frontend/src/features/sponsors/AGENTS.md
+++ b/frontend/src/features/sponsors/AGENTS.md
@@ -1,0 +1,9 @@
+# Sponsors Feature Frontend Guidelines
+
+These notes apply to files within `frontend/src/features/sponsors/`.
+
+- Keep sponsor workflows mobile-first and rely on the shared earthy brown palette—reuse dashboard card shells where possible.
+- API helpers in this folder should wrap `apiRequest` and always return parsed JSON objects without mutating global auth state.
+- Dialogs or forms should lean on lightweight `useState` hooks; avoid bringing in modal libraries so the bundle stays lean.
+- When presenting impact metrics, favour succinct labels ("Volunteer hours", "Gallery views") and format numbers for Indian locales.
+- Always expose an `isSubmitting` prop on forms so buttons can reflect loading states during async sponsor mutations.

--- a/frontend/src/features/sponsors/SponsorImpactSummary.jsx
+++ b/frontend/src/features/sponsors/SponsorImpactSummary.jsx
@@ -1,0 +1,48 @@
+const numberFormatter = new Intl.NumberFormat('en-IN', { maximumFractionDigits: 2 });
+
+function MetricCard({ label, value, icon }) {
+  return (
+    <div className="flex flex-col gap-2 rounded-3xl border border-brand-forest/15 bg-brand-sand/60 p-4 shadow-sm">
+      <span className="text-2xl" aria-hidden="true">
+        {icon}
+      </span>
+      <span className="text-xs font-semibold uppercase tracking-[0.24em] text-brand-muted">{label}</span>
+      <span className="text-lg font-semibold text-brand-forest">{value}</span>
+    </div>
+  );
+}
+
+export default function SponsorImpactSummary({ metrics }) {
+  if (!metrics) {
+    return null;
+  }
+  const cards = [
+    {
+      label: 'Active sponsorships',
+      value: numberFormatter.format(metrics.totalApprovedSponsorships || 0),
+      icon: '🤝',
+    },
+    {
+      label: 'Volunteer hours',
+      value: numberFormatter.format(metrics.totalVolunteerHours || 0),
+      icon: '⏱️',
+    },
+    {
+      label: 'Gallery views',
+      value: numberFormatter.format(metrics.totalGalleryViews || 0),
+      icon: '📸',
+    },
+    {
+      label: 'Funds pledged (₹)',
+      value: numberFormatter.format(metrics.totalFunds || 0),
+      icon: '💰',
+    },
+  ];
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      {cards.map((card) => (
+        <MetricCard key={card.label} {...card} />
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/features/sponsors/SponsorOnboardingForm.jsx
+++ b/frontend/src/features/sponsors/SponsorOnboardingForm.jsx
@@ -1,0 +1,165 @@
+import { useEffect, useState } from 'react';
+
+const DEFAULT_VALUES = {
+  orgName: '',
+  website: '',
+  logoUrl: '',
+  contactName: '',
+  contactEmail: '',
+  contactPhone: '',
+  brandGuidelines: '',
+};
+
+export default function SponsorOnboardingForm({ initialValues, onSubmit, isSubmitting, ctaLabel = 'Submit application' }) {
+  const [form, setForm] = useState(DEFAULT_VALUES);
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+
+  useEffect(() => {
+    if (!initialValues) {
+      setForm(DEFAULT_VALUES);
+      return;
+    }
+    setForm({
+      orgName: initialValues.orgName || '',
+      website: initialValues.website || '',
+      logoUrl: initialValues.logoUrl || '',
+      contactName: initialValues.contactName || '',
+      contactEmail: initialValues.contactEmail || '',
+      contactPhone: initialValues.contactPhone || '',
+      brandGuidelines:
+        initialValues.brandAssets && initialValues.brandAssets.guidelines
+          ? initialValues.brandAssets.guidelines
+          : '',
+    });
+  }, [initialValues]);
+
+  const handleChange = (event) => {
+    const { name, value } = event.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setError('');
+    setSuccess('');
+    if (!form.orgName.trim()) {
+      setError('Organization name is required.');
+      return;
+    }
+    try {
+      await onSubmit?.({
+        orgName: form.orgName.trim(),
+        website: form.website.trim() || undefined,
+        logoUrl: form.logoUrl.trim() || undefined,
+        contactName: form.contactName.trim() || undefined,
+        contactEmail: form.contactEmail.trim() || undefined,
+        contactPhone: form.contactPhone.trim() || undefined,
+        brandAssets: {
+          guidelines: form.brandGuidelines.trim(),
+        },
+      });
+      setSuccess('Details saved. We will keep you updated.');
+    } catch (submissionError) {
+      setError(submissionError.message || 'Unable to save sponsor details.');
+    }
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="flex flex-col gap-4 rounded-3xl border border-brand-forest/15 bg-white p-5 shadow-[0_20px_40px_rgba(47,133,90,0.08)]"
+    >
+      <div className="grid gap-4 sm:[grid-template-columns:repeat(2,minmax(0,1fr))]">
+        <label className="flex flex-col gap-2 text-sm">
+          <span className="font-semibold text-brand-forest">Organization name</span>
+          <input
+            type="text"
+            name="orgName"
+            required
+            value={form.orgName}
+            onChange={handleChange}
+            className="rounded-lg border border-brand-forest/20 bg-brand-sand/40 px-3 py-2 text-sm shadow-sm focus:border-brand-green focus:outline-none"
+            placeholder="Your brand"
+          />
+        </label>
+        <label className="flex flex-col gap-2 text-sm">
+          <span className="font-semibold text-brand-forest">Website</span>
+          <input
+            type="url"
+            name="website"
+            value={form.website}
+            onChange={handleChange}
+            className="rounded-lg border border-brand-forest/20 bg-brand-sand/40 px-3 py-2 text-sm shadow-sm focus:border-brand-green focus:outline-none"
+            placeholder="https://example.org"
+          />
+        </label>
+        <label className="flex flex-col gap-2 text-sm">
+          <span className="font-semibold text-brand-forest">Primary contact name</span>
+          <input
+            type="text"
+            name="contactName"
+            value={form.contactName}
+            onChange={handleChange}
+            className="rounded-lg border border-brand-forest/20 bg-brand-sand/40 px-3 py-2 text-sm shadow-sm focus:border-brand-green focus:outline-none"
+            placeholder="Who should we thank?"
+          />
+        </label>
+        <label className="flex flex-col gap-2 text-sm">
+          <span className="font-semibold text-brand-forest">Contact email</span>
+          <input
+            type="email"
+            name="contactEmail"
+            value={form.contactEmail}
+            onChange={handleChange}
+            className="rounded-lg border border-brand-forest/20 bg-brand-sand/40 px-3 py-2 text-sm shadow-sm focus:border-brand-green focus:outline-none"
+            placeholder="team@example.org"
+          />
+        </label>
+        <label className="flex flex-col gap-2 text-sm">
+          <span className="font-semibold text-brand-forest">Contact phone</span>
+          <input
+            type="tel"
+            name="contactPhone"
+            value={form.contactPhone}
+            onChange={handleChange}
+            className="rounded-lg border border-brand-forest/20 bg-brand-sand/40 px-3 py-2 text-sm shadow-sm focus:border-brand-green focus:outline-none"
+            placeholder="+91"
+          />
+        </label>
+        <label className="flex flex-col gap-2 text-sm">
+          <span className="font-semibold text-brand-forest">Logo URL</span>
+          <input
+            type="url"
+            name="logoUrl"
+            value={form.logoUrl}
+            onChange={handleChange}
+            className="rounded-lg border border-brand-forest/20 bg-brand-sand/40 px-3 py-2 text-sm shadow-sm focus:border-brand-green focus:outline-none"
+            placeholder="https://.../logo.png"
+          />
+        </label>
+      </div>
+      <label className="flex flex-col gap-2 text-sm">
+        <span className="font-semibold text-brand-forest">Brand guidelines</span>
+        <textarea
+          name="brandGuidelines"
+          rows={4}
+          value={form.brandGuidelines}
+          onChange={handleChange}
+          className="rounded-lg border border-brand-forest/20 bg-brand-sand/40 px-3 py-2 text-sm shadow-sm focus:border-brand-green focus:outline-none"
+          placeholder="Recognition preferences, tone, hero statements"
+        />
+      </label>
+      {error ? <p className="m-0 rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-700">{error}</p> : null}
+      {success ? <p className="m-0 rounded-xl border border-brand-green/20 bg-brand-sand/70 p-3 text-sm text-brand-forest">{success}</p> : null}
+      <div className="flex flex-wrap items-center gap-3">
+        <button type="submit" className="btn-primary" disabled={isSubmitting}>
+          {isSubmitting ? 'Saving…' : ctaLabel}
+        </button>
+        <span className="text-xs text-brand-muted">
+          We review every sponsor to keep the community trusted.
+        </span>
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/features/sponsors/SponsorSponsorshipList.jsx
+++ b/frontend/src/features/sponsors/SponsorSponsorshipList.jsx
@@ -1,0 +1,97 @@
+import SponsorImpactSummary from './SponsorImpactSummary';
+
+const numberFormatter = new Intl.NumberFormat('en-IN', { maximumFractionDigits: 2 });
+
+function StatusBadge({ status }) {
+  const normalized = (status || '').toUpperCase();
+  const tone =
+    normalized === 'APPROVED'
+      ? 'bg-brand-forest/10 text-brand-forest'
+      : normalized === 'DECLINED'
+      ? 'bg-red-100 text-red-700'
+      : 'bg-brand-sand text-brand-muted';
+  return (
+    <span className={`inline-flex items-center gap-1 rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] ${tone}`}>
+      {normalized}
+    </span>
+  );
+}
+
+function ContributionDetails({ sponsorship }) {
+  if (!sponsorship) {
+    return null;
+  }
+  const report = sponsorship.reportSnapshot || sponsorship.report_snapshot || null;
+  return (
+    <div className="flex flex-col gap-3 rounded-3xl border border-brand-forest/10 bg-white/80 p-4">
+      <header className="flex flex-col gap-1">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <h4 className="m-0 text-base font-semibold text-brand-forest">{sponsorship.event?.title || 'Sponsored event'}</h4>
+          <StatusBadge status={sponsorship.status} />
+        </div>
+        <p className="m-0 text-xs uppercase tracking-[0.22em] text-brand-muted">
+          {sponsorship.type === 'FUNDS' ? 'Financial support' : 'In-kind support'}
+          {typeof sponsorship.amount === 'number'
+            ? ` · ₹${numberFormatter.format(sponsorship.amount)}`
+            : ''}
+        </p>
+        <p className="m-0 text-xs text-brand-muted">
+          {sponsorship.event?.location || 'Across our communities'}
+        </p>
+      </header>
+      {report ? (
+        <dl className="grid gap-3 text-xs text-brand-muted sm:grid-cols-2">
+          <div>
+            <dt className="font-semibold text-brand-forest">Volunteer hours</dt>
+            <dd className="m-0">{numberFormatter.format(report.totals?.totalHours || 0)}</dd>
+          </div>
+          <div>
+            <dt className="font-semibold text-brand-forest">Gallery views</dt>
+            <dd className="m-0">{numberFormatter.format(report.gallery?.viewCount || 0)}</dd>
+          </div>
+          <div>
+            <dt className="font-semibold text-brand-forest">Attendance rate</dt>
+            <dd className="m-0">
+              {report.totals?.attendanceRate
+                ? `${numberFormatter.format(report.totals.attendanceRate * 100)}%`
+                : '–'}
+            </dd>
+          </div>
+          <div>
+            <dt className="font-semibold text-brand-forest">Cost per hour</dt>
+            <dd className="m-0">
+              {report.roi?.costPerHour ? `₹${numberFormatter.format(report.roi.costPerHour)}` : '–'}
+            </dd>
+          </div>
+        </dl>
+      ) : (
+        <p className="m-0 rounded-xl border border-dashed border-brand-forest/20 bg-brand-sand/50 p-3 text-xs text-brand-muted">
+          Impact report will appear after the event wraps up.
+        </p>
+      )}
+      {sponsorship.notes ? (
+        <p className="m-0 text-xs text-brand-muted">{sponsorship.notes}</p>
+      ) : null}
+    </div>
+  );
+}
+
+export default function SponsorSponsorshipList({ sponsorships, metrics }) {
+  if (!Array.isArray(sponsorships) || !sponsorships.length) {
+    return (
+      <div className="rounded-3xl border border-dashed border-brand-forest/20 bg-white/80 p-5 text-sm text-brand-muted">
+        Once your sponsorships are confirmed they will appear here with live metrics.
+      </div>
+    );
+  }
+  return (
+    <div className="flex flex-col gap-6">
+      <SponsorImpactSummary metrics={metrics} />
+      <div className="grid gap-4">
+        {sponsorships.map((sponsorship) => (
+          <ContributionDetails key={sponsorship.id} sponsorship={sponsorship} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/sponsors/SponsorSupportForm.jsx
+++ b/frontend/src/features/sponsors/SponsorSupportForm.jsx
@@ -1,0 +1,122 @@
+import { useEffect, useState } from 'react';
+
+const SUPPORT_TYPES = [
+  { value: 'FUNDS', label: 'Financial support (₹)' },
+  { value: 'IN_KIND', label: 'In-kind resources' },
+];
+
+export default function SponsorSupportForm({ event, onSubmit, onCancel, isSubmitting = false, initialSponsorship }) {
+  const [type, setType] = useState('FUNDS');
+  const [amount, setAmount] = useState('');
+  const [notes, setNotes] = useState('');
+  const [message, setMessage] = useState('');
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (!initialSponsorship) {
+      setType('FUNDS');
+      setAmount('');
+      setNotes('');
+      return;
+    }
+    setType(initialSponsorship.type || 'FUNDS');
+    setAmount(
+      initialSponsorship.amount !== undefined && initialSponsorship.amount !== null
+        ? String(initialSponsorship.amount)
+        : ''
+    );
+    setNotes(initialSponsorship.notes || '');
+  }, [initialSponsorship]);
+
+  if (!event) {
+    return null;
+  }
+
+  const handleSubmit = async (eventSubmit) => {
+    eventSubmit.preventDefault();
+    setError('');
+    setMessage('');
+
+    if (type === 'FUNDS' && (!amount || Number(amount) <= 0)) {
+      setError('Enter an estimated amount for financial sponsorships.');
+      return;
+    }
+
+    try {
+      await onSubmit?.({
+        type,
+        amount: amount ? Number(amount) : undefined,
+        notes: notes.trim() || undefined,
+      });
+      setMessage('Thank you! Your pledge is recorded.');
+    } catch (submissionError) {
+      setError(submissionError.message || 'Unable to save sponsorship right now.');
+    }
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="flex flex-col gap-4 rounded-3xl border border-brand-forest/15 bg-white p-5 shadow-[0_24px_48px_rgba(47,133,90,0.08)]"
+    >
+      <header className="flex flex-col gap-1">
+        <span className="text-xs uppercase tracking-[0.24em] text-brand-muted">Support</span>
+        <h3 className="m-0 font-display text-xl font-semibold text-brand-forest">{event.title}</h3>
+        <p className="m-0 text-sm text-brand-muted">{event.location}</p>
+      </header>
+      <div className="flex flex-col gap-3">
+        {SUPPORT_TYPES.map((option) => (
+          <label key={option.value} className="flex items-center gap-3 rounded-2xl border border-brand-forest/15 bg-brand-sand/60 px-4 py-3 text-sm font-medium text-brand-forest">
+            <input
+              type="radio"
+              name="sponsorType"
+              value={option.value}
+              checked={type === option.value}
+              onChange={() => setType(option.value)}
+              className="h-4 w-4 text-brand-forest focus:ring-brand-green"
+            />
+            {option.label}
+          </label>
+        ))}
+      </div>
+      {type === 'FUNDS' ? (
+        <label className="flex flex-col gap-2 text-sm">
+          <span className="font-semibold text-brand-forest">Estimated amount (₹)</span>
+          <input
+            type="number"
+            min="0"
+            step="0.01"
+            value={amount}
+            onChange={(eventChange) => setAmount(eventChange.target.value)}
+            className="rounded-lg border border-brand-forest/20 bg-brand-sand/40 px-3 py-2 text-sm shadow-sm focus:border-brand-green focus:outline-none"
+            placeholder="50000"
+          />
+        </label>
+      ) : null}
+      <label className="flex flex-col gap-2 text-sm">
+        <span className="font-semibold text-brand-forest">Notes for the team</span>
+        <textarea
+          rows={3}
+          value={notes}
+          onChange={(eventChange) => setNotes(eventChange.target.value)}
+          className="rounded-lg border border-brand-forest/20 bg-brand-sand/40 px-3 py-2 text-sm shadow-sm focus:border-brand-green focus:outline-none"
+          placeholder="Share how you plan to support or recognition preferences."
+        />
+      </label>
+      {error ? <p className="m-0 rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-700">{error}</p> : null}
+      {message ? <p className="m-0 rounded-xl border border-brand-green/20 bg-brand-sand/70 p-3 text-sm text-brand-forest">{message}</p> : null}
+      <div className="flex flex-wrap items-center gap-3">
+        <button type="submit" className="btn-primary" disabled={isSubmitting}>
+          {isSubmitting ? 'Submitting…' : 'Confirm sponsorship'}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="rounded-md border border-brand-forest/20 bg-white px-3 py-2 text-sm font-semibold text-brand-forest shadow-sm"
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/features/sponsors/api.js
+++ b/frontend/src/features/sponsors/api.js
@@ -1,0 +1,29 @@
+import { apiRequest } from '../../lib/apiClient';
+
+export function applyForSponsor(token, payload) {
+  return apiRequest('/api/sponsors/apply', { method: 'POST', token, body: payload });
+}
+
+export function fetchSponsorProfile(token) {
+  return apiRequest('/api/sponsors/me', { token });
+}
+
+export function updateSponsorProfile(token, payload) {
+  return apiRequest('/api/sponsors/me', { method: 'PATCH', token, body: payload });
+}
+
+export function fetchSponsorSponsorships(token) {
+  return apiRequest('/api/sponsors/me/sponsorships', { token });
+}
+
+export function fetchSponsorDashboard(token) {
+  return apiRequest('/api/sponsors/me/dashboard', { token });
+}
+
+export function fetchSponsorReports(token) {
+  return apiRequest('/api/sponsors/me/reports', { token });
+}
+
+export function pledgeEventSponsorship(token, eventId, payload) {
+  return apiRequest(`/api/events/${eventId}/sponsor`, { method: 'POST', token, body: payload });
+}

--- a/frontend/src/features/volunteer/EventDiscovery.jsx
+++ b/frontend/src/features/volunteer/EventDiscovery.jsx
@@ -22,7 +22,16 @@ function summarize(event) {
   return `${event.description.slice(0, 137)}…`;
 }
 
-export default function EventDiscovery({ events, filters, onFilterChange, onSignup, onLeave, isLoading }) {
+export default function EventDiscovery({
+  events,
+  filters,
+  onFilterChange,
+  onSignup,
+  onLeave,
+  isLoading,
+  mode = 'volunteer',
+  sponsorOptions = null,
+}) {
   const [form, setForm] = useState({ category: '', location: '', theme: '', date: '' });
   const [actionStates, setActionStates] = useState({});
 
@@ -197,8 +206,27 @@ export default function EventDiscovery({ events, filters, onFilterChange, onSign
                   </dd>
                 </div>
               </dl>
+              {sponsors.length ? (
+                <div className="flex flex-wrap items-center gap-2">
+                  {sponsors.map((sponsor) => (
+                    <span
+                      key={sponsor.sponsorId || sponsor.orgName}
+                      className="inline-flex items-center gap-2 rounded-full bg-brand-sand px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-brand-forest"
+                    >
+                      {sponsor.logoUrl ? (
+                        <img src={sponsor.logoUrl} alt={sponsor.orgName} className="h-5 w-5 rounded-full object-cover" />
+                      ) : null}
+                      {sponsor.orgName}
+                    </span>
+                  ))}
+                </div>
+              ) : null}
               <div className="flex flex-wrap items-center gap-2">
-                {!alreadyJoined ? (
+                {isSponsorMode ? (
+                  <button type="button" className="btn-primary" onClick={() => sponsorOptions?.onSupport?.(event)}>
+                    {mySponsorship ? 'Update pledge' : 'Support this event'}
+                  </button>
+                ) : !alreadyJoined ? (
                   <button
                     type="button"
                     className="btn-primary"
@@ -217,20 +245,23 @@ export default function EventDiscovery({ events, filters, onFilterChange, onSign
                     {isLeaving ? 'Leaving…' : 'Leave event'}
                   </button>
                 )}
-                {alreadyJoined ? (
+                {!isSponsorMode && alreadyJoined ? (
                   <span className="text-xs font-semibold text-brand-green">You\u2019re confirmed!</span>
                 ) : null}
-                {isFull && !alreadyJoined ? (
+                {!isSponsorMode && isFull && !alreadyJoined ? (
                   <span className="text-xs text-brand-muted">This event reached capacity.</span>
                 ) : null}
-                {state.status === 'join-error' || state.status === 'leave-error' ? (
+                {!isSponsorMode && (state.status === 'join-error' || state.status === 'leave-error') ? (
                   <span className="text-xs text-red-600">{state.message}</span>
                 ) : null}
-                {state.status === 'join-success' && !alreadyJoined ? (
+                {!isSponsorMode && state.status === 'join-success' && !alreadyJoined ? (
                   <span className="text-xs font-semibold text-brand-green">{state.message}</span>
                 ) : null}
-                {state.status === 'leave-success' && alreadyJoined ? (
+                {!isSponsorMode && state.status === 'leave-success' && alreadyJoined ? (
                   <span className="text-xs font-semibold text-brand-green">{state.message}</span>
+                ) : null}
+                {isSponsorMode && mySponsorship ? (
+                  <span className="text-xs text-brand-muted">{`Your pledge is ${mySponsorship.status.toLowerCase()}.`}</span>
                 ) : null}
               </div>
             </article>
@@ -239,7 +270,11 @@ export default function EventDiscovery({ events, filters, onFilterChange, onSign
       </div>
       {events.length ? (
         <p className="m-0 text-xs text-brand-muted">
-          {totalAvailable
+          {mode === 'sponsor'
+            ? totalAvailable
+              ? `${totalAvailable} event${totalAvailable === 1 ? '' : 's'} ready for sponsorship.`
+              : 'All listed events are already fully supported.'
+            : totalAvailable
             ? `${totalAvailable} event${totalAvailable === 1 ? '' : 's'} still ${
                 totalAvailable === 1 ? 'has' : 'have'
               } volunteer spots available.`


### PR DESCRIPTION
## Summary
- add sponsor repository, service, and routes to handle applications, pledges, approvals, and report delivery
- extend volunteer journey and gallery services so events and galleries surface approved sponsor logos and personal sponsorship context
- wire sponsor dashboard/front-end flows with onboarding, sponsorship pledging, impact summaries, and documentation updates for phase 5

## Testing
- npm run test:connections *(fails: Postgres unavailable in container)*
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd444c54b8833386079259b2ee84f3