### PR TITLE
feat: deliver admin console with moderation and reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ Onkur is a mobile-first volunteering platform rooted in sustainability and commu
 - Event and gallery experiences that surface approved sponsor logos and contributions for every supported event.
 - Automated impact reports summarizing volunteer hours, gallery views, and ROI metrics delivered to sponsor inboxes.
 
+### Phase 6 – Admin Oversight (Complete)
+- Unified admin console that surfaces moderation queues for events, sponsors, and gallery media with bulk-ready workflows.
+- Approval and rejection APIs that publish or return submissions to draft while capturing audit trails and notifying submitters.
+- User management panel to adjust multi-role assignments and deactivate accounts without touching the database.
+- Reporting overview with platform metrics plus one-click CSV/Excel exports for users, events, sponsorships, and media.
+- Extended audit logging with before/after snapshots tied to each entity for transparent governance.
+
 Consult the living [product wiki](docs/Wiki.md) for design rationale, API schemas, and rollout notes for each phase.
 
 ---

--- a/backend/src/features/admin/AGENTS.md
+++ b/backend/src/features/admin/AGENTS.md
@@ -1,0 +1,10 @@
+# Admin Feature Guidelines
+
+These notes apply to files within `backend/src/features/admin/`.
+
+- Keep moderation and reporting logic inside the service layer; route handlers should be limited to validation and response shaping.
+- Reuse repository helpers from other features when updating entity state so that existing business rules (emails, metrics) stay consistent.
+- Every admin action must emit an audit log with `entityType`, `entityId`, and before/after snapshots that omit sensitive fields like password hashes.
+- Prefer returning lightweight summaries to the API client—leave heavy exports to the CSV helpers so the JSON responses stay fast on mobile networks.
+- Use the shared Winston logger for notable moderation outcomes or export generation failures.
+- When extending exports, keep the CSV and Excel builders in sync and ensure the service reports the correct MIME type/extension so the frontend can parse filenames from the `Content-Disposition` header.

--- a/backend/src/features/admin/admin.repository.js
+++ b/backend/src/features/admin/admin.repository.js
@@ -1,0 +1,168 @@
+const pool = require('../common/db');
+
+async function getOverviewMetrics() {
+  const [roleCountsResult, userCountsResult, eventStatsResult, volunteerTotalsResult, volunteerActiveResult, sponsorProfilesResult, sponsorFundsResult, galleryStatsResult, auditRecentResult] = await Promise.all([
+    pool.query(`SELECT role, COUNT(*)::INT AS count FROM user_roles GROUP BY role`),
+    pool.query(`
+      SELECT
+        COUNT(*)::INT AS total_count,
+        COUNT(*) FILTER (WHERE is_active) ::INT AS active_count,
+        COUNT(*) FILTER (WHERE NOT is_active) ::INT AS inactive_count
+      FROM users
+    `),
+    pool.query(`
+      SELECT
+        COUNT(*) FILTER (WHERE status = 'PUBLISHED') ::INT AS published_count,
+        COUNT(*) FILTER (WHERE status = 'COMPLETED') ::INT AS completed_count,
+        COUNT(*) FILTER (WHERE approval_status = 'PENDING') ::INT AS pending_count,
+        COUNT(*) FILTER (WHERE status = 'PUBLISHED' AND date_start >= NOW()) ::INT AS upcoming_count
+      FROM events
+    `),
+    pool.query(`SELECT COALESCE(SUM(minutes), 0)::BIGINT AS total_minutes FROM volunteer_hours`),
+    pool.query(`
+      SELECT COUNT(DISTINCT user_id)::INT AS active_volunteers
+      FROM event_attendance
+      WHERE check_in_at >= NOW() - INTERVAL '30 days'
+    `),
+    pool.query(`
+      SELECT
+        COUNT(*) FILTER (WHERE status = 'APPROVED') ::INT AS approved_count,
+        COUNT(*) FILTER (WHERE status = 'PENDING') ::INT AS pending_count,
+        COUNT(*) FILTER (WHERE status = 'DECLINED') ::INT AS declined_count
+      FROM sponsor_profiles
+    `),
+    pool.query(`SELECT COALESCE(SUM(amount), 0)::NUMERIC AS total_amount FROM sponsorships WHERE status = 'APPROVED'`),
+    pool.query(`
+      SELECT
+        COUNT(*) FILTER (WHERE status = 'PENDING') ::INT AS pending_count,
+        COUNT(*) FILTER (WHERE status = 'APPROVED') ::INT AS approved_count
+      FROM event_media
+    `),
+    pool.query(`SELECT COUNT(*)::INT AS recent_actions FROM audit_logs WHERE created_at >= NOW() - INTERVAL '7 days'`),
+  ]);
+
+  const roleCounts = roleCountsResult.rows.reduce((acc, row) => {
+    acc[row.role] = Number(row.count || 0);
+    return acc;
+  }, {});
+
+  const userCounts = userCountsResult.rows[0] || {};
+  const eventStats = eventStatsResult.rows[0] || {};
+  const volunteerTotals = volunteerTotalsResult.rows[0] || {};
+  const volunteerActive = volunteerActiveResult.rows[0] || {};
+  const sponsorProfiles = sponsorProfilesResult.rows[0] || {};
+  const sponsorFunds = sponsorFundsResult.rows[0] || {};
+  const galleryStats = galleryStatsResult.rows[0] || {};
+  const auditRecent = auditRecentResult.rows[0] || {};
+
+  return {
+    roleCounts,
+    users: {
+      total: Number(userCounts.total_count || 0),
+      active: Number(userCounts.active_count || 0),
+      inactive: Number(userCounts.inactive_count || 0),
+    },
+    events: {
+      published: Number(eventStats.published_count || 0),
+      completed: Number(eventStats.completed_count || 0),
+      pendingApproval: Number(eventStats.pending_count || 0),
+      upcoming: Number(eventStats.upcoming_count || 0),
+    },
+    volunteers: {
+      totalMinutes: Number(volunteerTotals.total_minutes || 0),
+      activeLast30Days: Number(volunteerActive.active_volunteers || 0),
+    },
+    sponsors: {
+      approved: Number(sponsorProfiles.approved_count || 0),
+      pending: Number(sponsorProfiles.pending_count || 0),
+      declined: Number(sponsorProfiles.declined_count || 0),
+      approvedFunds: Number(sponsorFunds.total_amount || 0),
+    },
+    gallery: {
+      pending: Number(galleryStats.pending_count || 0),
+      approved: Number(galleryStats.approved_count || 0),
+    },
+    audits: {
+      actionsLast7Days: Number(auditRecent.recent_actions || 0),
+    },
+  };
+}
+
+async function getUsersForExport() {
+  const result = await pool.query(`
+    SELECT
+      u.id,
+      u.name,
+      u.email,
+      u.is_active,
+      u.created_at,
+      u.email_verified_at,
+      ARRAY_REMOVE(ARRAY_AGG(ur.role), NULL) AS roles
+    FROM users u
+    LEFT JOIN user_roles ur ON ur.user_id = u.id
+    GROUP BY u.id
+    ORDER BY u.created_at DESC
+  `);
+  return result.rows;
+}
+
+async function getEventsForExport() {
+  const result = await pool.query(`
+    SELECT
+      e.id,
+      e.title,
+      e.status,
+      e.approval_status,
+      e.date_start,
+      e.date_end,
+      e.created_at,
+      e.published_at,
+      e.created_by,
+      e.category,
+      e.location
+    FROM events e
+    ORDER BY e.created_at DESC
+  `);
+  return result.rows;
+}
+
+async function getSponsorshipsForExport() {
+  const result = await pool.query(`
+    SELECT
+      s.id,
+      s.sponsor_id,
+      s.event_id,
+      s.type,
+      s.amount,
+      s.status,
+      s.approved_at,
+      s.pledged_at
+    FROM sponsorships s
+    ORDER BY s.pledged_at DESC
+  `);
+  return result.rows;
+}
+
+async function getMediaForExport() {
+  const result = await pool.query(`
+    SELECT
+      m.id,
+      m.event_id,
+      m.uploader_id,
+      m.status,
+      m.created_at,
+      m.approved_at,
+      m.rejection_reason
+    FROM event_media m
+    ORDER BY m.created_at DESC
+  `);
+  return result.rows;
+}
+
+module.exports = {
+  getOverviewMetrics,
+  getUsersForExport,
+  getEventsForExport,
+  getSponsorshipsForExport,
+  getMediaForExport,
+};

--- a/backend/src/features/admin/admin.route.js
+++ b/backend/src/features/admin/admin.route.js
@@ -1,0 +1,102 @@
+const express = require('express');
+const { authenticate, authorizeRoles } = require('../auth/auth.middleware');
+const {
+  getModerationQueue,
+  approveEntity,
+  rejectEntity,
+  updateUser,
+  getReportsOverview,
+  exportData,
+} = require('./admin.service');
+
+const router = express.Router();
+const authOnly = authenticate();
+const adminOnly = authorizeRoles('ADMIN');
+const uuidPattern = /^[0-9a-fA-F-]{36}$/;
+
+router.get('/api/admin/moderation', authOnly, adminOnly, async (req, res) => {
+  try {
+    const { type } = req.query;
+    const queue = await getModerationQueue({ type });
+    res.json(queue);
+  } catch (error) {
+    const status = error.statusCode || 500;
+    res.status(status).json({ error: error.message });
+  }
+});
+
+router.post('/api/admin/approve/:entityType/:id', authOnly, adminOnly, async (req, res) => {
+  try {
+    const { entityType, id } = req.params;
+    if (!uuidPattern.test(id)) {
+      return res.status(400).json({ error: 'Invalid entity identifier' });
+    }
+    const note = req.body?.note ? String(req.body.note).trim() : null;
+    const result = await approveEntity({ entityType, entityId: id, actorId: req.user.id, note });
+    res.json({ result });
+  } catch (error) {
+    const status = error.statusCode || 500;
+    res.status(status).json({ error: error.message });
+  }
+});
+
+router.post('/api/admin/reject/:entityType/:id', authOnly, adminOnly, async (req, res) => {
+  try {
+    const { entityType, id } = req.params;
+    if (!uuidPattern.test(id)) {
+      return res.status(400).json({ error: 'Invalid entity identifier' });
+    }
+    const note = req.body?.note ? String(req.body.note).trim() : null;
+    const result = await rejectEntity({ entityType, entityId: id, actorId: req.user.id, note });
+    res.json({ result });
+  } catch (error) {
+    const status = error.statusCode || 500;
+    res.status(status).json({ error: error.message });
+  }
+});
+
+router.patch('/api/admin/users/:id', authOnly, adminOnly, async (req, res) => {
+  try {
+    const { id } = req.params;
+    if (!uuidPattern.test(id)) {
+      return res.status(400).json({ error: 'Invalid user identifier' });
+    }
+    const { roles, isActive } = req.body || {};
+    const result = await updateUser({ userId: id, roles, isActive, actorId: req.user.id });
+    res.json({ user: result });
+  } catch (error) {
+    const status = error.statusCode || 500;
+    res.status(status).json({ error: error.message });
+  }
+});
+
+router.get('/api/admin/reports/overview', authOnly, adminOnly, async (_req, res) => {
+  try {
+    const overview = await getReportsOverview();
+    res.json({ overview });
+  } catch (error) {
+    const status = error.statusCode || 500;
+    res.status(status).json({ error: error.message });
+  }
+});
+
+router.get('/api/admin/export', authOnly, adminOnly, async (req, res) => {
+  try {
+    const { entity, format } = req.query;
+    const { content, contentType, extension } = await exportData({ entity, format });
+    const baseName = typeof entity === 'string' && entity.trim() ? entity.trim().replace(/[^a-z0-9_-]/gi, '') : 'export';
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const filename = `${baseName || 'export'}-${timestamp}.${extension}`;
+    res.setHeader('Content-Type', contentType);
+    res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+    res.send(content);
+  } catch (error) {
+    const status = error.statusCode || 500;
+    res.status(status).json({ error: error.message });
+  }
+});
+
+module.exports = {
+  basePath: '/',
+  router,
+};

--- a/backend/src/features/admin/admin.service.js
+++ b/backend/src/features/admin/admin.service.js
@@ -1,0 +1,601 @@
+const logger = require('../../utils/logger');
+const {
+  getOverviewMetrics,
+  getUsersForExport,
+  getEventsForExport,
+  getSponsorshipsForExport,
+  getMediaForExport,
+} = require('./admin.repository');
+const {
+  listEventsPendingApproval,
+  setEventApprovalStatus,
+  findEventById,
+} = require('../event-management/eventManagement.repository');
+const {
+  recordAuditLog,
+  findUserById,
+  setUserActiveStatus,
+  replaceUserRoles,
+} = require('../auth/auth.repository');
+const { sortRolesByPriority } = require('../auth/role.helpers');
+const { ROLES } = require('../auth/constants');
+const { updateSponsorApproval } = require('../sponsors/sponsor.service');
+const { findSponsorProfile, listSponsorProfiles } = require('../sponsors/sponsor.repository');
+const { listPendingMedia, findMediaById } = require('../event-gallery/eventGallery.repository');
+const { moderateMedia } = require('../event-gallery/eventGallery.service');
+const { sendTemplatedEmail } = require('../email/email.service');
+
+function toIso(value) {
+  if (!value) {
+    return null;
+  }
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}
+
+function sanitizeRolesInput(roles) {
+  if (!roles) {
+    return [];
+  }
+  const source = Array.isArray(roles) ? roles : [roles];
+  const normalized = source
+    .map((role) => (typeof role === 'string' ? role.trim().toUpperCase() : ''))
+    .filter((role) => ROLES.includes(role));
+  return sortRolesByPriority(normalized);
+}
+
+function describeEventLocation(event) {
+  if (!event) {
+    return 'TBD';
+  }
+  if (event.isOnline) {
+    return event.location || 'Online';
+  }
+  const parts = [event.location, event.cityName, event.stateName].filter(Boolean);
+  return parts.length ? parts.join(', ') : 'TBD';
+}
+
+function toAuditUser(user) {
+  if (!user) {
+    return null;
+  }
+  const roles = Array.isArray(user.roles) && user.roles.length ? sortRolesByPriority(user.roles) : [];
+  return {
+    id: user.id,
+    email: user.email,
+    name: user.name,
+    role: user.role || null,
+    roles,
+    isActive: user.is_active !== false,
+    emailVerified: Boolean(user.email_verified_at),
+  };
+}
+
+function toAuditEvent(event) {
+  if (!event) {
+    return null;
+  }
+  return {
+    id: event.id,
+    title: event.title,
+    status: event.status,
+    approvalStatus: event.approvalStatus || event.approval_status || 'PENDING',
+    approvalNote: event.approvalNote || event.approval_note || null,
+    dateStart: toIso(event.dateStart || event.date_start),
+    dateEnd: toIso(event.dateEnd || event.date_end),
+    createdBy: event.createdBy || event.created_by || null,
+  };
+}
+
+function toAuditSponsor(profile) {
+  if (!profile) {
+    return null;
+  }
+  return {
+    userId: profile.userId || profile.user_id,
+    orgName: profile.orgName || profile.org_name,
+    status: profile.status,
+    approvedAt: toIso(profile.approvedAt || profile.approved_at),
+  };
+}
+
+function toAuditMedia(media) {
+  if (!media) {
+    return null;
+  }
+  return {
+    id: media.id,
+    eventId: media.eventId || media.event_id,
+    uploaderId: media.uploaderId || media.uploader_id,
+    status: media.status,
+  };
+}
+
+function mapEventSummary(event) {
+  if (!event) {
+    return null;
+  }
+  return {
+    id: event.id,
+    title: event.title,
+    status: event.status,
+    approvalStatus: event.approvalStatus || event.approval_status || 'PENDING',
+    approvalNote: event.approvalNote || event.approval_note || null,
+    createdBy: event.createdBy || event.created_by || null,
+    createdByName: event.createdByName || event.creator_name || null,
+    createdByEmail: event.createdByEmail || event.creator_email || null,
+    createdAt: toIso(event.createdAt || event.created_at),
+    dateStart: toIso(event.dateStart || event.date_start),
+    dateEnd: toIso(event.dateEnd || event.date_end),
+    category: event.category || null,
+    location: event.location || null,
+  };
+}
+
+function mapSponsorSummary(profile) {
+  if (!profile) {
+    return null;
+  }
+  return {
+    userId: profile.userId,
+    orgName: profile.orgName,
+    contactName: profile.contactName,
+    contactEmail: profile.contactEmail,
+    status: profile.status,
+    appliedAt: toIso(profile.createdAt || profile.created_at),
+  };
+}
+
+function mapMediaSummary(media, eventLookup = new Map()) {
+  if (!media) {
+    return null;
+  }
+  const event = eventLookup.get(media.eventId);
+  return {
+    id: media.id,
+    eventId: media.eventId,
+    uploaderId: media.uploaderId,
+    caption: media.caption,
+    status: media.status,
+    submittedAt: toIso(media.createdAt || media.created_at),
+    eventTitle: event ? event.title : null,
+  };
+}
+
+function mapUserSummary(user) {
+  if (!user) {
+    return null;
+  }
+  const roles = Array.isArray(user.roles) && user.roles.length ? sortRolesByPriority(user.roles) : [];
+  return {
+    id: user.id,
+    name: user.name,
+    email: user.email,
+    role: user.role || (roles.length ? roles[0] : null),
+    roles,
+    isActive: user.is_active !== false,
+    createdAt: toIso(user.created_at || user.createdAt),
+    emailVerifiedAt: toIso(user.email_verified_at || user.emailVerifiedAt),
+  };
+}
+
+function formatCsvValue(value) {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  const stringValue = typeof value === 'string' ? value : String(value);
+  const needsEscaping = /[",\n]/.test(stringValue);
+  const escaped = stringValue.replace(/"/g, '""');
+  return needsEscaping ? `"${escaped}"` : escaped;
+}
+
+function extractColumnValue(column, row) {
+  return typeof column.accessor === 'function' ? column.accessor(row) : row[column.key];
+}
+
+function buildCsv(columns, rows) {
+  const header = columns.map((column) => column.header).join(',');
+  const dataLines = rows.map((row) => columns.map((column) => formatCsvValue(extractColumnValue(column, row))).join(','));
+  return [header, ...dataLines].join('\n');
+}
+
+function escapeXml(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function buildExcelXml(columns, rows, sheetName = 'Export') {
+  const headerRow = columns
+    .map((column) => `<Cell><Data ss:Type="String">${escapeXml(column.header)}</Data></Cell>`)
+    .join('');
+
+  const dataRows = rows
+    .map((row) => {
+      const cells = columns
+        .map((column) => {
+          const raw = extractColumnValue(column, row);
+          if (raw === null || raw === undefined || raw === '') {
+            return '<Cell/>';
+          }
+          if (typeof raw === 'number' && Number.isFinite(raw)) {
+            return `<Cell><Data ss:Type="Number">${raw}</Data></Cell>`;
+          }
+          return `<Cell><Data ss:Type="String">${escapeXml(raw)}</Data></Cell>`;
+        })
+        .join('');
+      return `<Row>${cells}</Row>`;
+    })
+    .join('');
+
+  return (
+    `<?xml version="1.0"?>` +
+    `<?mso-application progid="Excel.Sheet"?>` +
+    `<Workbook xmlns="urn:schemas-microsoft-com:office:spreadsheet" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:x="urn:schemas-microsoft-com:office:excel" xmlns:ss="urn:schemas-microsoft-com:office:spreadsheet">` +
+    `<Worksheet ss:Name="${escapeXml(sheetName)}">` +
+    `<Table>` +
+    `<Row>${headerRow}</Row>` +
+    dataRows +
+    `</Table>` +
+    `</Worksheet>` +
+    `</Workbook>`
+  );
+}
+
+async function getModerationQueue({ type }) {
+  const normalized = typeof type === 'string' ? type.trim().toLowerCase() : '';
+  if (normalized === 'events') {
+    const events = await listEventsPendingApproval();
+    return {
+      type: 'events',
+      count: events.length,
+      items: events.map(mapEventSummary),
+    };
+  }
+  if (normalized === 'sponsors') {
+    const sponsors = await listSponsorProfiles({ statuses: ['PENDING'] });
+    return {
+      type: 'sponsors',
+      count: sponsors.length,
+      items: sponsors.map(mapSponsorSummary),
+    };
+  }
+  if (normalized === 'media') {
+    const queue = await listPendingMedia({ page: 1, pageSize: 50 });
+    const uniqueEventIds = Array.from(new Set(queue.media.map((item) => item.eventId))).filter(Boolean);
+    const events = await Promise.all(uniqueEventIds.map((eventId) => findEventById(eventId).catch(() => null)));
+    const eventLookup = new Map(events.filter(Boolean).map((event) => [event.id, event]));
+    return {
+      type: 'media',
+      count: queue.total,
+      items: queue.media.map((item) => mapMediaSummary(item, eventLookup)),
+    };
+  }
+  throw Object.assign(new Error('Unsupported moderation type'), { statusCode: 400 });
+}
+
+async function approveEvent({ eventId, actorId, note }) {
+  const before = await findEventById(eventId);
+  if (!before) {
+    throw Object.assign(new Error('Event not found'), { statusCode: 404 });
+  }
+  const updated = await setEventApprovalStatus(eventId, {
+    status: 'APPROVED',
+    note,
+    moderatorId: actorId,
+  });
+
+  await recordAuditLog({
+    actorId,
+    action: 'admin.event.approve',
+    entityType: 'event',
+    entityId: updated.id,
+    before: toAuditEvent(before),
+    after: toAuditEvent(updated),
+  });
+
+  if (updated.createdBy) {
+    try {
+      const creator = await findUserById(updated.createdBy);
+      if (creator?.email) {
+        await sendTemplatedEmail({
+          to: creator.email,
+          subject: 'Your event is approved and live',
+          heading: 'Your event is live! 🌿',
+          bodyLines: [
+            `Hi ${creator.name?.split(' ')[0] || 'there'},`,
+            `We reviewed and approved <strong>${updated.title}</strong>. It's now visible to volunteers.`,
+            `Start: ${toIso(updated.dateStart || updated.date_start) || 'TBD'} · Location: ${describeEventLocation(updated)}`,
+          ],
+          previewText: 'Your event is ready for volunteers',
+        });
+      }
+    } catch (error) {
+      logger.warn('Failed to send event approval email', { eventId, error: error.message });
+    }
+  }
+
+  return mapEventSummary(updated);
+}
+
+async function rejectEvent({ eventId, actorId, note }) {
+  const before = await findEventById(eventId);
+  if (!before) {
+    throw Object.assign(new Error('Event not found'), { statusCode: 404 });
+  }
+  const updated = await setEventApprovalStatus(eventId, {
+    status: 'REJECTED',
+    note,
+    moderatorId: actorId,
+  });
+
+  await recordAuditLog({
+    actorId,
+    action: 'admin.event.reject',
+    entityType: 'event',
+    entityId: updated.id,
+    before: toAuditEvent(before),
+    after: toAuditEvent(updated),
+  });
+
+  if (updated.createdBy) {
+    try {
+      const creator = await findUserById(updated.createdBy);
+      if (creator?.email) {
+        await sendTemplatedEmail({
+          to: creator.email,
+          subject: 'Event submission update',
+          heading: 'We need a quick update',
+          bodyLines: [
+            `Hi ${creator.name?.split(' ')[0] || 'there'},`,
+            `We reviewed <strong>${updated.title}</strong> and need a few tweaks before it can go live.`,
+            note ? `Moderator note: ${note}` : 'Reply to this email for guidance or resubmit when you are ready.',
+          ],
+          previewText: 'Your event needs updates before publishing',
+        });
+      }
+    } catch (error) {
+      logger.warn('Failed to send event rejection email', { eventId, error: error.message });
+    }
+  }
+
+  return mapEventSummary(updated);
+}
+
+async function approveSponsor({ sponsorId, actorId }) {
+  const before = await findSponsorProfile(sponsorId);
+  if (!before) {
+    throw Object.assign(new Error('Sponsor profile not found'), { statusCode: 404 });
+  }
+  const updated = await updateSponsorApproval({ sponsorId, status: 'APPROVED' });
+  await recordAuditLog({
+    actorId,
+    action: 'admin.sponsor.approve',
+    entityType: 'sponsor_profile',
+    entityId: sponsorId,
+    before: toAuditSponsor(before),
+    after: toAuditSponsor(updated),
+  });
+  return mapSponsorSummary(updated);
+}
+
+async function rejectSponsor({ sponsorId, actorId }) {
+  const before = await findSponsorProfile(sponsorId);
+  if (!before) {
+    throw Object.assign(new Error('Sponsor profile not found'), { statusCode: 404 });
+  }
+  const updated = await updateSponsorApproval({ sponsorId, status: 'DECLINED' });
+  await recordAuditLog({
+    actorId,
+    action: 'admin.sponsor.reject',
+    entityType: 'sponsor_profile',
+    entityId: sponsorId,
+    before: toAuditSponsor(before),
+    after: toAuditSponsor(updated),
+  });
+  return mapSponsorSummary(updated);
+}
+
+async function approveMedia({ mediaId, actorId }) {
+  const before = await findMediaById(mediaId);
+  if (!before) {
+    throw Object.assign(new Error('Media not found'), { statusCode: 404 });
+  }
+  const updated = await moderateMedia({ mediaId, action: 'approve', moderatorId: actorId });
+  await recordAuditLog({
+    actorId,
+    action: 'admin.media.approve',
+    entityType: 'event_media',
+    entityId: mediaId,
+    before: toAuditMedia(before),
+    after: toAuditMedia(updated),
+  });
+  return updated;
+}
+
+async function rejectMedia({ mediaId, actorId, reason }) {
+  const before = await findMediaById(mediaId);
+  if (!before) {
+    throw Object.assign(new Error('Media not found'), { statusCode: 404 });
+  }
+  const updated = await moderateMedia({ mediaId, action: 'reject', moderatorId: actorId, reason });
+  await recordAuditLog({
+    actorId,
+    action: 'admin.media.reject',
+    entityType: 'event_media',
+    entityId: mediaId,
+    before: toAuditMedia(before),
+    after: toAuditMedia(updated),
+  });
+  return updated;
+}
+
+async function approveEntity({ entityType, entityId, actorId, note }) {
+  const normalized = typeof entityType === 'string' ? entityType.trim().toLowerCase() : '';
+  if (normalized === 'events') {
+    return approveEvent({ eventId: entityId, actorId, note });
+  }
+  if (normalized === 'sponsors') {
+    return approveSponsor({ sponsorId: entityId, actorId });
+  }
+  if (normalized === 'media') {
+    return approveMedia({ mediaId: entityId, actorId });
+  }
+  throw Object.assign(new Error('Unsupported entity type'), { statusCode: 400 });
+}
+
+async function rejectEntity({ entityType, entityId, actorId, note }) {
+  const normalized = typeof entityType === 'string' ? entityType.trim().toLowerCase() : '';
+  if (normalized === 'events') {
+    return rejectEvent({ eventId: entityId, actorId, note });
+  }
+  if (normalized === 'sponsors') {
+    return rejectSponsor({ sponsorId: entityId, actorId });
+  }
+  if (normalized === 'media') {
+    return rejectMedia({ mediaId: entityId, actorId, reason: note });
+  }
+  throw Object.assign(new Error('Unsupported entity type'), { statusCode: 400 });
+}
+
+async function updateUser({ userId, roles, isActive, actorId }) {
+  const existing = await findUserById(userId);
+  if (!existing) {
+    throw Object.assign(new Error('User not found'), { statusCode: 404 });
+  }
+
+  let current = existing;
+
+  if (roles !== undefined) {
+    const normalizedRoles = sanitizeRolesInput(roles);
+    if (!normalizedRoles.length) {
+      throw Object.assign(new Error('At least one valid role is required'), { statusCode: 400 });
+    }
+    const updatedRolesUser = await replaceUserRoles({ userId, roles: normalizedRoles });
+    await recordAuditLog({
+      actorId,
+      action: 'admin.user.roles',
+      entityType: 'user',
+      entityId: userId,
+      before: toAuditUser(current),
+      after: toAuditUser(updatedRolesUser),
+    });
+    current = updatedRolesUser;
+  }
+
+  if (typeof isActive === 'boolean' && isActive !== (current.is_active !== false)) {
+    const toggled = await setUserActiveStatus({ userId, isActive });
+    await recordAuditLog({
+      actorId,
+      action: isActive ? 'admin.user.activate' : 'admin.user.deactivate',
+      entityType: 'user',
+      entityId: userId,
+      before: toAuditUser(current),
+      after: toAuditUser(toggled),
+    });
+    current = toggled;
+  }
+
+  return mapUserSummary(current);
+}
+
+async function getReportsOverview() {
+  return getOverviewMetrics();
+}
+
+async function exportData({ entity, format }) {
+  const normalized = typeof entity === 'string' ? entity.trim().toLowerCase() : '';
+  const normalizedFormat = typeof format === 'string' ? format.trim().toLowerCase() : 'csv';
+
+  function formatResponse({ columns, rows }) {
+    if (normalizedFormat === 'excel' || normalizedFormat === 'xls' || normalizedFormat === 'xlsx') {
+      return {
+        content: buildExcelXml(columns, rows, `${normalized || 'export'}`.slice(0, 24) || 'Export'),
+        contentType: 'application/vnd.ms-excel',
+        extension: 'xls',
+      };
+    }
+    if (normalizedFormat === 'csv' || normalizedFormat === '') {
+      return {
+        content: buildCsv(columns, rows),
+        contentType: 'text/csv',
+        extension: 'csv',
+      };
+    }
+    throw Object.assign(new Error('Unsupported export format'), { statusCode: 400 });
+  }
+
+  if (normalized === 'users') {
+    const rows = await getUsersForExport();
+    const columns = [
+      { key: 'id', header: 'User ID' },
+      { key: 'name', header: 'Name' },
+      { key: 'email', header: 'Email' },
+      { key: 'roles', header: 'Roles', accessor: (row) => (Array.isArray(row.roles) ? row.roles.join('; ') : '') },
+      { key: 'is_active', header: 'Active' },
+      { key: 'email_verified_at', header: 'Email Verified At', accessor: (row) => toIso(row.email_verified_at) },
+      { key: 'created_at', header: 'Created At', accessor: (row) => toIso(row.created_at) },
+    ];
+    return formatResponse({ columns, rows });
+  }
+  if (normalized === 'events') {
+    const rows = await getEventsForExport();
+    const columns = [
+      { key: 'id', header: 'Event ID' },
+      { key: 'title', header: 'Title' },
+      { key: 'status', header: 'Status' },
+      { key: 'approval_status', header: 'Approval Status' },
+      { key: 'date_start', header: 'Start', accessor: (row) => toIso(row.date_start) },
+      { key: 'date_end', header: 'End', accessor: (row) => toIso(row.date_end) },
+      { key: 'created_at', header: 'Created At', accessor: (row) => toIso(row.created_at) },
+      { key: 'published_at', header: 'Published At', accessor: (row) => toIso(row.published_at) },
+      { key: 'created_by', header: 'Created By' },
+      { key: 'category', header: 'Category' },
+      { key: 'location', header: 'Location' },
+    ];
+    return formatResponse({ columns, rows });
+  }
+  if (normalized === 'sponsorships') {
+    const rows = await getSponsorshipsForExport();
+    const columns = [
+      { key: 'id', header: 'Sponsorship ID' },
+      { key: 'sponsor_id', header: 'Sponsor ID' },
+      { key: 'event_id', header: 'Event ID' },
+      { key: 'type', header: 'Type' },
+      { key: 'amount', header: 'Amount' },
+      { key: 'status', header: 'Status' },
+      { key: 'approved_at', header: 'Approved At', accessor: (row) => toIso(row.approved_at) },
+      { key: 'pledged_at', header: 'Pledged At', accessor: (row) => toIso(row.pledged_at) },
+    ];
+    return formatResponse({ columns, rows });
+  }
+  if (normalized === 'media') {
+    const rows = await getMediaForExport();
+    const columns = [
+      { key: 'id', header: 'Media ID' },
+      { key: 'event_id', header: 'Event ID' },
+      { key: 'uploader_id', header: 'Uploader ID' },
+      { key: 'status', header: 'Status' },
+      { key: 'created_at', header: 'Created At', accessor: (row) => toIso(row.created_at) },
+      { key: 'approved_at', header: 'Approved At', accessor: (row) => toIso(row.approved_at) },
+      { key: 'rejection_reason', header: 'Rejection Reason' },
+    ];
+    return formatResponse({ columns, rows });
+  }
+  throw Object.assign(new Error('Unsupported export entity'), { statusCode: 400 });
+}
+
+module.exports = {
+  getModerationQueue,
+  approveEntity,
+  rejectEntity,
+  updateUser,
+  getReportsOverview,
+  exportData,
+};

--- a/backend/src/features/event-management/eventManagement.service.js
+++ b/backend/src/features/event-management/eventManagement.service.js
@@ -452,6 +452,10 @@ function mapEvent(event) {
       ? event.requiredAvailability
       : [],
     isOnline: Boolean(event.isOnline ?? event.is_online),
+    approvalStatus: event.approvalStatus || event.approval_status || 'PENDING',
+    approvalNote: event.approvalNote || event.approval_note || null,
+    approvalDecidedAt: toIso(event.approvalDecidedAt || event.approval_decided_at),
+    approvalDecidedBy: event.approvalDecidedBy || event.approval_decided_by || null,
   };
 }
 
@@ -616,6 +620,12 @@ async function publishEvent(eventId, actor) {
   }
   if (event.status === 'COMPLETED') {
     throw Object.assign(new Error('Completed events cannot be republished'), { statusCode: 400 });
+  }
+
+  if ((event.approvalStatus || event.approval_status || 'PENDING') !== 'APPROVED') {
+    throw Object.assign(new Error('Admin approval is required before publishing this event'), {
+      statusCode: 403,
+    });
   }
 
   const updated = await setEventStatus(eventId, 'PUBLISHED');

--- a/backend/src/features/sponsors/sponsor.repository.js
+++ b/backend/src/features/sponsors/sponsor.repository.js
@@ -1,5 +1,6 @@
 const { randomUUID } = require('crypto');
 const pool = require('../common/db');
+const { ensureSchema: ensureVolunteerSchema } = require('../volunteer-journey/volunteerJourney.repository');
 
 const VALID_PROFILE_STATUSES = ['PENDING', 'APPROVED', 'DECLINED'];
 const VALID_SPONSORSHIP_TYPES = ['FUNDS', 'IN_KIND'];
@@ -70,6 +71,7 @@ function mapSponsorshipRow(row) {
 }
 
 const schemaPromise = (async () => {
+  await ensureVolunteerSchema();
   await pool.query(`
     CREATE TABLE IF NOT EXISTS sponsor_profiles (
       user_id UUID PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,

--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -184,6 +184,11 @@ he app boots under the CDN.
 - **Change:** Introduced the sponsor workflow end to end: sponsors apply for approval, admins moderate applications, approved sponsors pledge funds or in-kind support to events, and dashboards surface live sponsorships with ROI-ready metrics and impact reports.
 - **Impact:** Sponsors gain a dedicated workspace to support events, see their logos across event and gallery experiences, and receive automated summaries of volunteer hours, attendance, and gallery visibility tied to their contributions.
 
+## Phase 6 admin oversight
+- **Date:** 2025-10-08
+- **Change:** Delivered a comprehensive admin console with moderation queues for events, sponsors, and gallery media; approval/rejection APIs that log before/after snapshots; user management to toggle roles and deactivate accounts; and downloadable reports with CSV/Excel output plus refreshed metrics tiles.
+- **Impact:** Admins can govern the entire platform from one screen, keep audit trails for every action, notify submitters automatically, and download system-wide datasets for compliance or analytics without touching the database.
+
 
 ## Sponsor event discovery guardrails
 - **Date:** 2025-10-02

--- a/frontend/src/features/admin/AGENTS.md
+++ b/frontend/src/features/admin/AGENTS.md
@@ -1,0 +1,10 @@
+# Admin Frontend Guidelines
+
+These instructions apply to files within `frontend/src/features/admin/`.
+
+- Compose the admin experience from small presentational components that receive data and callbacks as props; keep async logic in hooks or the top-level dashboard.
+- Use the shared `apiClient` for JSON requests and fall back to the Fetch API directly when downloading CSV files so headers can stay configurable.
+- Keep layouts responsive by relying on CSS grid or flex utilities—verify mobile breakpoints around 360px wide still render readable queues.
+- Surface moderation errors inline near the triggering control rather than using `alert()` so the dashboard remains accessible.
+- Whenever you expose an export action, disable the trigger while the request is in flight to prevent duplicate downloads.
+- Keep export controls paired with a shared format selector so CSV and Excel toggles stay in sync across datasets.

--- a/frontend/src/features/admin/AdminOverviewCards.jsx
+++ b/frontend/src/features/admin/AdminOverviewCards.jsx
@@ -1,0 +1,137 @@
+import DashboardCard from '../dashboard/DashboardCard';
+
+function formatMinutes(minutes) {
+  if (!minutes) {
+    return '0 hrs';
+  }
+  const hours = Math.round((Number(minutes) || 0) / 60);
+  return `${hours} hrs`;
+}
+
+export default function AdminOverviewCards({ overview, loading = false, error = '' }) {
+  if (loading) {
+    return (
+      <div className="md:col-span-full">
+        <DashboardCard
+          title="Community snapshot"
+          description="Pulse metrics will appear once the reports load."
+        >
+          <p className="m-0 text-sm text-brand-muted">Loading overview…</p>
+        </DashboardCard>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="md:col-span-full">
+        <DashboardCard
+          title="Community snapshot"
+          description="We hit a snag while loading metrics."
+        >
+          <p className="m-0 text-sm font-medium text-red-600">{error}</p>
+        </DashboardCard>
+      </div>
+    );
+  }
+
+  if (!overview) {
+    return null;
+  }
+
+  const roleEntries = Object.entries(overview.roleCounts || {});
+
+  return (
+    <div className="grid gap-5 md:grid-cols-2">
+      <DashboardCard
+        title="Community snapshot"
+        description="Active accounts and role distribution across the platform."
+      >
+        <ul className="m-0 list-none space-y-1.5 p-0 text-sm text-brand-muted">
+          <li>
+            Active users: <strong className="text-brand-forest">{overview.users?.active ?? 0}</strong>
+          </li>
+          <li>
+            Inactive users: <strong className="text-brand-forest">{overview.users?.inactive ?? 0}</strong>
+          </li>
+          <li>
+            Total accounts: <strong className="text-brand-forest">{overview.users?.total ?? 0}</strong>
+          </li>
+          {roleEntries.length ? (
+            <li>
+              <span className="font-semibold text-brand-forest">Roles</span>
+              <ul className="mt-1 list-disc space-y-0.5 pl-5 text-xs text-brand-muted">
+                {roleEntries.map(([role, count]) => (
+                  <li key={role} className="uppercase tracking-[0.2em] text-brand-forest">
+                    {role}: {count}
+                  </li>
+                ))}
+              </ul>
+            </li>
+          ) : null}
+        </ul>
+      </DashboardCard>
+
+      <DashboardCard
+        title="Event pipeline"
+        description="Monitor the flow of events from submission to impact."
+      >
+        <ul className="m-0 list-none space-y-1.5 p-0 text-sm text-brand-muted">
+          <li>
+            Pending approval: <strong className="text-brand-forest">{overview.events?.pendingApproval ?? 0}</strong>
+          </li>
+          <li>
+            Published: <strong className="text-brand-forest">{overview.events?.published ?? 0}</strong>
+          </li>
+          <li>
+            Upcoming: <strong className="text-brand-forest">{overview.events?.upcoming ?? 0}</strong>
+          </li>
+          <li>
+            Completed: <strong className="text-brand-forest">{overview.events?.completed ?? 0}</strong>
+          </li>
+        </ul>
+      </DashboardCard>
+
+      <DashboardCard
+        title="Sponsor impact"
+        description="Track sponsor approvals and approved contribution volume."
+      >
+        <ul className="m-0 list-none space-y-1.5 p-0 text-sm text-brand-muted">
+          <li>
+            Approved sponsors: <strong className="text-brand-forest">{overview.sponsors?.approved ?? 0}</strong>
+          </li>
+          <li>
+            Pending reviews: <strong className="text-brand-forest">{overview.sponsors?.pending ?? 0}</strong>
+          </li>
+          <li>
+            Declined applications: <strong className="text-brand-forest">{overview.sponsors?.declined ?? 0}</strong>
+          </li>
+          <li>
+            Approved funds: <strong className="text-brand-forest">₹{Number(overview.sponsors?.approvedFunds || 0).toLocaleString()}</strong>
+          </li>
+        </ul>
+      </DashboardCard>
+
+      <DashboardCard
+        title="Engagement pulse"
+        description="Volunteer momentum and gallery health across the last month."
+      >
+        <ul className="m-0 list-none space-y-1.5 p-0 text-sm text-brand-muted">
+          <li>
+            Volunteer hours logged: <strong className="text-brand-forest">{formatMinutes(overview.volunteers?.totalMinutes)}</strong>
+          </li>
+          <li>
+            Active volunteers (30 days):{' '}
+            <strong className="text-brand-forest">{overview.volunteers?.activeLast30Days ?? 0}</strong>
+          </li>
+          <li>
+            Gallery items pending: <strong className="text-brand-forest">{overview.gallery?.pending ?? 0}</strong>
+          </li>
+          <li>
+            Approvals last week: <strong className="text-brand-forest">{overview.audits?.actionsLast7Days ?? 0}</strong>
+          </li>
+        </ul>
+      </DashboardCard>
+    </div>
+  );
+}

--- a/frontend/src/features/admin/ModerationQueues.jsx
+++ b/frontend/src/features/admin/ModerationQueues.jsx
@@ -1,0 +1,144 @@
+import { useMemo } from 'react';
+import DashboardCard from '../dashboard/DashboardCard';
+
+const QUEUE_TYPES = [
+  { key: 'events', label: 'Events' },
+  { key: 'sponsors', label: 'Sponsors' },
+  { key: 'media', label: 'Galleries' },
+];
+
+function formatDate(value) {
+  if (!value) return 'TBD';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return 'TBD';
+  return new Intl.DateTimeFormat('en-IN', { dateStyle: 'medium', timeStyle: 'short' }).format(date);
+}
+
+export default function ModerationQueues({
+  type,
+  queue,
+  notes,
+  onTypeChange,
+  onApprove,
+  onReject,
+  onNoteChange,
+  loading,
+  error,
+}) {
+  const activeType = useMemo(() => type || 'events', [type]);
+  const items = queue?.items || [];
+
+  return (
+    <DashboardCard
+      title="Moderation center"
+      description="Approve events, sponsor applications, and gallery submissions from a single hub."
+      className="md:col-span-full"
+    >
+      <div className="flex flex-wrap gap-2">
+        {QUEUE_TYPES.map((entry) => {
+          const active = entry.key === activeType;
+          return (
+            <button
+              key={entry.key}
+              type="button"
+              onClick={() => onTypeChange(entry.key)}
+              className={`rounded-full px-4 py-2 text-sm font-semibold transition ${
+                active
+                  ? 'bg-brand-forest text-white shadow'
+                  : 'bg-white text-brand-forest shadow-sm hover:bg-brand-sand/60'
+              }`}
+            >
+              {entry.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {error ? <p className="mt-4 text-sm font-medium text-red-600">{error}</p> : null}
+      {loading ? <p className="mt-4 text-sm text-brand-muted">Loading moderation queue…</p> : null}
+
+      {!loading && !items.length ? (
+        <p className="mt-4 text-sm text-brand-muted">No pending items. Enjoy the calm! 🌿</p>
+      ) : null}
+
+      <ul className="mt-4 grid list-none gap-4 p-0">
+        {items.map((item) => {
+          const noteValue = notes[item.id] || '';
+          return (
+            <li key={item.id} className="rounded-xl border border-brand-green/30 bg-white/90 p-4 shadow-sm">
+              <header className="flex flex-col gap-1 border-b border-brand-green/20 pb-3">
+                <h3 className="m-0 font-display text-lg font-semibold text-brand-forest">
+                  {activeType === 'events' && item.title}
+                  {activeType === 'sponsors' && item.orgName}
+                  {activeType === 'media' && (item.eventTitle || 'Gallery submission')}
+                </h3>
+                <p className="m-0 text-xs uppercase tracking-[0.2em] text-brand-muted">
+                  {activeType === 'events' && 'Event submission'}
+                  {activeType === 'sponsors' && 'Sponsor application'}
+                  {activeType === 'media' && 'Gallery item'}
+                </p>
+              </header>
+
+              <div className="mt-3 space-y-2 text-sm text-brand-muted">
+                {activeType === 'events' ? (
+                  <>
+                    <p className="m-0">Submitted by: {item.createdByName || 'Unknown'} · {item.createdByEmail || 'N/A'}</p>
+                    <p className="m-0">Schedule: {formatDate(item.dateStart)} → {formatDate(item.dateEnd)}</p>
+                    <p className="m-0">Location: {item.location || 'TBD'}</p>
+                    {item.approvalNote ? (
+                      <p className="m-0 text-amber-700">Previous note: {item.approvalNote}</p>
+                    ) : null}
+                  </>
+                ) : null}
+
+                {activeType === 'sponsors' ? (
+                  <>
+                    <p className="m-0">Contact: {item.contactName || 'Team lead'} · {item.contactEmail || 'N/A'}</p>
+                    <p className="m-0">Applied on: {formatDate(item.appliedAt)}</p>
+                  </>
+                ) : null}
+
+                {activeType === 'media' ? (
+                  <>
+                    <p className="m-0">Uploaded by: {item.uploaderId}</p>
+                    <p className="m-0">Submitted: {formatDate(item.submittedAt)}</p>
+                    {item.caption ? <p className="m-0">Caption: {item.caption}</p> : null}
+                  </>
+                ) : null}
+              </div>
+
+              <div className="mt-4 flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                <label className="flex-1 text-xs font-semibold uppercase tracking-[0.2em] text-brand-muted">
+                  Moderation note
+                  <input
+                    type="text"
+                    value={noteValue}
+                    onChange={(event) => onNoteChange(item.id, event.target.value)}
+                    placeholder={activeType === 'events' ? 'Optional feedback for managers' : 'Optional note'}
+                    className="mt-1 w-full rounded-md border border-brand-green/40 bg-white px-3 py-2 text-sm text-brand-forest focus:border-brand-green focus:outline-none focus:ring-2 focus:ring-brand-green/40"
+                  />
+                </label>
+                <div className="flex gap-2 md:justify-end">
+                  <button
+                    type="button"
+                    onClick={() => onReject(activeType, item.id, noteValue)}
+                    className="rounded-full border border-brand-green/40 px-4 py-2 text-sm font-semibold text-brand-forest transition hover:bg-brand-sand/70"
+                  >
+                    Reject
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => onApprove(activeType, item.id)}
+                    className="rounded-full bg-brand-forest px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-brand-forest/90"
+                  >
+                    Approve
+                  </button>
+                </div>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </DashboardCard>
+  );
+}

--- a/frontend/src/features/admin/ReportingPanel.jsx
+++ b/frontend/src/features/admin/ReportingPanel.jsx
@@ -1,0 +1,63 @@
+import DashboardCard from '../dashboard/DashboardCard';
+
+const EXPORT_OPTIONS = [
+  { key: 'users', label: 'Users dataset' },
+  { key: 'events', label: 'Events dataset' },
+  { key: 'sponsorships', label: 'Sponsorships dataset' },
+  { key: 'media', label: 'Gallery dataset' },
+];
+
+export default function ReportingPanel({ onExport, exportState, format, onFormatChange }) {
+  return (
+    <DashboardCard
+      title="Reporting & exports"
+      description="Snapshot metrics and export raw data for deeper analysis."
+      className="md:col-span-full"
+    >
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <p className="m-0 text-sm text-brand-muted">
+          Choose your file type, then download the dataset you need.
+        </p>
+        <label className="flex items-center gap-2 text-sm font-medium text-brand-forest">
+          Format
+          <select
+            value={format}
+            onChange={(event) => onFormatChange(event.target.value)}
+            className="rounded-lg border border-brand-green/40 bg-white px-3 py-1 text-sm shadow-sm focus:border-brand-forest focus:outline-none focus:ring-2 focus:ring-brand-forest/40"
+          >
+            <option value="csv">CSV</option>
+            <option value="excel">Excel</option>
+          </select>
+        </label>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        {EXPORT_OPTIONS.map((option) => {
+          const busy = exportState.entity === option.key && exportState.status === 'loading';
+          return (
+            <button
+              key={option.key}
+              type="button"
+              onClick={() => onExport(option.key, format)}
+              disabled={busy}
+              className="rounded-xl border border-brand-green/30 bg-white px-4 py-3 text-sm font-semibold text-brand-forest shadow-sm transition hover:bg-brand-sand/60 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {busy
+                ? 'Preparing…'
+                : `Download ${option.label} (${format === 'excel' ? 'Excel' : 'CSV'})`}
+            </button>
+          );
+        })}
+      </div>
+
+      {exportState.error ? (
+        <p className="mt-3 text-sm font-medium text-red-600">{exportState.error}</p>
+      ) : null}
+
+      <p className="mt-4 text-xs text-brand-muted">
+        Exports include UTC timestamps. CSV opens in any spreadsheet, and the Excel option ships a ready-to-open workbook for
+        stakeholders who prefer .xls files.
+      </p>
+    </DashboardCard>
+  );
+}

--- a/frontend/src/features/admin/UserManagementPanel.jsx
+++ b/frontend/src/features/admin/UserManagementPanel.jsx
@@ -1,0 +1,102 @@
+import DashboardCard from '../dashboard/DashboardCard';
+
+export default function UserManagementPanel({
+  users,
+  roles,
+  form,
+  onFormChange,
+  onSubmit,
+  state,
+  onRefresh,
+}) {
+  return (
+    <DashboardCard
+      title="User management"
+      description="Adjust roles or deactivate accounts when responsibilities change."
+    >
+      <form onSubmit={onSubmit} className="flex flex-col gap-4">
+        <div className="flex flex-col gap-1.5">
+          <label className="text-sm font-semibold text-brand-muted" htmlFor="admin-user-select">
+            Select user
+          </label>
+          <div className="flex gap-2">
+            <select
+              id="admin-user-select"
+              name="userId"
+              value={form.userId}
+              onChange={(event) => onFormChange({ userId: event.target.value })}
+              className="w-full rounded-md border border-brand-green/40 bg-white/90 px-3 py-3 text-base shadow-sm transition focus:border-brand-green focus:outline-none focus:ring-2 focus:ring-brand-green/40"
+            >
+              <option value="">Choose a user</option>
+              {users.map((entry) => (
+                <option key={entry.id} value={entry.id}>
+                  {entry.name} · {entry.email} {entry.isActive ? '' : '(inactive)'}
+                </option>
+              ))}
+            </select>
+            <button
+              type="button"
+              onClick={onRefresh}
+              className="rounded-md border border-brand-green/40 bg-white px-3 py-2 text-sm font-semibold text-brand-forest shadow-sm transition hover:bg-brand-sand/70"
+            >
+              Refresh
+            </button>
+          </div>
+        </div>
+
+        <fieldset className="flex flex-col gap-3 rounded-md border border-brand-green/30 bg-brand-sand/20 px-3 py-3">
+          <legend className="px-2 text-xs font-semibold uppercase tracking-[0.2em] text-brand-muted">
+            Roles
+          </legend>
+          {roles.map((role) => {
+            const inputId = `admin-role-${role.toLowerCase()}`;
+            const checked = form.roles.includes(role);
+            return (
+              <label
+                key={role}
+                htmlFor={inputId}
+                className="flex items-center justify-between gap-3 rounded-md border border-brand-green/40 bg-white/80 px-3 py-2"
+              >
+                <span className="text-sm font-medium text-brand-forest">{role.replace('_', ' ')}</span>
+                <input
+                  id={inputId}
+                  type="checkbox"
+                  checked={checked}
+                  onChange={() =>
+                    onFormChange({
+                      roles: checked
+                        ? form.roles.filter((entry) => entry !== role)
+                        : [...form.roles, role],
+                    })
+                  }
+                  className="h-4 w-4 rounded border-brand-green text-brand-green focus:ring-brand-green"
+                />
+              </label>
+            );
+          })}
+        </fieldset>
+
+        <label className="flex items-center justify-between gap-3 rounded-md border border-brand-green/40 bg-white/80 px-3 py-2 text-sm font-medium text-brand-forest">
+          Active account
+          <input
+            type="checkbox"
+            checked={form.isActive}
+            onChange={(event) => onFormChange({ isActive: event.target.checked })}
+            className="h-4 w-4 rounded border-brand-green text-brand-green focus:ring-brand-green"
+          />
+        </label>
+
+        {state.error ? <p className="text-sm font-medium text-red-600">{state.error}</p> : null}
+        {state.message ? <p className="text-sm font-semibold text-brand-green">{state.message}</p> : null}
+
+        <button
+          type="submit"
+          className="btn-primary"
+          disabled={state.status === 'loading'}
+        >
+          {state.status === 'loading' ? 'Saving…' : 'Update user'}
+        </button>
+      </form>
+    </DashboardCard>
+  );
+}

--- a/frontend/src/features/admin/api.js
+++ b/frontend/src/features/admin/api.js
@@ -1,0 +1,69 @@
+import { apiRequest, API_BASE } from '../../lib/apiClient';
+
+export async function fetchModerationQueue({ token, type }) {
+  const params = type ? `?type=${encodeURIComponent(type)}` : '';
+  return apiRequest(`/api/admin/moderation${params}`, { token });
+}
+
+export async function approveEntity({ token, entityType, entityId, note }) {
+  return apiRequest(`/api/admin/approve/${entityType}/${entityId}`, {
+    method: 'POST',
+    token,
+    body: note ? { note } : undefined,
+  });
+}
+
+export async function rejectEntity({ token, entityType, entityId, note }) {
+  return apiRequest(`/api/admin/reject/${entityType}/${entityId}`, {
+    method: 'POST',
+    token,
+    body: note ? { note } : undefined,
+  });
+}
+
+export async function patchUser({ token, userId, roles, isActive }) {
+  const body = {};
+  if (roles !== undefined) {
+    body.roles = roles;
+  }
+  if (typeof isActive === 'boolean') {
+    body.isActive = isActive;
+  }
+  return apiRequest(`/api/admin/users/${userId}`, {
+    method: 'PATCH',
+    token,
+    body,
+  });
+}
+
+export async function fetchOverview({ token }) {
+  return apiRequest('/api/admin/reports/overview', { token });
+}
+
+export async function exportAdminData({ token, entity, format }) {
+  const url = new URL(`${API_BASE}/api/admin/export`);
+  if (entity) {
+    url.searchParams.set('entity', entity);
+  }
+  if (format) {
+    url.searchParams.set('format', format);
+  }
+  const response = await fetch(url.toString(), {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  if (!response.ok) {
+    throw new Error('Failed to export data');
+  }
+  const disposition = response.headers.get('content-disposition');
+  let filename = '';
+  if (disposition) {
+    const match = /filename="?([^";]+)"?/i.exec(disposition);
+    if (match?.[1]) {
+      filename = match[1];
+    }
+  }
+  const blob = await response.blob();
+  return { blob, filename };
+}


### PR DESCRIPTION
## Summary
- add an admin feature module that exposes moderation, approval, reporting, and export APIs while extending audit logs and user activation controls
- update event, sponsor, and gallery repositories to support approval status workflows and pg-mem friendly schema bootstrapping
- refresh the admin dashboard with dedicated components for overview metrics, moderation queues, user management, and CSV exports plus Phase 6 documentation updates

## Testing
- npm test
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68cda399f78883338916a2a34f40d020