### PR TITLE
Prevent stale React vendor caches after container restarts

### DIFF
--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -1,5 +1,10 @@
 # Onkur Change Log
 
+## Dev server cache headers for React integrity
+- **Date:** 2025-10-12
+- **Change:** Configured the Vite dev server to emit `no-store` cache headers so module requests bypass browser caches after container restarts and documented the requirement in the frontend agent guide.
+- **Impact:** Prevents stale React vendor chunks from lingering in browser caches, eliminating the "Invalid hook call" errors that previously required a manual cache clear before the dashboard would load again.
+
 ## Impact analytics rollup hardening
 - **Date:** 2025-10-11
 - **Change:** Hardened the impact analytics repository to sum recorded dashboard views instead of counting rows, expanded the Jest suite with in-memory database coverage for story submission, moderation notifications, and overview export math, and refreshed impact feature guidelines to keep future changes aligned.

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -4,3 +4,4 @@
 - If you add or rename modulepreload tags or adjust Vite HTML transforms, update the `ensure-crossorigin-attributes` plugin in `vite.config.js` to keep the injected scripts in sync.
 - Load Google Fonts via `<link>` tags in `index.html` (not `@import`) and include `display=swap` so rendering stays non-blocking.
 - Avoid committing binary font assets; rely on the Google Fonts API with latin subsets when adjusting typography and note any changes in the wiki.
+- Keep the dev server cache headers (`server.headers`) set to `no-store` values in `vite.config.js` so browsers always fetch fresh modules after container restarts.

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -77,6 +77,11 @@ export default defineConfig({
     dedupe: ['react', 'react-dom'],
   },
   server: {
+    headers: {
+      'Cache-Control': 'no-store, no-cache, must-revalidate',
+      Pragma: 'no-cache',
+      Expires: '0',
+    },
     proxy: {
       '/api': 'http://localhost:5000', // Proxy API requests to backend
     },


### PR DESCRIPTION
## Summary
- add no-store cache headers to the Vite dev server so module responses bypass browser caches after restarts
- document the cache header requirement in the frontend agent guidelines and changelog

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cdc19a1d808333916462a6dcc06efd