### PR TITLE
Improve home LCP by eager loading landing page

### DIFF
--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -183,4 +183,9 @@
 - **Change:** Swapped the dashboard back to Google Fonts, loading Inter and Nunito weights through `<link>` tags that request latin subsets with `display=swap` while removing the bundled WOFF2 assets and `fonts.css` entrypoint.
 - **Impact:** The build avoids binary font commits while still shipping non-blocking typography with the lighter latin-focused families the UI expects.
 
+## Landing LCP fallback removal
+- **Date:** 2025-10-03
+- **Change:** Inlined the public `HomePage` in `App.jsx` instead of lazy loading it so first impressions avoid the Suspense spinner and the hero content can render with the initial bundle.
+- **Impact:** Largest Contentful Paint on the marketing home now depends on the first script payload alone, eliminating the extra network hop that pushed GTmetrix LCP near 5.5 seconds.
+
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,13 +4,14 @@ import ProtectedRoute from './features/auth/ProtectedRoute';
 import PublicOnlyRoute from './features/auth/PublicOnlyRoute';
 import LoadingScreen from './features/layout/LoadingScreen';
 
+import HomePage from './features/landing/HomePage';
+
 const AppLayout = lazy(() => import('./features/layout/AppLayout'));
 const LoginPage = lazy(() => import('./features/auth/LoginPage'));
 const SignupPage = lazy(() => import('./features/auth/SignupPage'));
 const CheckEmailPage = lazy(() => import('./features/auth/CheckEmailPage'));
 const VerifyEmailPage = lazy(() => import('./features/auth/VerifyEmailPage'));
 const DashboardRouter = lazy(() => import('./features/dashboard/DashboardRouter'));
-const HomePage = lazy(() => import('./features/landing/HomePage'));
 const PublicGalleryPage = lazy(() => import('./features/event-gallery/PublicGalleryPage'));
 
 function App() {

--- a/frontend/src/features/landing/AGENTS.md
+++ b/frontend/src/features/landing/AGENTS.md
@@ -1,0 +1,7 @@
+# Landing Page Guidelines
+
+These notes cover files under `frontend/src/features/landing/`.
+
+- Keep the home experience eagerly loaded from `App.jsx` so first-time visitors avoid Suspense fallbacks that delay Largest Contentful Paint.
+- When adding imagery to the hero, prefer responsive assets with explicit dimensions and `loading="eager"` for above-the-fold media to protect LCP.
+- Document any UX or performance changes that impact the public marketing funnel in `docs/Wiki.md`.


### PR DESCRIPTION
## Summary
- import the landing HomePage synchronously so first paint is not gated behind a lazy chunk
- document the expectation in landing AGENTS.md and record the performance change in the wiki

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd9155138c8333afcc4f9cd1db0bca