### PR TITLE
Optimize frontend bundle for GTmetrix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ These instructions apply to the entire repository unless a nested `AGENTS.md` ov
 - Ensure new API calls read `import.meta.env.VITE_API_BASE_URL` for the backend origin.
 - Run `npm run build` from the `frontend` directory to validate that the Vite build still succeeds after making frontend changes.
 - Preserve the `/app` HTML rewrite middleware in `vite.config.js` so that deep links like `/app/events` continue to resolve when the dev server is accessed directly.
+- When adding new top-level routes, prefer `React.lazy` with a shared suspense fallback so bundle splitting stays effective for GTmetrix performance budgets.
 
 ## Tooling
 - Do not commit environment secrets or generated assets under `dist/` or `build/`.

--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -162,4 +162,10 @@
 - **Impact:** Event lists now render reliably for every role, giving sponsors and volunteers uninterrupted access to filters, signups, and pledge actions even while data loads or profiles await approval.
 
 
+## GTmetrix bundle optimizations
+- **Date:** 2025-10-02
+- **Change:** Swapped top-level routes and dashboard surfaces to `React.lazy` + Suspense fallbacks so React Router pages load on demand, and tuned `vite.config.js` to leverage Terser minification, drop console/debugger statements, and emit manual vendor chunks for React and router packages.
+- **Impact:** Initial page loads download smaller JavaScript payloads while subsequent navigation streams feature-specific code, aligning the dashboard with GTmetrix recommendations for minification, unused code removal, and bundle splitting.
+
+
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,7 @@
         "autoprefixer": "^10.4.21",
         "postcss": "^8.5.6",
         "tailwindcss": "^3.4.10",
+        "terser": "^5.44.0",
         "vite": "^4.0.0"
       }
     },
@@ -739,6 +740,17 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -877,6 +889,19 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/ansi-regex": {
@@ -1057,6 +1082,13 @@
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/camelcase-css": {
       "version": "2.0.1",
@@ -2287,6 +2319,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2295,6 +2337,17 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "node_modules/string-width": {
@@ -2474,6 +2527,32 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/terser": {
+      "version": "5.44.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.44.0.tgz",
+      "integrity": "sha512-nIVck8DK+GM/0Frwd+nIhZ84pR/BX7rmXMfYwyg+Sri5oGVE99/E3KvXqpC2xHFxyqXyGHTKBSioxxplrO4I4w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.15.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/thenify": {
       "version": "3.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "autoprefixer": "^10.4.21",
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.10",
+    "terser": "^5.44.0",
     "vite": "^4.0.0"
   }
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,57 +1,62 @@
+import { Suspense, lazy } from 'react';
 import { Navigate, Route, Routes } from 'react-router-dom';
-import AppLayout from './features/layout/AppLayout';
-import LoginPage from './features/auth/LoginPage';
-import SignupPage from './features/auth/SignupPage';
-import CheckEmailPage from './features/auth/CheckEmailPage';
-import VerifyEmailPage from './features/auth/VerifyEmailPage';
 import ProtectedRoute from './features/auth/ProtectedRoute';
 import PublicOnlyRoute from './features/auth/PublicOnlyRoute';
-import DashboardRouter from './features/dashboard/DashboardRouter';
-import HomePage from './features/landing/HomePage';
-import PublicGalleryPage from './features/event-gallery/PublicGalleryPage';
+import LoadingScreen from './features/layout/LoadingScreen';
+
+const AppLayout = lazy(() => import('./features/layout/AppLayout'));
+const LoginPage = lazy(() => import('./features/auth/LoginPage'));
+const SignupPage = lazy(() => import('./features/auth/SignupPage'));
+const CheckEmailPage = lazy(() => import('./features/auth/CheckEmailPage'));
+const VerifyEmailPage = lazy(() => import('./features/auth/VerifyEmailPage'));
+const DashboardRouter = lazy(() => import('./features/dashboard/DashboardRouter'));
+const HomePage = lazy(() => import('./features/landing/HomePage'));
+const PublicGalleryPage = lazy(() => import('./features/event-gallery/PublicGalleryPage'));
 
 function App() {
   return (
-    <AppLayout>
-      <Routes>
-        <Route path="/" element={<HomePage />} />
-        <Route path="/gallery" element={<PublicGalleryPage />} />
-        <Route
-          path="/app/*"
-          element={
-            <ProtectedRoute>
-              <DashboardRouter />
-            </ProtectedRoute>
-          }
-        />
-        <Route
-          path="/login"
-          element={
-            <PublicOnlyRoute>
-              <LoginPage />
-            </PublicOnlyRoute>
-          }
-        />
-        <Route
-          path="/signup"
-          element={
-            <PublicOnlyRoute>
-              <SignupPage />
-            </PublicOnlyRoute>
-          }
-        />
-        <Route
-          path="/check-email"
-          element={
-            <PublicOnlyRoute>
-              <CheckEmailPage />
-            </PublicOnlyRoute>
-          }
-        />
-        <Route path="/verify-email" element={<VerifyEmailPage />} />
-        <Route path="*" element={<Navigate to="/" replace />} />
-      </Routes>
-    </AppLayout>
+    <Suspense fallback={<LoadingScreen label="Loading Onkur…" />}>
+      <AppLayout>
+        <Routes>
+          <Route path="/" element={<HomePage />} />
+          <Route path="/gallery" element={<PublicGalleryPage />} />
+          <Route
+            path="/app/*"
+            element={
+              <ProtectedRoute>
+                <DashboardRouter />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/login"
+            element={
+              <PublicOnlyRoute>
+                <LoginPage />
+              </PublicOnlyRoute>
+            }
+          />
+          <Route
+            path="/signup"
+            element={
+              <PublicOnlyRoute>
+                <SignupPage />
+              </PublicOnlyRoute>
+            }
+          />
+          <Route
+            path="/check-email"
+            element={
+              <PublicOnlyRoute>
+                <CheckEmailPage />
+              </PublicOnlyRoute>
+            }
+          />
+          <Route path="/verify-email" element={<VerifyEmailPage />} />
+          <Route path="*" element={<Navigate to="/" replace />} />
+        </Routes>
+      </AppLayout>
+    </Suspense>
   );
 }
 

--- a/frontend/src/features/dashboard/DashboardRouter.jsx
+++ b/frontend/src/features/dashboard/DashboardRouter.jsx
@@ -1,14 +1,16 @@
-import { useMemo } from 'react';
+import { Suspense, lazy, useMemo } from 'react';
 import { Navigate, Route, Routes } from 'react-router-dom';
 
 import { useAuth } from '../auth/AuthContext';
-import AdminDashboard from './AdminDashboard';
-import EventManagerDashboard from './EventManagerDashboard';
-import EventsPage from './EventsPage';
-import GalleryPage from './GalleryPage';
-import ProfilePage from './ProfilePage';
-import SponsorDashboard from './SponsorDashboard';
-import VolunteerDashboard from './VolunteerDashboard';
+import LoadingScreen from '../layout/LoadingScreen';
+
+const AdminDashboard = lazy(() => import('./AdminDashboard'));
+const EventManagerDashboard = lazy(() => import('./EventManagerDashboard'));
+const EventsPage = lazy(() => import('./EventsPage'));
+const GalleryPage = lazy(() => import('./GalleryPage'));
+const ProfilePage = lazy(() => import('./ProfilePage'));
+const SponsorDashboard = lazy(() => import('./SponsorDashboard'));
+const VolunteerDashboard = lazy(() => import('./VolunteerDashboard'));
 import { determinePrimaryRole, normalizeRoles } from './roleUtils';
 
 const HOME_COMPONENTS = {
@@ -44,21 +46,23 @@ export default function DashboardRouter() {
   const HomeComponent = resolveHome(primaryRole);
 
   return (
-    <Routes>
-      <Route index element={<HomeComponent />} />
-      <Route
-        path="events"
-        element={<EventsPage role={primaryRole} roles={normalizedRoles} />}
-      />
-      <Route
-        path="gallery"
-        element={<GalleryPage role={primaryRole} roles={normalizedRoles} />}
-      />
-      <Route
-        path="profile"
-        element={<ProfilePage role={primaryRole} roles={normalizedRoles} />}
-      />
-      <Route path="*" element={<Navigate to="." replace />} />
-    </Routes>
+    <Suspense fallback={<LoadingScreen label="Loading your dashboard" />}>
+      <Routes>
+        <Route index element={<HomeComponent />} />
+        <Route
+          path="events"
+          element={<EventsPage role={primaryRole} roles={normalizedRoles} />}
+        />
+        <Route
+          path="gallery"
+          element={<GalleryPage role={primaryRole} roles={normalizedRoles} />}
+        />
+        <Route
+          path="profile"
+          element={<ProfilePage role={primaryRole} roles={normalizedRoles} />}
+        />
+        <Route path="*" element={<Navigate to="." replace />} />
+      </Routes>
+    </Suspense>
   );
 }

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -24,6 +24,40 @@ export default defineConfig({
     proxy: {
       '/api': 'http://localhost:5000', // Proxy API requests to backend
     },
-    allowedHosts: ['onkur.dodon.in']
+    allowedHosts: ['onkur.dodon.in'],
+  },
+  build: {
+    target: 'es2018',
+    minify: 'terser',
+    terserOptions: {
+      compress: {
+        drop_console: true,
+        drop_debugger: true,
+      },
+      format: {
+        comments: false,
+      },
+    },
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (id.includes('node_modules')) {
+            if (id.includes('react-router-dom')) {
+              return 'react-router';
+            }
+            if (id.includes('react')) {
+              return 'react-vendor';
+            }
+            return 'vendor';
+          }
+
+          if (id.includes('src/features/dashboard')) {
+            return 'dashboard';
+          }
+
+          return undefined;
+        },
+      },
+    },
   },
 });


### PR DESCRIPTION
## Summary
- lazy load top-level routes and dashboard views with shared suspense fallbacks so feature bundles download on demand
- tune the Vite production build to use terser minification, drop console/debugger statements, and emit vendor/dashboard chunks for better cacheability
- document the GTmetrix bundle plan in the contributor playbook and wiki changelog

## Testing
- npm run build (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68cd844200108333be0b3c6f9ea28ff6