### PR TITLE
Ensure gallery URLs follow live storage endpoint

### DIFF
--- a/backend/src/features/event-gallery/AGENTS.md
+++ b/backend/src/features/event-gallery/AGENTS.md
@@ -5,3 +5,4 @@ These notes apply to files within `backend/src/features/event-gallery/`.
 - Keep media moderation logic in the service layer so routes stay focused on validation and response shaping.
 - Sanitize and validate upload inputs in the service before persisting them; repositories should assume normalized payloads.
 - Whenever storage access is optional, log structured warnings via the shared logger so deployments can diagnose missing buckets without breaking uploads.
+- Always derive public media URLs from the current MinIO/S3 config using the shared helper so host or protocol changes roll out to existing records automatically.

--- a/backend/src/features/event-gallery/eventGallery.repository.js
+++ b/backend/src/features/event-gallery/eventGallery.repository.js
@@ -2,6 +2,7 @@ const { randomUUID } = require('crypto');
 const pool = require('../common/db');
 const { ensureSchema: ensureSponsorSchema } = require('../sponsors/sponsor.repository');
 const { ensureSchema: ensureVolunteerSchema } = require('../volunteer-journey/volunteerJourney.repository');
+const { resolveMediaUrl } = require('./storageUrl');
 
 const VALID_STATUSES = ['PENDING', 'APPROVED', 'REJECTED'];
 
@@ -25,7 +26,7 @@ function mapMediaRow(row) {
     eventId: row.event_id,
     uploaderId: row.uploader_id,
     storageKey: row.storage_key,
-    url: row.url,
+    url: resolveMediaUrl({ storageKey: row.storage_key, persistedUrl: row.url }),
     mimeType: row.mime_type,
     fileSize: Number(row.file_size || 0),
     width: row.width ? Number(row.width) : null,

--- a/backend/src/features/event-gallery/storageUrl.js
+++ b/backend/src/features/event-gallery/storageUrl.js
@@ -1,0 +1,35 @@
+const config = require('../../config');
+
+function buildStorageUrl({ key }) {
+  if (!key) {
+    return null;
+  }
+
+  const { bucket, endPoint, port, useSSL } = config.minio || {};
+  if (!bucket || !endPoint) {
+    return null;
+  }
+
+  const protocol = useSSL ? 'https' : 'http';
+  const portPart = port && ![80, 443].includes(Number(port)) ? `:${port}` : '';
+
+  return `${protocol}://${endPoint}${portPart}/${bucket}/${key}`;
+}
+
+function resolveMediaUrl({ storageKey, persistedUrl }) {
+  if (!storageKey || storageKey.startsWith('inline://')) {
+    return persistedUrl || null;
+  }
+
+  const generated = buildStorageUrl({ key: storageKey });
+  if (generated) {
+    return generated;
+  }
+
+  return persistedUrl || null;
+}
+
+module.exports = {
+  buildStorageUrl,
+  resolveMediaUrl,
+};

--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -1,3 +1,8 @@
+# Dynamic gallery URL resolution
+- **Date:** 2025-10-13
+- **Change:** Introduced a shared gallery storage URL helper that always rebuilds public media links from the live MinIO/S3 configuration and wired repository mappers to consume it while keeping inline fallbacks intact.
+- **Impact:** Updating `MINIO_ENDPOINT`, port, or TLS settings now retroactively adjusts previously uploaded gallery image URLs without backfilling the database, ensuring legacy media keeps working after storage host changes.
+
 # Onkur Change Log
 
 ## Dev server cache headers for React integrity


### PR DESCRIPTION
## Summary
- add a shared gallery storage URL helper that builds object URLs from the active MinIO/S3 configuration
- recompute media URLs when persisting and hydrating records so existing gallery items pick up endpoint changes automatically
- document the convention for future contributors and record the change in the wiki

## Testing
- npm run test:connections *(fails: Postgres connection failed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cdc52cceec833389937556c89a6d89