### PR TITLE
Show loading indicator during dashboard route transitions

### DIFF
--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -1,5 +1,10 @@
 # Onkur Change Log
 
+## Layout Suspense loader overlay
+- **Date:** 2025-10-06
+- **Change:** Wrapped the layout content area in its own `Suspense` boundary that renders the shared `LoadingScreen` and adjusted the loader container sizing so route-to-route navigation always presents an inline progress indicator without collapsing the spinner.
+- **Impact:** Volunteers, sponsors, and admins now see immediate feedback when navigating between dashboard sections, confirming their interactions while lazy-loaded routes stream in.
+
 ## React dedupe for hook stability
 - **Date:** 2025-10-05
 - **Change:** Configured Vite to deduplicate `react` and `react-dom` module resolution so the dev server and production build alw

--- a/frontend/src/features/layout/AGENTS.md
+++ b/frontend/src/features/layout/AGENTS.md
@@ -6,3 +6,4 @@ These notes apply to files within `frontend/src/features/layout/`.
 - When updating header or navigation spacing, verify both mobile (bottom navigation) and desktop (header navigation) breakpoints remain accessible.
 - Prefer declarative `Link` components from `react-router-dom` over `button` elements for navigation interactions.
 - The mobile bottom navigation hosts the logout action; keep the dedicated button accessible and visually balanced alongside the nav items when adjusting the bar.
+- Preserve the nested `Suspense` boundary in `AppLayout` so route transitions continue to surface the shared `LoadingScreen` feedback inside the layout shell.

--- a/frontend/src/features/layout/AppLayout.jsx
+++ b/frontend/src/features/layout/AppLayout.jsx
@@ -1,9 +1,10 @@
-import { useMemo } from 'react';
+import { Suspense, useMemo } from 'react';
 
 import { Link, useLocation } from 'react-router-dom';
 import { useAuth } from '../auth/AuthContext';
 import BottomNav from './BottomNav';
 import DesktopNav from './DesktopNav';
+import LoadingScreen from './LoadingScreen';
 
 function formatRole(role) {
   if (!role) return '';
@@ -109,7 +110,9 @@ export default function AppLayout({ children }) {
         {isAuthenticated ? <DesktopNav active={activeNav} /> : null}
       </header>
       <main className="flex-1 px-5 pb-16 pt-6 sm:px-8">
-        <div className="mx-auto flex w-full max-w-4xl flex-col gap-6">{children}</div>
+        <Suspense fallback={<LoadingScreen label="Loading the next page…" />}>
+          <div className="mx-auto flex w-full max-w-4xl flex-col gap-6">{children}</div>
+        </Suspense>
       </main>
       {isAuthenticated ? <BottomNav active={activeNav} /> : null}
     </div>

--- a/frontend/src/features/layout/LoadingScreen.jsx
+++ b/frontend/src/features/layout/LoadingScreen.jsx
@@ -1,7 +1,7 @@
 export default function LoadingScreen({ label = 'Loading Onkur…' }) {
   return (
     <div
-      className="flex flex-col items-center justify-center gap-4 px-4 py-16 text-brand-green"
+      className="flex w-full min-h-[220px] flex-col items-center justify-center gap-4 px-4 py-16 text-brand-green"
       role="status"
       aria-live="polite"
     >


### PR DESCRIPTION
## Summary
- wrap the layout content area in an inner Suspense boundary so lazy routes render the shared loading screen while navigation completes
- enlarge the loading screen container to stay centered within the layout shell and documented the expectation in the layout agent notes
- record the navigation feedback enhancement in the project wiki

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cda02de25c83338c9149728db1158a