### PR TITLE
Fix audit log metadata default

### DIFF
--- a/backend/src/features/auth/AGENTS.md
+++ b/backend/src/features/auth/AGENTS.md
@@ -5,6 +5,8 @@ These notes cover files within `backend/src/features/auth/`.
 - Keep the authentication flow lightweight and functional-first; business logic should live in `auth.service.js` and database queries in `auth.repository.js`.
 - Validation helpers can stay inside the route file as long as they remain small; extract them if they grow beyond a few checks.
 - Prefer structured audit metadata objects that can be serialized to JSON without circular references.
+- When you extend audit logging, default missing metadata to an empty object (`{}`) so inserts respect the database `NOT NULL`
+  constraint on the `metadata` column.
 - Whenever you add a new token type, document it in `docs/wiki/README.md` and extend the revoke helpers instead of creating new tables.
 - User records now maintain a primary `role` plus an expanded `user_roles` join table; always update both via the repository helpers so API responses expose a normalized `roles` array.
 - The admin bootstrapper seeds or promotes an ADMIN account from environment variables; prefer updating `admin.bootstrap.js` when adjusting default admin behavior.

--- a/backend/src/features/auth/auth.repository.js
+++ b/backend/src/features/auth/auth.repository.js
@@ -329,8 +329,12 @@ async function recordAuditLog({
   await ensureSchema();
   const id = randomUUID();
   const beforeJson = serializeSnapshot(before);
-  const afterJson = serializeSnapshot(after ?? metadata ?? {});
-  const metadataJson = metadata && after === null ? serializeSnapshot(metadata) : null;
+  const hasExplicitAfter = after !== undefined && after !== null;
+  const normalizedMetadata = metadata === undefined || metadata === null ? {} : metadata;
+  const afterJson = hasExplicitAfter
+    ? serializeSnapshot(after)
+    : serializeSnapshot(normalizedMetadata);
+  const metadataJson = serializeSnapshot(normalizedMetadata);
   await pool.query(
     `
       INSERT INTO audit_logs (id, actor_id, action, entity_type, entity_id, before, after, metadata)

--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -1,5 +1,13 @@
 # Onkur Change Log
 
+## Audit log metadata defaults
+- **Date:** 2025-10-09
+- **Change:** Normalized the backend audit logging helper to always persist an empty JSON object when optional metadata is
+  omitted, aligning inserts with the database `metadata` column's `NOT NULL` constraint and preventing login attempts from
+  failing mid-request.
+- **Impact:** Authentication flows, including login, now record audit trails without tripping the metadata constraint, so users
+  reach the dashboard even when no supplemental metadata accompanies the audit entry.
+
 ## React 18.3 alignment for auth hooks
 - **Date:** 2025-10-07
 - **Change:** Upgraded the frontend to `react@18.3.1` and `react-dom@18.3.1`, refreshed the lockfile, and enforced `npm dedupe` guidance so the Auth context resolves hooks against a single React dispatcher.


### PR DESCRIPTION
## Summary
- ensure audit log inserts always persist an empty metadata JSON object when no supplemental data is provided so the database constraint is satisfied
- document the audit logging expectation in the auth feature guidelines and wiki

## Testing
- npm run test:connections *(fails: Postgres connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_68cdaace6bf883338c35eaa64e478e88