### PR TITLE
Fix React dedupe for hooks

### DIFF
--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -1,5 +1,12 @@
 # Onkur Change Log
 
+## React dedupe for hook stability
+- **Date:** 2025-10-05
+- **Change:** Configured Vite to deduplicate `react` and `react-dom` module resolution so the dev server and production build alw
+  ays share a single React instance.
+- **Impact:** Custom hooks like `useDocumentTitle` execute within React's dispatcher again, resolving the "Invalid hook call" err
+  or that prevented the landing page from rendering.
+
 ## Direct main bundle loading
 - **Date:** 2025-10-04
 - **Change:** Updated the frontend entry script to load `src/main.js` directly, replaced the JSX entry module with a JavaScript

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -73,6 +73,9 @@ const ensureCrossoriginPlugin = {
 
 export default defineConfig({
   plugins: [react(), appRouteRewritePlugin, ensureCrossoriginPlugin],
+  resolve: {
+    dedupe: ['react', 'react-dom'],
+  },
   server: {
     proxy: {
       '/api': 'http://localhost:5000', // Proxy API requests to backend


### PR DESCRIPTION
## Summary
- dedupe react and react-dom in Vite config so the app always uses a single React runtime
- document the React dedupe change and resolved hook error in the project wiki

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd9f274020833396b2648a07388cd2