### PR TITLE
Guard sponsor metadata in event discovery

### DIFF
--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -156,3 +156,10 @@
 - **Impact:** Sponsors gain a dedicated workspace to support events, see their logos across event and gallery experiences, and receive automated summaries of volunteer hours, attendance, and gallery visibility tied to their contributions.
 
 
+## Sponsor event discovery guardrails
+- **Date:** 2025-10-02
+- **Change:** Hardened the shared event discovery component to treat sponsor metadata as optional, guarding array access and action handlers so the volunteer and sponsor dashboards no longer crash when the API omits sponsorship details.
+- **Impact:** Event lists now render reliably for every role, giving sponsors and volunteers uninterrupted access to filters, signups, and pledge actions even while data loads or profiles await approval.
+
+
+

--- a/frontend/src/features/volunteer/AGENTS.md
+++ b/frontend/src/features/volunteer/AGENTS.md
@@ -11,3 +11,4 @@ These notes apply to files under `frontend/src/features/volunteer/`.
 - Hours logging UI should hide mutation forms when there are no eligible events and instead guide volunteers to join an event first.
 - When surfacing guidance CTAs (like the events hub link), apply `self-start` alongside `btn-primary` so the button keeps its standard width instead of stretching edge-to-edge.
 - Provide "Leave event" affordances alongside signup actions, keep them styled as bordered secondary buttons, and surface inline feedback that clears when new data loads.
+- Guard sponsor metadata like arrays and call-to-action handlers before rendering so volunteer and sponsor dashboards stay resilient when APIs omit optional fields.

--- a/frontend/src/features/volunteer/EventDiscovery.jsx
+++ b/frontend/src/features/volunteer/EventDiscovery.jsx
@@ -34,6 +34,7 @@ export default function EventDiscovery({
 }) {
   const [form, setForm] = useState({ category: '', location: '', theme: '', date: '' });
   const [actionStates, setActionStates] = useState({});
+  const isSponsorMode = mode === 'sponsor';
 
   useEffect(() => {
     setForm({
@@ -181,6 +182,9 @@ export default function EventDiscovery({
           const alreadyJoined = event.isRegistered;
           const isFull = event.availableSlots <= 0;
           const canJoin = !alreadyJoined && !isFull && !isJoining && !isLeaving;
+          const sponsors = Array.isArray(event.sponsors) ? event.sponsors : [];
+          const mySponsorship = event.mySponsorship || null;
+          const canSupport = isSponsorMode && typeof sponsorOptions?.onSupport === 'function';
           return (
             <article
               key={event.id}
@@ -223,7 +227,12 @@ export default function EventDiscovery({
               ) : null}
               <div className="flex flex-wrap items-center gap-2">
                 {isSponsorMode ? (
-                  <button type="button" className="btn-primary" onClick={() => sponsorOptions?.onSupport?.(event)}>
+                  <button
+                    type="button"
+                    className="btn-primary"
+                    disabled={!canSupport}
+                    onClick={() => sponsorOptions?.onSupport?.(event)}
+                  >
                     {mySponsorship ? 'Update pledge' : 'Support this event'}
                   </button>
                 ) : !alreadyJoined ? (


### PR DESCRIPTION
## Summary
- guard the volunteer event discovery component against missing sponsor metadata and disable support actions without handlers
- document the expectation for volunteer feature files and log the change in the wiki

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd53f13c8c83339f9865cc1c746c69