### PR TITLE
chore: enforce repository hygiene and automation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+
+jobs:
+  backend:
+    name: Backend lint & test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: backend/package-lock.json
+      - run: npm ci
+      - run: npm run format:check
+      - run: npm run lint
+      - run: npm test
+
+  frontend:
+    name: Frontend lint, test & build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci
+      - run: npm run format:check
+      - run: npm run lint
+      - run: npm run test
+      - run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -1,34 +1,34 @@
-# Environment files
-.env
-*.env
-!.env.example
-!*/.env.example
-
-# Node dependencies
+# Dependency directories
 node_modules/
-backend/node_modules/
 frontend/node_modules/
+backend/node_modules/
 
 # Build outputs
-/dist/
-/build/
 frontend/dist/
 backend/dist/
-
-# Logs
-*.log
-logs/
-
-# Coverage
 coverage/
-
-# OS / editor
-.DS_Store
-Thumbs.db
-.vscode/
-.idea/
-
-# Misc
+*.log
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# Environment files
+.env
+.env.local
+*.env
+
+# Editor files
+.DS_Store
+.vscode/
+.idea/
+
+# Runtime data
+*.pid
+*.seed
+
+# Docker artifacts
+*.pid.lock
+
+# Misc
+.tmp/
+.sass-cache/

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,7 @@
+{
+  "printWidth": 100,
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "semi": true,
+  "arrowParens": "always"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,10 +3,12 @@
 These instructions apply to the entire repository unless a nested `AGENTS.md` overrides them.
 
 ## Documentation expectations
+
 - Keep `README.md`, `.env.example` files, and the wiki in sync when you add or remove configuration options.
 - Prefer adding new guides under `docs/wiki/` when workflow explanations exceed a few paragraphs; cross-link them from the README.
 
 ## Backend changes (`backend/`)
+
 - Add new APIs as feature modules under `backend/src/features/<feature-name>/` and export Express routers from files ending in `.route.js`.
 - Avoid editing `src/app.js`, `src/server.js`, or `src/routes/index.js` unless you are improving the framework itself; feature work should plug in through the auto-loader.
 - Use the shared Winston logger from `backend/src/utils/logger.js` for all logs and include structured metadata where it adds clarity.
@@ -14,6 +16,7 @@ These instructions apply to the entire repository unless a nested `AGENTS.md` ov
 - When feasible, run `npm run test:connections` from the `backend` directory to verify database and MinIO connectivity after making integration changes.
 
 ## Frontend changes (`frontend/`)
+
 - Group related UI pieces under `frontend/src/features/<feature-name>/` and prefer feature-level components over editing `App.jsx` directly.
 - Ensure new API calls read `import.meta.env.VITE_API_BASE_URL` for the backend origin.
 - Run `npm run build` from the `frontend` directory to validate that the Vite build still succeeds after making frontend changes.
@@ -21,5 +24,9 @@ These instructions apply to the entire repository unless a nested `AGENTS.md` ov
 - When adding new top-level routes, prefer `React.lazy` with a shared suspense fallback so bundle splitting stays effective for GTmetrix performance budgets.
 
 ## Tooling
+
 - Do not commit environment secrets or generated assets under `dist/` or `build/`.
 - Use meaningful logging and inline comments sparingly—favor self-documenting code and keep this template lightweight.
+- Run the automated quality commands before pushing: `npm run lint` + `npm test` in `backend/` and `npm run lint`, `npm run test`,
+  and `npm run build` in `frontend/`. The CI pipeline enforces these checks along with Prettier formatting guards.
+- Leave `node_modules/` out of commits; dependency directories now live in `.gitignore` and should be recreated with `npm install`.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,66 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned with this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project team at [conduct@onkur.example](mailto:conduct@onkur.example). All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+1. **Correction**
+   - _Community Impact_: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+   - _Consequence_: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+2. **Warning**
+   - _Community Impact_: A violation through a single incident or series of actions.
+   - _Consequence_: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+3. **Temporary Ban**
+   - _Community Impact_: A serious violation of community standards, including sustained inappropriate behavior.
+   - _Consequence_: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+4. **Permanent Ban**
+   - _Community Impact_: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+   - _Consequence_: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1.
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the [FAQ](https://www.contributor-covenant.org/faq) or translations at the [Contributor Covenant translations](https://www.contributor-covenant.org/translations).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,54 @@
+# Contributing to Onkur
+
+Thanks for helping nurture the Onkur platform! This guide covers the basics for setting up your environment and submitting quality contributions.
+
+## Getting started
+
+1. **Fork and clone** the repository.
+2. Create a feature branch from `main`.
+3. Install dependencies:
+   - Backend: `cd backend && npm install`
+   - Frontend: `cd frontend && npm install`
+4. Copy the environment templates and adjust them for your setup:
+   - Backend: `cp backend/.env.example backend/.env`
+   - Frontend: `cp frontend/.env.example frontend/.env`
+
+## Development workflow
+
+- Keep backend feature code within `backend/src/features/<feature-name>/` and frontend work within `frontend/src/features/<feature-name>/` to preserve the modular structure described in `AGENTS.md`.
+- Document meaningful changes in `docs/Wiki.md` so future contributors understand the rationale.
+- Update any affected `.env.example`, README instructions, or wiki guides when you add configuration toggles.
+
+## Quality checks
+
+Before opening a pull request, run the automated checks locally:
+
+```bash
+# Backend
+cd backend
+npm run format:check
+npm run lint
+npm test
+
+# Frontend
+cd ../frontend
+npm run format:check
+npm run lint
+npm run test
+npm run build
+```
+
+The GitHub Actions pipeline runs the same commands on every push and pull request.
+
+## Commit & PR guidelines
+
+- Write descriptive commit messages that explain the why and the what.
+- Keep pull requests focused; smaller, reviewable PRs are easier to merge quickly.
+- Include screenshots or screen recordings for noticeable UI changes.
+- Note any follow-up work or known limitations in the PR description.
+
+## Community expectations
+
+Be kind, inclusive, and respectful. Please review our [Code of Conduct](CODE_OF_CONDUCT.md) to understand the shared standards for everyone who interacts with the project.
+
+Happy contributing! 🌿

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Onkur
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 # 🌿 Onkur Platform Overview
 
+[![CI](https://github.com/Onkur/Onkur/actions/workflows/ci.yml/badge.svg)](https://github.com/Onkur/Onkur/actions/workflows/ci.yml)
+
 Onkur is a mobile-first volunteering platform rooted in sustainability and community stewardship. The product is rolling out in three phases that collectively deliver authentication, volunteer empowerment, and rich event management workflows. Each milestone builds on a green-themed, responsive foundation so that every role—from volunteers to sponsors—has a tailored experience on phones first and desktops second.
 
 ## 🚦 Phase roadmap
 
 ### Phase 1 – Foundation (Complete)
+
 - Email + password signup, login, and logout backed by JWT auth with secure storage and revocation.
 - Role-based dashboards for Volunteers, Event Managers, Sponsors, and Admins, guarded by role-aware routing.
 - Admin tools to assign roles and manage the community directory while blocking unauthorized access.
@@ -12,6 +15,7 @@ Onkur is a mobile-first volunteering platform rooted in sustainability and commu
 - CI/CD workflow that installs dependencies, runs linting + unit tests for auth, and validates frontend builds.
 
 ### Phase 2 – Volunteer Journey (Complete)
+
 - Rich volunteer profile editor capturing skills, interests, location, and availability.
 - Event discovery with filters for date, location, category, and theme plus duplicate-signup prevention and capacity checks.
 - Event signup flow with confirmation + reminder emails, hours logging, and eco-badge thresholds (10/50/100 hours).
@@ -19,6 +23,7 @@ Onkur is a mobile-first volunteering platform rooted in sustainability and commu
 - Metrics tracking for conversion (views → signups), average volunteer hours, and retention.
 
 ### Phase 3 – Event Manager Workspace (Complete)
+
 - Event manager dashboard to create, draft, publish, and complete events with full date/time and capacity controls.
 - Task assignment surface so managers can allocate volunteers to event responsibilities and keep dashboards in sync.
 - Attendance tooling for check-in/out that feeds volunteer hour totals automatically.
@@ -26,6 +31,7 @@ Onkur is a mobile-first volunteering platform rooted in sustainability and commu
 - Notification suite for publish confirmations, assignment notices, reminders, and post-event acknowledgements.
 
 ### Phase 4 – Event Gallery (Complete)
+
 - Mobile-first gallery grid with lightbox viewer backed by infinite scroll so visitors can relive event stories quickly.
 - Volunteer and event manager upload flow with EXIF-stripped image processing, tag selection for volunteers/sponsors/communities, and moderation email notices.
 - Admin moderation queue to approve or reject submissions, capturing decision latency metrics and sponsor mentions automatically.
@@ -33,12 +39,14 @@ Onkur is a mobile-first volunteering platform rooted in sustainability and commu
 - MinIO/S3-backed storage with graceful inline fallback plus transactional emails to notify contributors and sponsors when galleries go live.
 
 ### Phase 5 – Sponsor Partnerships (Complete)
+
 - Sponsor registration and approval workflow that promotes verified organizations into the sponsor role.
 - Sponsor dashboard to manage organization profiles, pledge funds or in-kind support, and review live sponsorships.
 - Event and gallery experiences that surface approved sponsor logos and contributions for every supported event.
 - Automated impact reports summarizing volunteer hours, gallery views, and ROI metrics delivered to sponsor inboxes.
 
 ### Phase 6 – Admin Oversight (Complete)
+
 - Unified admin console that surfaces moderation queues for events, sponsors, and gallery media with bulk-ready workflows.
 - Approval and rejection APIs that publish or return submissions to draft while capturing audit trails and notifying submitters.
 - User management panel to adjust multi-role assignments and deactivate accounts without touching the database.
@@ -46,6 +54,7 @@ Onkur is a mobile-first volunteering platform rooted in sustainability and commu
 - Extended audit logging with before/after snapshots tied to each entity for transparent governance.
 
 ### Phase 7 – Impact & Community (Complete)
+
 - Beneficiaries, volunteers, and sponsors can submit rich event stories that flow through admin moderation with automated approval/rejection emails.
 - Approved impact stories surface alongside event galleries with sponsor highlights and community-friendly storytelling cards.
 - Platform-wide analytics dashboard reveals volunteer hours, participation, gallery engagement, and sponsor impressions with CSV export support.
@@ -58,6 +67,7 @@ Consult the living [product wiki](docs/Wiki.md) for design rationale, API schema
 ## 🚀 Getting started
 
 ### Backend (Express + Postgres)
+
 1. Install dependencies
    ```bash
    cd backend
@@ -89,6 +99,7 @@ Consult the living [product wiki](docs/Wiki.md) for design rationale, API schema
    ```
 
 ### Frontend (Vite + React)
+
 1. Install dependencies and configure the API origin
    ```bash
    cd frontend
@@ -104,34 +115,59 @@ Consult the living [product wiki](docs/Wiki.md) for design rationale, API schema
    Visit `http://localhost:5173` to explore the mobile-first shell.
 
 ### Docker (optional)
+
 Spin up both apps with shared hot reload:
+
 ```bash
 docker compose up --build
 ```
+
 - Backend: http://localhost:5000
 - Frontend: http://localhost:3000 (proxying Vite on 5173)
 
 ---
 
 ## ✅ Testing & quality
-Run the test suite and production build locally before pushing:
+
+Run the automated formatting, linting, tests, and production build locally before pushing:
 
 ```bash
 # backend
 cd backend
+npm run format:check
+npm run lint
 npm test
 
 # frontend
 cd ../frontend
+npm run format:check
+npm run lint
+npm run test
 npm run build
 ```
 
-The GitHub Actions pipeline (`.github/workflows/ci.yml`) mirrors these steps to keep the main branch healthy.
-Jest coverage now includes the impact storytelling pipeline—submission, moderation notifications, and analytics exports—so regressions surface quickly.
+These commands mirror the GitHub Actions workflow (`.github/workflows/ci.yml`) so pull requests stay green. Prettier guards consistent formatting, ESLint highlights common pitfalls, Vitest exercises the routing shell, and Jest protects the existing service contracts across the backend feature modules.
 
 ---
 
+## 🧹 Repository hygiene & environment
+
+- `.gitignore` now keeps `node_modules/`, build outputs, and log files out of commits. Reinstall dependencies with `npm install` in each workspace after cloning or pulling.
+- Bootstrap environment variables quickly by copying the provided `.env.example` files in `backend/` and `frontend/` before starting servers or tests.
+- The toolchain targets Node.js 20; matching that version keeps linting, testing, and build behavior consistent with CI.
+
+## 🤝 Contributing & community
+
+- Review the [CONTRIBUTING.md](CONTRIBUTING.md) guide for workflow conventions, required quality checks, and pull request tips.
+- Participation is governed by our [Code of Conduct](CODE_OF_CONDUCT.md); report concerns to the maintainers at conduct@onkur.example.
+- Summaries of noteworthy changes belong in [docs/Wiki.md](docs/Wiki.md) so future contributors understand the why behind updates.
+
+## 📄 License
+
+The project is available under the [MIT License](LICENSE).
+
 ## 🧭 Architecture quick reference
+
 - **Backend features** live under `backend/src/features/<feature-name>/`. Auth endpoints are defined in `auth.route.js`, volunteer flows under `volunteer-journey/`, and event tooling under `event-management/`.
 - **Frontend features** live under `frontend/src/features/<feature-name>/`. Dedicated modules for auth, volunteer, and event manager experiences plug into the router and reuse the shared `AuthProvider` for session state.
 - **Shared documentation**: the wiki captures stakeholder goals, color palette, data models, API reference, and roadmap milestones.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,40 +1,37 @@
 # Server
 PORT=5000
-CORS_ORIGIN=http://localhost:1010
+CORS_ORIGIN=http://localhost:5173
 LOG_LEVEL=info
-LOG_FILE=logs/onkur.log
-
-# App URLs
-APP_BASE_URL=http://localhost:1010
-
-# Email
-EMAIL_FROM="Onkur <no-reply@onkur.org>"
-EMAIL_SMTP_HOST=smtp.example.com
-EMAIL_SMTP_PORT=587
-EMAIL_SMTP_SECURE=false
-EMAIL_SMTP_USER=onkur
-EMAIL_SMTP_PASS=super-secret
 
 # Database
-DATABASE_URL=postgres://sayabasu:%211Dilbert@192.168.1.3:5432/onkur_db
+DATABASE_URL=postgres://postgres:postgres@localhost:5432/onkur
 
 # Authentication
-JWT_SECRET=Jindal12345
-JWT_EXPIRY=1h
-JWT_ISSUER=onkur-api
+JWT_SECRET=change-me
+JWT_EXPIRY=1d
+JWT_ISSUER=onkur
 BCRYPT_SALT_ROUNDS=12
 
 # Admin bootstrap
-# ADMIN_EMAIL accepts a comma-separated list that will be echoed in verification prompts.
-ADMIN_NAME=Onkur Platform Admin
+ADMIN_NAME=Onkur Admin
 ADMIN_EMAIL=admin@example.com
-ADMIN_PASSWORD=ChangeMeNow123
+ADMIN_PASSWORD=change-me
 
-# MinIO / Object storage
-MINIO_ENDPOINT=192.168.1.3
-MINIO_PORT=2000
-MINIO_ACCESS_KEY=sayabasu
-MINIO_SECRET_KEY=!1Dilbert
-MINIO_BUCKET=onkur
+# Email (SMTP)
+EMAIL_FROM="Onkur <no-reply@example.com>"
+EMAIL_SMTP_HOST=smtp.example.com
+EMAIL_SMTP_PORT=587
+EMAIL_SMTP_SECURE=false
+EMAIL_SMTP_USER=apikey
+EMAIL_SMTP_PASS=secret
+
+# Object storage
+MINIO_ENDPOINT=localhost
+MINIO_PORT=9000
 MINIO_USE_SSL=false
+MINIO_ACCESS_KEY=onkur
+MINIO_SECRET_KEY=supersecret
+MINIO_BUCKET=onkur-media
 
+# Application URLs
+APP_BASE_URL=http://localhost:5173

--- a/backend/.eslintignore
+++ b/backend/.eslintignore
@@ -1,0 +1,3 @@
+dist/
+coverage/
+node_modules/

--- a/backend/.eslintrc.cjs
+++ b/backend/.eslintrc.cjs
@@ -1,0 +1,18 @@
+module.exports = {
+  root: true,
+  env: {
+    node: true,
+    commonjs: true,
+    es2022: true,
+    jest: true,
+  },
+  extends: ['eslint:recommended', 'plugin:jest/recommended', 'prettier'],
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'script',
+  },
+  plugins: ['jest'],
+  rules: {
+    'jest/expect-expect': 'warn',
+  },
+};

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,23 +9,27 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "bcryptjs": "^3.0.2",
-        "cors": "^2.8.5",
-        "dotenv": "^17.2.2",
-        "express": "^5.1.0",
-        "file-type": "^19.5.0",
-        "jsonwebtoken": "^9.0.2",
-        "minio": "^8.0.6",
-        "multer": "^2.0.2",
-        "nodemailer": "^6.10.1",
-        "pg": "^8.16.3",
-        "sharp": "^0.33.4",
-        "winston": "^3.17.0"
+        "bcryptjs": "3.0.2",
+        "cors": "2.8.5",
+        "dotenv": "17.2.2",
+        "express": "5.1.0",
+        "file-type": "19.5.0",
+        "jsonwebtoken": "9.0.2",
+        "minio": "8.0.6",
+        "multer": "2.0.2",
+        "nodemailer": "6.10.1",
+        "pg": "8.16.3",
+        "sharp": "0.33.4",
+        "winston": "3.17.0"
       },
       "devDependencies": {
-        "jest": "^29.7.0",
-        "nodemon": "^3.1.10",
-        "pg-mem": "^3.0.5"
+        "eslint": "8.57.0",
+        "eslint-config-prettier": "9.1.0",
+        "eslint-plugin-jest": "27.9.0",
+        "jest": "29.7.0",
+        "nodemon": "3.1.10",
+        "pg-mem": "3.0.5",
+        "prettier": "3.3.3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -584,10 +588,131 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
+      "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.6.0",
+        "globals": "^13.19.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
+      "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array": {
+      "version": "0.11.14",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
+      "integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
+      "deprecated": "Use @eslint/config-array instead",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^2.0.2",
+        "debug": "^4.3.1",
+        "minimatch": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/object-schema": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+      "deprecated": "Use @eslint/object-schema instead",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
-      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "version": "0.33.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.4.tgz",
+      "integrity": "sha512-p0suNqXufJs9t3RqLBO6vvrgr5OhgbWp76s5gTRvdmxmuv9E1rcaqGUsl3l4mKVmXPkTkTErXediAui4x+8PSA==",
       "cpu": [
         "arm64"
       ],
@@ -597,19 +722,23 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "glibc": ">=2.26",
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+        "@img/sharp-libvips-darwin-arm64": "1.0.2"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
-      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "version": "0.33.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.4.tgz",
+      "integrity": "sha512-0l7yRObwtTi82Z6ebVI2PnHT8EB2NxBgpK2MiKJZJ7cz32R4lxd001ecMhzzsZig3Yv9oclvqqdV93jo9hy+Dw==",
       "cpu": [
         "x64"
       ],
@@ -619,19 +748,23 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "glibc": ">=2.26",
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.0.4"
+        "@img/sharp-libvips-darwin-x64": "1.0.2"
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
-      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.2.tgz",
+      "integrity": "sha512-tcK/41Rq8IKlSaKRCCAuuY3lDJjQnYIW1UXU1kxcEKrfL8WR7N6+rzNoOxoQRJWTAECuKwgAHnPvqXGN8XfkHA==",
       "cpu": [
         "arm64"
       ],
@@ -640,14 +773,20 @@
       "os": [
         "darwin"
       ],
+      "engines": {
+        "macos": ">=11",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
-      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.2.tgz",
+      "integrity": "sha512-Ofw+7oaWa0HiiMiKWqqaZbaYV3/UGL2wAPeLuJTx+9cXpCRdvQhCLG0IH8YGwM0yGWGLpsF4Su9vM1o6aer+Fw==",
       "cpu": [
         "x64"
       ],
@@ -656,14 +795,20 @@
       "os": [
         "darwin"
       ],
+      "engines": {
+        "macos": ">=10.13",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
-      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.2.tgz",
+      "integrity": "sha512-iLWCvrKgeFoglQxdEwzu1eQV04o8YeYGFXtfWU26Zr2wWT3q3MTzC+QTCO3ZQfWd3doKHT4Pm2kRmLbupT+sZw==",
       "cpu": [
         "arm"
       ],
@@ -672,14 +817,20 @@
       "os": [
         "linux"
       ],
+      "engines": {
+        "glibc": ">=2.28",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
-      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.2.tgz",
+      "integrity": "sha512-x7kCt3N00ofFmmkkdshwj3vGPCnmiDh7Gwnd4nUwZln2YjqPxV1NlTyZOvoDWdKQVDL911487HOueBvrpflagw==",
       "cpu": [
         "arm64"
       ],
@@ -688,14 +839,20 @@
       "os": [
         "linux"
       ],
+      "engines": {
+        "glibc": ">=2.26",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
-      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.2.tgz",
+      "integrity": "sha512-cmhQ1J4qVhfmS6szYW7RT+gLJq9dH2i4maq+qyXayUSn9/3iY2ZeWpbAgSpSVbV2E1JUL2Gg7pwnYQ1h8rQIog==",
       "cpu": [
         "s390x"
       ],
@@ -704,14 +861,20 @@
       "os": [
         "linux"
       ],
+      "engines": {
+        "glibc": ">=2.28",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
-      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.2.tgz",
+      "integrity": "sha512-E441q4Qdb+7yuyiADVi5J+44x8ctlrqn8XgkDTwr4qPJzWkaHwD489iZ4nGDgcuya4iMN3ULV6NwbhRZJ9Z7SQ==",
       "cpu": [
         "x64"
       ],
@@ -720,14 +883,20 @@
       "os": [
         "linux"
       ],
+      "engines": {
+        "glibc": ">=2.26",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
-      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.2.tgz",
+      "integrity": "sha512-3CAkndNpYUrlDqkCM5qhksfE+qSIREVpyoeHIU6jd48SJZViAmznoQQLAv4hVXF7xyUB9zf+G++e2v1ABjCbEQ==",
       "cpu": [
         "arm64"
       ],
@@ -736,14 +905,20 @@
       "os": [
         "linux"
       ],
+      "engines": {
+        "musl": ">=1.2.2",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
-      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.2.tgz",
+      "integrity": "sha512-VI94Q6khIHqHWNOh6LLdm9s2Ry4zdjWJwH56WoiJU7NTeDwyApdZZ8c+SADC8OH98KWNQXnE01UdJ9CSfZvwZw==",
       "cpu": [
         "x64"
       ],
@@ -752,14 +927,20 @@
       "os": [
         "linux"
       ],
+      "engines": {
+        "musl": ">=1.2.2",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
-      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "version": "0.33.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.4.tgz",
+      "integrity": "sha512-RUgBD1c0+gCYZGCCe6mMdTiOFS0Zc/XrN0fYd6hISIKcDUbAW5NtSQW9g/powkrXYm6Vzwd6y+fqmExDuCdHNQ==",
       "cpu": [
         "arm"
       ],
@@ -769,19 +950,23 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "glibc": ">=2.28",
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.0.5"
+        "@img/sharp-libvips-linux-arm": "1.0.2"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
-      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "version": "0.33.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.4.tgz",
+      "integrity": "sha512-2800clwVg1ZQtxwSoTlHvtm9ObgAax7V6MTAB/hDT945Tfyy3hVkmiHpeLPCKYqYR1Gcmv1uDZ3a4OFwkdBL7Q==",
       "cpu": [
         "arm64"
       ],
@@ -791,19 +976,23 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "glibc": ">=2.26",
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.0.4"
+        "@img/sharp-libvips-linux-arm64": "1.0.2"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
-      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+      "version": "0.33.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.4.tgz",
+      "integrity": "sha512-h3RAL3siQoyzSoH36tUeS0PDmb5wINKGYzcLB5C6DIiAn2F3udeFAum+gj8IbA/82+8RGCTn7XW8WTFnqag4tQ==",
       "cpu": [
         "s390x"
       ],
@@ -813,19 +1002,23 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "glibc": ">=2.31",
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.0.4"
+        "@img/sharp-libvips-linux-s390x": "1.0.2"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
-      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "version": "0.33.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.4.tgz",
+      "integrity": "sha512-GoR++s0XW9DGVi8SUGQ/U4AeIzLdNjHka6jidVwapQ/JebGVQIpi52OdyxCNVRE++n1FCLzjDovJNozif7w/Aw==",
       "cpu": [
         "x64"
       ],
@@ -835,19 +1028,23 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "glibc": ">=2.26",
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.0.4"
+        "@img/sharp-libvips-linux-x64": "1.0.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
-      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "version": "0.33.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.4.tgz",
+      "integrity": "sha512-nhr1yC3BlVrKDTl6cO12gTpXMl4ITBUZieehFvMntlCXFzH2bvKG76tBL2Y/OqhupZt81pR7R+Q5YhJxW0rGgQ==",
       "cpu": [
         "arm64"
       ],
@@ -857,19 +1054,23 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "musl": ">=1.2.2",
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
-      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "version": "0.33.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.4.tgz",
+      "integrity": "sha512-uCPTku0zwqDmZEOi4ILyGdmW76tH7dm8kKlOIV1XC5cLyJ71ENAAqarOHQh0RLfpIpbV5KOpXzdU6XkJtS0daw==",
       "cpu": [
         "x64"
       ],
@@ -879,38 +1080,45 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "musl": ">=1.2.2",
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.2"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
-      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+      "version": "0.33.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.4.tgz",
+      "integrity": "sha512-Bmmauh4sXUsUqkleQahpdNXKvo+wa1V9KhT2pDA4VJGKwnKMJXiSTGphn0gnJrlooda0QxCtXc6RX1XAU6hMnQ==",
       "cpu": [
         "wasm32"
       ],
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.2.0"
+        "@emnapi/runtime": "^1.1.1"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
-      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "version": "0.33.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.4.tgz",
+      "integrity": "sha512-99SJ91XzUhYHbx7uhK3+9Lf7+LjwMGQZMDlO/E/YVJ7Nc3lyDFZPGhjwiYdctoH2BOzW9+TnfqcaMKt0jHLdqw==",
       "cpu": [
         "ia32"
       ],
@@ -920,16 +1128,19 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
-      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "version": "0.33.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.4.tgz",
+      "integrity": "sha512-3QLocdTRVIrFNye5YocZl+KKpYKP+fksi1QhmOArgx7GyhIbQp/WrJRu176jm8IxromS7RIkzMiMINVdBtC8Aw==",
       "cpu": [
         "x64"
       ],
@@ -939,7 +1150,10 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
@@ -1314,6 +1528,44 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
@@ -1435,6 +1687,13 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "24.5.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.1.tgz",
@@ -1444,6 +1703,13 @@
       "dependencies": {
         "undici-types": "~7.12.0"
       }
+    },
+    "node_modules/@types/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
@@ -1475,6 +1741,142 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
+      "integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/visitor-keys": "5.62.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
+      "integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
+      "integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/visitor-keys": "5.62.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.62.0.tgz",
+      "integrity": "sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@types/json-schema": "^7.0.9",
+        "@types/semver": "^7.3.12",
+        "@typescript-eslint/scope-manager": "5.62.0",
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/typescript-estree": "5.62.0",
+        "eslint-scope": "^5.1.1",
+        "semver": "^7.3.7"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
+      "integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "5.62.0",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/@zxing/text-encoding": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz",
@@ -1493,6 +1895,46 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/ansi-escapes": {
@@ -1585,6 +2027,16 @@
       "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/async": {
@@ -2347,6 +2799,13 @@
         }
       }
     },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -2412,12 +2871,38 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/discontinuous-range": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
       "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/dotenv": {
       "version": "17.2.2",
@@ -2575,6 +3060,245 @@
         "node": ">=8"
       }
     },
+    "node_modules/eslint": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
+      "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.57.0",
+        "@humanwhocodes/config-array": "^0.11.14",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
+        "@ungap/structured-clone": "^1.2.0",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
+        "esquery": "^1.4.2",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "globals": "^13.19.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3",
+        "strip-ansi": "^6.0.1",
+        "text-table": "^0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
+      "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-jest": {
+      "version": "27.9.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.9.0.tgz",
+      "integrity": "sha512-QIT7FH7fNmd9n4se7FFKHbsLKGQiw885Ds6Y/sxKgCZ6natwCsXdgPOADnYVxN2QrRweF0FZWbJ6S7Rsn7llug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/utils": "^5.10.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^5.0.0 || ^6.0.0 || ^7.0.0",
+        "eslint": "^7.0.0 || ^8.0.0",
+        "jest": "*"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        },
+        "jest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/eslint/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/eslint/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/eslint/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/espree": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.9.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -2587,6 +3311,52 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/etag": {
@@ -2696,10 +3466,41 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
     },
@@ -2721,6 +3522,16 @@
         "fxparser": "src/cli/cli.js"
       }
     },
+    "node_modules/fastq": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
+      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
@@ -2737,14 +3548,27 @@
       "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
       "license": "MIT"
     },
+    "node_modules/file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^3.0.4"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
     "node_modules/file-type": {
-      "version": "19.6.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-19.6.0.tgz",
-      "integrity": "sha512-VZR5I7k5wkD0HgFnMsq5hOsSc710MJMu5Nc5QYsbe38NN5iPV/XTObYLc/cpttRTf6lX538+5uO1ZQRhYibiZQ==",
+      "version": "19.5.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-19.5.0.tgz",
+      "integrity": "sha512-dMuq6WWnP6BpQY0zYJNpTtQWgeCImSMG0BTIzUBXvxbwc1HWP/E7AE4UWU9XSCOPGJuOHda0HpDnwM2FW+d90A==",
       "license": "MIT",
       "dependencies": {
         "get-stream": "^9.0.1",
-        "strtok3": "^9.0.1",
+        "strtok3": "^8.1.0",
         "token-types": "^6.0.0",
         "uint8array-extras": "^1.3.0"
       },
@@ -2835,6 +3659,28 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/flat-cache": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.3",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/fn.name": {
       "version": "1.1.0",
@@ -3028,6 +3874,56 @@
         "node": ">= 6"
       }
     },
+    "node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globals/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -3046,6 +3942,13 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/has-flag": {
       "version": "3.0.0",
@@ -3182,6 +4085,16 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/ignore-by-default": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
@@ -3195,6 +4108,33 @@
       "integrity": "sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-fresh/node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/import-local": {
       "version": "3.2.0",
@@ -3385,6 +4325,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-promise": {
@@ -4173,10 +5123,24 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
     },
@@ -4199,6 +5163,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -4266,6 +5237,16 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -4290,6 +5271,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/lines-and-columns": {
@@ -4352,6 +5347,13 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.once": {
@@ -4449,6 +5451,16 @@
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -4860,6 +5872,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -4911,6 +5941,19 @@
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
       "engines": {
         "node": ">=6"
       }
@@ -4988,6 +6031,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/peek-readable": {
@@ -5273,6 +6326,32 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
@@ -5344,6 +6423,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/pure-rand": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
@@ -5393,6 +6482,27 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/railroad-diagrams": {
       "version": "1.0.0",
@@ -5563,6 +6673,34 @@
         "node": ">=0.12"
       }
     },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/router": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -5577,6 +6715,30 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/safe-buffer": {
@@ -5710,42 +6872,43 @@
       "license": "ISC"
     },
     "node_modules/sharp": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
-      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
+      "version": "0.33.4",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.4.tgz",
+      "integrity": "sha512-7i/dt5kGl7qR4gwPRD2biwD2/SvBn3O04J77XKFgL2OnZtQw+AG9wnuS/csmu80nPRHLYE9E41fyEiG8nhH6/Q==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "color": "^4.2.3",
         "detect-libc": "^2.0.3",
-        "semver": "^7.6.3"
+        "semver": "^7.6.0"
       },
       "engines": {
+        "libvips": ">=8.15.2",
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.33.5",
-        "@img/sharp-darwin-x64": "0.33.5",
-        "@img/sharp-libvips-darwin-arm64": "1.0.4",
-        "@img/sharp-libvips-darwin-x64": "1.0.4",
-        "@img/sharp-libvips-linux-arm": "1.0.5",
-        "@img/sharp-libvips-linux-arm64": "1.0.4",
-        "@img/sharp-libvips-linux-s390x": "1.0.4",
-        "@img/sharp-libvips-linux-x64": "1.0.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
-        "@img/sharp-linux-arm": "0.33.5",
-        "@img/sharp-linux-arm64": "0.33.5",
-        "@img/sharp-linux-s390x": "0.33.5",
-        "@img/sharp-linux-x64": "0.33.5",
-        "@img/sharp-linuxmusl-arm64": "0.33.5",
-        "@img/sharp-linuxmusl-x64": "0.33.5",
-        "@img/sharp-wasm32": "0.33.5",
-        "@img/sharp-win32-ia32": "0.33.5",
-        "@img/sharp-win32-x64": "0.33.5"
+        "@img/sharp-darwin-arm64": "0.33.4",
+        "@img/sharp-darwin-x64": "0.33.4",
+        "@img/sharp-libvips-darwin-arm64": "1.0.2",
+        "@img/sharp-libvips-darwin-x64": "1.0.2",
+        "@img/sharp-libvips-linux-arm": "1.0.2",
+        "@img/sharp-libvips-linux-arm64": "1.0.2",
+        "@img/sharp-libvips-linux-s390x": "1.0.2",
+        "@img/sharp-libvips-linux-x64": "1.0.2",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.2",
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.2",
+        "@img/sharp-linux-arm": "0.33.4",
+        "@img/sharp-linux-arm64": "0.33.4",
+        "@img/sharp-linux-s390x": "0.33.4",
+        "@img/sharp-linux-x64": "0.33.4",
+        "@img/sharp-linuxmusl-arm64": "0.33.4",
+        "@img/sharp-linuxmusl-x64": "0.33.4",
+        "@img/sharp-wasm32": "0.33.4",
+        "@img/sharp-win32-ia32": "0.33.4",
+        "@img/sharp-win32-x64": "0.33.4"
       }
     },
     "node_modules/sharp/node_modules/color": {
@@ -6126,13 +7289,13 @@
       "license": "MIT"
     },
     "node_modules/strtok3": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-9.1.1.tgz",
-      "integrity": "sha512-FhwotcEqjr241ZbjFzjlIYg6c5/L/s4yBGWSMvJ9UoExiSqL+FnFA/CaeZx17WGaZMS/4SOZp8wH18jSS4R4lw==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-8.1.0.tgz",
+      "integrity": "sha512-ExzDvHYPj6F6QkSNe/JxSlBxTh3OrI6wrAIz53ulxo1c4hBJ1bT9C/JrAthEKHWG9riVH3Xzg7B03Oxty6S2Lw==",
       "license": "MIT",
       "dependencies": {
         "@tokenizer/token": "^0.3.0",
-        "peek-readable": "^5.3.1"
+        "peek-readable": "^5.1.4"
       },
       "engines": {
         "node": ">=16"
@@ -6187,6 +7350,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
       "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+      "license": "MIT"
+    },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/through2": {
@@ -6271,6 +7441,42 @@
       "license": "0BSD",
       "optional": true
     },
+    "node_modules/tsutils": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^1.8.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+      }
+    },
+    "node_modules/tsutils/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -6313,6 +7519,21 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
       "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     },
     "node_modules/uint8array-extras": {
       "version": "1.5.0",
@@ -6378,6 +7599,16 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/util": {
@@ -6516,6 +7747,16 @@
       },
       "engines": {
         "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/wrap-ansi": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -10,6 +10,10 @@
     "test:minio": "node src/utils/test-minio.js",
     "test:connections": "npm run test:db && npm run test:minio",
     "test": "jest",
+    "lint": "eslint \"src/**/*.js\" \"tests/**/*.js\"",
+    "lint:fix": "npm run lint -- --fix",
+    "format": "prettier --write \"src/**/*.js\" \"tests/**/*.js\"",
+    "format:check": "prettier --check \"src/**/*.js\" \"tests/**/*.js\"",
     "send:test-email": "node scripts/send-test-email.js"
   },
   "keywords": [],
@@ -17,22 +21,26 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
-    "bcryptjs": "^3.0.2",
-    "cors": "^2.8.5",
-    "dotenv": "^17.2.2",
-    "express": "^5.1.0",
-    "jsonwebtoken": "^9.0.2",
-    "minio": "^8.0.6",
-    "multer": "^2.0.2",
-    "file-type": "^19.5.0",
-    "nodemailer": "^6.10.1",
-    "pg": "^8.16.3",
-    "sharp": "^0.33.4",
-    "winston": "^3.17.0"
+    "bcryptjs": "3.0.2",
+    "cors": "2.8.5",
+    "dotenv": "17.2.2",
+    "express": "5.1.0",
+    "jsonwebtoken": "9.0.2",
+    "minio": "8.0.6",
+    "multer": "2.0.2",
+    "file-type": "19.5.0",
+    "nodemailer": "6.10.1",
+    "pg": "8.16.3",
+    "sharp": "0.33.4",
+    "winston": "3.17.0"
   },
   "devDependencies": {
-    "jest": "^29.7.0",
-    "nodemon": "^3.1.10",
-    "pg-mem": "^3.0.5"
+    "eslint": "8.57.0",
+    "eslint-config-prettier": "9.1.0",
+    "eslint-plugin-jest": "27.9.0",
+    "jest": "29.7.0",
+    "nodemon": "3.1.10",
+    "pg-mem": "3.0.5",
+    "prettier": "3.3.3"
   }
 }

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -1,7 +1,7 @@
-const express = require("express");
-const cors = require("cors");
-const config = require("./config");
-const { registerRoutes } = require("./routes");
+const express = require('express');
+const cors = require('cors');
+const config = require('./config');
+const { registerRoutes } = require('./routes');
 
 const app = express();
 

--- a/backend/src/config/index.js
+++ b/backend/src/config/index.js
@@ -1,30 +1,30 @@
-const dotenv = require("dotenv");
+const dotenv = require('dotenv');
 
 // Load environment variables once for the entire application.
 dotenv.config();
 
 const config = {
-  port: parseInt(process.env.PORT || "5000", 10),
-  corsOrigin: process.env.CORS_ORIGIN || "http://localhost:3000",
-  logLevel: process.env.LOG_LEVEL || "info",
-  logFile: process.env.LOG_FILE || "",
+  port: parseInt(process.env.PORT || '5000', 10),
+  corsOrigin: process.env.CORS_ORIGIN || 'http://localhost:3000',
+  logLevel: process.env.LOG_LEVEL || 'info',
+  logFile: process.env.LOG_FILE || '',
   databaseUrl: process.env.DATABASE_URL,
   app: {
-    baseUrl: process.env.APP_BASE_URL || process.env.CORS_ORIGIN || "http://localhost:3000",
+    baseUrl: process.env.APP_BASE_URL || process.env.CORS_ORIGIN || 'http://localhost:3000',
   },
   jwt: {
     secret: process.env.JWT_SECRET,
-    expiry: process.env.JWT_EXPIRY || "1h",
-    issuer: process.env.JWT_ISSUER || "onk ur-api",
+    expiry: process.env.JWT_EXPIRY || '1h',
+    issuer: process.env.JWT_ISSUER || 'onk ur-api',
   },
   bcrypt: {
-    saltRounds: parseInt(process.env.BCRYPT_SALT_ROUNDS || "12", 10),
+    saltRounds: parseInt(process.env.BCRYPT_SALT_ROUNDS || '12', 10),
   },
   email: {
-    from: process.env.EMAIL_FROM || "Onkur <no-reply@onkur.org>",
+    from: process.env.EMAIL_FROM || 'Onkur <no-reply@onkur.org>',
     smtpHost: process.env.EMAIL_SMTP_HOST,
     smtpPort: process.env.EMAIL_SMTP_PORT ? parseInt(process.env.EMAIL_SMTP_PORT, 10) : 587,
-    smtpSecure: process.env.EMAIL_SMTP_SECURE === "true",
+    smtpSecure: process.env.EMAIL_SMTP_SECURE === 'true',
     smtpUser: process.env.EMAIL_SMTP_USER,
     smtpPass: process.env.EMAIL_SMTP_PASS,
   },
@@ -34,12 +34,12 @@ const config = {
     accessKey: process.env.MINIO_ACCESS_KEY,
     secretKey: process.env.MINIO_SECRET_KEY,
     bucket: process.env.MINIO_BUCKET,
-    useSSL: process.env.MINIO_USE_SSL === "true",
+    useSSL: process.env.MINIO_USE_SSL === 'true',
   },
   admin: {
-    name: process.env.ADMIN_NAME || "",
-    email: process.env.ADMIN_EMAIL || "",
-    password: process.env.ADMIN_PASSWORD || "",
+    name: process.env.ADMIN_NAME || '',
+    email: process.env.ADMIN_EMAIL || '',
+    password: process.env.ADMIN_PASSWORD || '',
   },
 };
 

--- a/backend/src/features/admin/admin.repository.js
+++ b/backend/src/features/admin/admin.repository.js
@@ -1,7 +1,17 @@
 const pool = require('../common/db');
 
 async function getOverviewMetrics() {
-  const [roleCountsResult, userCountsResult, eventStatsResult, volunteerTotalsResult, volunteerActiveResult, sponsorProfilesResult, sponsorFundsResult, galleryStatsResult, auditRecentResult] = await Promise.all([
+  const [
+    roleCountsResult,
+    userCountsResult,
+    eventStatsResult,
+    volunteerTotalsResult,
+    volunteerActiveResult,
+    sponsorProfilesResult,
+    sponsorFundsResult,
+    galleryStatsResult,
+    auditRecentResult,
+  ] = await Promise.all([
     pool.query(`SELECT role, COUNT(*)::INT AS count FROM user_roles GROUP BY role`),
     pool.query(`
       SELECT
@@ -31,14 +41,18 @@ async function getOverviewMetrics() {
         COUNT(*) FILTER (WHERE status = 'DECLINED') ::INT AS declined_count
       FROM sponsor_profiles
     `),
-    pool.query(`SELECT COALESCE(SUM(amount), 0)::NUMERIC AS total_amount FROM sponsorships WHERE status = 'APPROVED'`),
+    pool.query(
+      `SELECT COALESCE(SUM(amount), 0)::NUMERIC AS total_amount FROM sponsorships WHERE status = 'APPROVED'`
+    ),
     pool.query(`
       SELECT
         COUNT(*) FILTER (WHERE status = 'PENDING') ::INT AS pending_count,
         COUNT(*) FILTER (WHERE status = 'APPROVED') ::INT AS approved_count
       FROM event_media
     `),
-    pool.query(`SELECT COUNT(*)::INT AS recent_actions FROM audit_logs WHERE created_at >= NOW() - INTERVAL '7 days'`),
+    pool.query(
+      `SELECT COUNT(*)::INT AS recent_actions FROM audit_logs WHERE created_at >= NOW() - INTERVAL '7 days'`
+    ),
   ]);
 
   const roleCounts = roleCountsResult.rows.reduce((acc, row) => {

--- a/backend/src/features/admin/admin.route.js
+++ b/backend/src/features/admin/admin.route.js
@@ -84,7 +84,10 @@ router.get('/api/admin/export', authOnly, adminOnly, async (req, res) => {
   try {
     const { entity, format } = req.query;
     const { content, contentType, extension } = await exportData({ entity, format });
-    const baseName = typeof entity === 'string' && entity.trim() ? entity.trim().replace(/[^a-z0-9_-]/gi, '') : 'export';
+    const baseName =
+      typeof entity === 'string' && entity.trim()
+        ? entity.trim().replace(/[^a-z0-9_-]/gi, '')
+        : 'export';
     const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
     const filename = `${baseName || 'export'}-${timestamp}.${extension}`;
     res.setHeader('Content-Type', contentType);

--- a/backend/src/features/admin/admin.service.js
+++ b/backend/src/features/admin/admin.service.js
@@ -59,7 +59,8 @@ function toAuditUser(user) {
   if (!user) {
     return null;
   }
-  const roles = Array.isArray(user.roles) && user.roles.length ? sortRolesByPriority(user.roles) : [];
+  const roles =
+    Array.isArray(user.roles) && user.roles.length ? sortRolesByPriority(user.roles) : [];
   return {
     id: user.id,
     email: user.email,
@@ -166,7 +167,8 @@ function mapUserSummary(user) {
   if (!user) {
     return null;
   }
-  const roles = Array.isArray(user.roles) && user.roles.length ? sortRolesByPriority(user.roles) : [];
+  const roles =
+    Array.isArray(user.roles) && user.roles.length ? sortRolesByPriority(user.roles) : [];
   return {
     id: user.id,
     name: user.name,
@@ -198,7 +200,9 @@ function extractColumnValue(column, row) {
 
 function buildCsv(columns, rows) {
   const header = columns.map((column) => column.header).join(',');
-  const dataLines = rows.map((row) => columns.map((column) => formatCsvValue(extractColumnValue(column, row))).join(','));
+  const dataLines = rows.map((row) =>
+    columns.map((column) => formatCsvValue(extractColumnValue(column, row))).join(',')
+  );
   return [header, ...dataLines].join('\n');
 }
 
@@ -268,8 +272,12 @@ async function getModerationQueue({ type }) {
   }
   if (normalized === 'media') {
     const queue = await listPendingMedia({ page: 1, pageSize: 50 });
-    const uniqueEventIds = Array.from(new Set(queue.media.map((item) => item.eventId))).filter(Boolean);
-    const events = await Promise.all(uniqueEventIds.map((eventId) => findEventById(eventId).catch(() => null)));
+    const uniqueEventIds = Array.from(new Set(queue.media.map((item) => item.eventId))).filter(
+      Boolean
+    );
+    const events = await Promise.all(
+      uniqueEventIds.map((eventId) => findEventById(eventId).catch(() => null))
+    );
     const eventLookup = new Map(events.filter(Boolean).map((event) => [event.id, event]));
     return {
       type: 'media',
@@ -355,7 +363,9 @@ async function rejectEvent({ eventId, actorId, note }) {
           bodyLines: [
             `Hi ${creator.name?.split(' ')[0] || 'there'},`,
             `We reviewed <strong>${updated.title}</strong> and need a few tweaks before it can go live.`,
-            note ? `Moderator note: ${note}` : 'Reply to this email for guidance or resubmit when you are ready.',
+            note
+              ? `Moderator note: ${note}`
+              : 'Reply to this email for guidance or resubmit when you are ready.',
           ],
           previewText: 'Your event needs updates before publishing',
         });
@@ -537,9 +547,17 @@ async function exportData({ entity, format }) {
       { key: 'id', header: 'User ID' },
       { key: 'name', header: 'Name' },
       { key: 'email', header: 'Email' },
-      { key: 'roles', header: 'Roles', accessor: (row) => (Array.isArray(row.roles) ? row.roles.join('; ') : '') },
+      {
+        key: 'roles',
+        header: 'Roles',
+        accessor: (row) => (Array.isArray(row.roles) ? row.roles.join('; ') : ''),
+      },
       { key: 'is_active', header: 'Active' },
-      { key: 'email_verified_at', header: 'Email Verified At', accessor: (row) => toIso(row.email_verified_at) },
+      {
+        key: 'email_verified_at',
+        header: 'Email Verified At',
+        accessor: (row) => toIso(row.email_verified_at),
+      },
       { key: 'created_at', header: 'Created At', accessor: (row) => toIso(row.created_at) },
     ];
     return formatResponse({ columns, rows });

--- a/backend/src/features/auth/admin.bootstrap.js
+++ b/backend/src/features/auth/admin.bootstrap.js
@@ -1,29 +1,26 @@
-const bcrypt = require("bcryptjs");
-const config = require("../../config");
-const logger = require("../../utils/logger");
+const bcrypt = require('bcryptjs');
+const config = require('../../config');
+const logger = require('../../utils/logger');
 const {
   createUser,
   findUserByEmail,
   replaceUserRoles,
   markEmailVerified,
   recordAuditLog,
-} = require("./auth.repository");
+} = require('./auth.repository');
 
-const ADMIN_ROLE = "ADMIN";
+const ADMIN_ROLE = 'ADMIN';
 
 function normalizeConfigValue(value) {
-  return typeof value === "string" ? value.trim() : "";
+  return typeof value === 'string' ? value.trim() : '';
 }
 
 function toAuditSnapshot(user) {
   if (!user) {
     return null;
   }
-  const roles = Array.isArray(user.roles) && user.roles.length
-    ? user.roles
-    : user.role
-    ? [user.role]
-    : [];
+  const roles =
+    Array.isArray(user.roles) && user.roles.length ? user.roles : user.role ? [user.role] : [];
   return {
     id: user.id,
     email: user.email,
@@ -37,41 +34,45 @@ function toAuditSnapshot(user) {
 async function ensureAdminUser() {
   const configuredName = normalizeConfigValue(config.admin?.name);
   const configuredEmail = normalizeConfigValue(config.admin?.email).toLowerCase();
-  const configuredPassword = config.admin?.password || "";
+  const configuredPassword = config.admin?.password || '';
 
   if (!configuredName || !configuredEmail || !configuredPassword) {
-    logger.info("Admin bootstrap skipped: ADMIN_NAME, ADMIN_EMAIL, and ADMIN_PASSWORD must be set");
+    logger.info('Admin bootstrap skipped: ADMIN_NAME, ADMIN_EMAIL, and ADMIN_PASSWORD must be set');
     return;
   }
 
   const existing = await findUserByEmail(configuredEmail);
   if (existing) {
-    const existingRoles = Array.isArray(existing.roles) && existing.roles.length
-      ? existing.roles
-      : existing.role
-      ? [existing.role]
-      : [];
+    const existingRoles =
+      Array.isArray(existing.roles) && existing.roles.length
+        ? existing.roles
+        : existing.role
+          ? [existing.role]
+          : [];
 
     const rolesWithoutAdmin = existingRoles.filter((role) => role !== ADMIN_ROLE);
     const desiredRoles = [ADMIN_ROLE, ...rolesWithoutAdmin];
 
     const needsRoleUpdate =
-      existing.role !== ADMIN_ROLE || existingRoles.length !== desiredRoles.length ||
+      existing.role !== ADMIN_ROLE ||
+      existingRoles.length !== desiredRoles.length ||
       desiredRoles.some((role, index) => existingRoles[index] !== role);
 
     if (needsRoleUpdate) {
       const updatedUser = await replaceUserRoles({ userId: existing.id, roles: desiredRoles });
       await recordAuditLog({
         actorId: existing.id,
-        action: "auth.bootstrap.admin.promote",
-        entityType: "user",
+        action: 'auth.bootstrap.admin.promote',
+        entityType: 'user',
         entityId: existing.id,
         before: toAuditSnapshot(existing),
         after: toAuditSnapshot(updatedUser),
       });
-      logger.info("Admin bootstrap: ensured existing user has ADMIN role", { email: configuredEmail });
+      logger.info('Admin bootstrap: ensured existing user has ADMIN role', {
+        email: configuredEmail,
+      });
     } else {
-      logger.info("Admin bootstrap: existing admin user detected", { email: configuredEmail });
+      logger.info('Admin bootstrap: existing admin user detected', { email: configuredEmail });
     }
 
     if (!existing.email_verified_at) {
@@ -93,13 +94,13 @@ async function ensureAdminUser() {
 
   await recordAuditLog({
     actorId: adminUser.id,
-    action: "auth.bootstrap.admin.created",
-    entityType: "user",
+    action: 'auth.bootstrap.admin.created',
+    entityType: 'user',
     entityId: adminUser.id,
     after: toAuditSnapshot(adminUser),
   });
 
-  logger.info("Admin bootstrap: created default admin user", { email: configuredEmail });
+  logger.info('Admin bootstrap: created default admin user', { email: configuredEmail });
 }
 
 module.exports = {

--- a/backend/src/features/auth/auth.middleware.js
+++ b/backend/src/features/auth/auth.middleware.js
@@ -29,11 +29,12 @@ function authorizeRoles(...allowedRoles) {
     if (!req.user) {
       return res.status(401).json({ error: 'Authentication required' });
     }
-    const userRoles = Array.isArray(req.user.roles) && req.user.roles.length
-      ? req.user.roles
-      : req.user.role
-      ? [req.user.role]
-      : [];
+    const userRoles =
+      Array.isArray(req.user.roles) && req.user.roles.length
+        ? req.user.roles
+        : req.user.role
+          ? [req.user.role]
+          : [];
     if (!userRoles.some((role) => allowedRoles.includes(role))) {
       return res.status(403).json({ error: 'Forbidden' });
     }

--- a/backend/src/features/auth/auth.repository.js
+++ b/backend/src/features/auth/auth.repository.js
@@ -2,7 +2,11 @@ const { randomUUID } = require('crypto');
 const pool = require('../common/db');
 const logger = require('../../utils/logger');
 const { ROLES, DEFAULT_ROLE } = require('./constants');
-const { sortRolesByPriority, determinePrimaryRole, buildRolePriorityCase } = require('./role.helpers');
+const {
+  sortRolesByPriority,
+  determinePrimaryRole,
+  buildRolePriorityCase,
+} = require('./role.helpers');
 
 const roleCheckArray = ROLES.map((role) => `'${role}'`).join(', ');
 const roleOrderCase = buildRolePriorityCase('role');
@@ -340,16 +344,7 @@ async function recordAuditLog({
       INSERT INTO audit_logs (id, actor_id, action, entity_type, entity_id, before, after, metadata)
       VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7::jsonb, $8::jsonb)
     `,
-    [
-      id,
-      actorId,
-      action,
-      entityType,
-      entityId || null,
-      beforeJson,
-      afterJson,
-      metadataJson,
-    ]
+    [id, actorId, action, entityType, entityId || null, beforeJson, afterJson, metadataJson]
   );
 }
 
@@ -369,7 +364,7 @@ async function revokeToken({ jti, expiresAt }) {
 async function isTokenRevoked(jti) {
   await ensureSchema();
   const result = await pool.query(
-    `SELECT 1 FROM revoked_tokens WHERE jti = $1 AND expires_at >= NOW()` ,
+    `SELECT 1 FROM revoked_tokens WHERE jti = $1 AND expires_at >= NOW()`,
     [jti]
   );
   return Boolean(result.rowCount);
@@ -390,7 +385,9 @@ async function createEmailVerificationToken({ userId, expiresInMinutes }) {
   const token = randomUUID().replace(/-/g, '');
   const expiresAt = new Date(Date.now() + expiresInMinutes * 60 * 1000);
 
-  await pool.query(`DELETE FROM email_verification_tokens WHERE user_id = $1 AND used_at IS NULL`, [userId]);
+  await pool.query(`DELETE FROM email_verification_tokens WHERE user_id = $1 AND used_at IS NULL`, [
+    userId,
+  ]);
 
   const result = await pool.query(
     `
@@ -440,10 +437,7 @@ async function deleteVerificationTokensForUser({ userId, exceptTokenId = null })
       [userId, exceptTokenId]
     );
   } else {
-    await pool.query(
-      `DELETE FROM email_verification_tokens WHERE user_id = $1`,
-      [userId]
-    );
+    await pool.query(`DELETE FROM email_verification_tokens WHERE user_id = $1`, [userId]);
   }
 }
 

--- a/backend/src/features/auth/auth.route.js
+++ b/backend/src/features/auth/auth.route.js
@@ -94,11 +94,7 @@ router.patch('/api/users/:id/role', adminOnly, async (req, res) => {
   try {
     const { role, roles } = req.body || {};
     const userId = req.params.id;
-    const desiredRoles = Array.isArray(roles)
-      ? roles
-      : role
-      ? [role]
-      : [];
+    const desiredRoles = Array.isArray(roles) ? roles : role ? [role] : [];
     const updated = await assignRole({ actorId: req.user.id, userId, roles: desiredRoles });
     res.json({ user: updated });
   } catch (error) {

--- a/backend/src/features/auth/auth.service.js
+++ b/backend/src/features/auth/auth.service.js
@@ -59,9 +59,10 @@ if (!JWT_SECRET) {
 
 function toPublicUser(user) {
   if (!user) return null;
-  const roles = Array.isArray(user.roles) && user.roles.length
-    ? sortRolesByPriority(user.roles)
-    : sortRolesByPriority(user.role ? [user.role] : []);
+  const roles =
+    Array.isArray(user.roles) && user.roles.length
+      ? sortRolesByPriority(user.roles)
+      : sortRolesByPriority(user.role ? [user.role] : []);
   const primaryRole = determinePrimaryRole(roles, user.role || DEFAULT_ROLE);
   return {
     id: user.id,
@@ -75,8 +76,7 @@ function toPublicUser(user) {
       user.email_verified_at instanceof Date
         ? user.email_verified_at.toISOString()
         : user.email_verified_at || null,
-    createdAt:
-      user.created_at instanceof Date ? user.created_at.toISOString() : user.created_at,
+    createdAt: user.created_at instanceof Date ? user.created_at.toISOString() : user.created_at,
   };
 }
 
@@ -122,7 +122,8 @@ function toAuditUserSnapshot(user) {
   if (!user) {
     return null;
   }
-  const roles = Array.isArray(user.roles) && user.roles.length ? sortRolesByPriority(user.roles) : undefined;
+  const roles =
+    Array.isArray(user.roles) && user.roles.length ? sortRolesByPriority(user.roles) : undefined;
   return {
     id: user.id,
     email: user.email,
@@ -235,7 +236,10 @@ async function login({ email, password }) {
       before: toAuditUserSnapshot(user),
       after: { email: user.email, success: false, reason: 'account_inactive' },
     });
-    throw createHttpError(403, 'This account has been deactivated. Reach out to the admin team to restore access.');
+    throw createHttpError(
+      403,
+      'This account has been deactivated. Reach out to the admin team to restore access.'
+    );
   }
 
   if (!user.email_verified_at) {

--- a/backend/src/features/auth/email.service.js
+++ b/backend/src/features/auth/email.service.js
@@ -2,7 +2,8 @@ const { sendTemplatedEmail } = require('../email/email.service');
 const config = require('../../config');
 
 function buildVerifyUrl(token) {
-  const baseUrl = (config.app && config.app.baseUrl) || config.corsOrigin || 'http://localhost:3000';
+  const baseUrl =
+    (config.app && config.app.baseUrl) || config.corsOrigin || 'http://localhost:3000';
   const normalized = baseUrl.replace(/\/$/, '');
   return `${normalized}/verify-email?token=${encodeURIComponent(token)}`;
 }

--- a/backend/src/features/common/db.js
+++ b/backend/src/features/common/db.js
@@ -1,5 +1,5 @@
-const { Pool } = require("pg");
-const config = require("../../config");
+const { Pool } = require('pg');
+const config = require('../../config');
 
 const pool = new Pool({
   connectionString: config.databaseUrl,

--- a/backend/src/features/common/minio.js
+++ b/backend/src/features/common/minio.js
@@ -1,5 +1,5 @@
-const Minio = require("minio");
-const config = require("../../config");
+const Minio = require('minio');
+const config = require('../../config');
 
 const minioClient = new Minio.Client({
   endPoint: config.minio.endPoint,

--- a/backend/src/features/email/email.service.js
+++ b/backend/src/features/email/email.service.js
@@ -55,16 +55,12 @@ function resolveTransporter() {
 
 function renderStandardTemplate({ heading, bodyLines = [], cta, previewText }) {
   const safeBody = Array.isArray(bodyLines) ? bodyLines : [String(bodyLines || '')];
-  const bodyHtml = safeBody
-    .map(
-      (line) =>
-        `<p class="paragraph">${line}</p>`
-    )
-    .join('');
+  const bodyHtml = safeBody.map((line) => `<p class="paragraph">${line}</p>`).join('');
 
-  const ctaHtml = cta && cta.url && cta.label
-    ? `<div class="cta"><a class="ctaButton" href="${cta.url}" target="_blank" rel="noreferrer">${cta.label}</a></div>`
-    : '';
+  const ctaHtml =
+    cta && cta.url && cta.label
+      ? `<div class="cta"><a class="ctaButton" href="${cta.url}" target="_blank" rel="noreferrer">${cta.label}</a></div>`
+      : '';
 
   const resolvedPreview = previewText || heading;
 
@@ -250,7 +246,10 @@ async function sendEmail({ to, subject, html, text, headers = {} }) {
   const finalSubject = applySubjectPrefix(subject);
 
   if (!transport) {
-    logger.info('Email send skipped because transport is not configured', { to, subject: finalSubject });
+    logger.info('Email send skipped because transport is not configured', {
+      to,
+      subject: finalSubject,
+    });
     return null;
   }
 
@@ -287,7 +286,13 @@ async function sendTemplatedEmail({ to, subject, heading, bodyLines, cta, previe
   if (template.previewText) {
     enrichedHeaders['X-Preheader-Text'] = template.previewText;
   }
-  return sendEmail({ to, subject, html: template.html, text: template.text, headers: enrichedHeaders });
+  return sendEmail({
+    to,
+    subject,
+    html: template.html,
+    text: template.text,
+    headers: enrichedHeaders,
+  });
 }
 
 module.exports = {

--- a/backend/src/features/event-gallery/eventGallery.route.js
+++ b/backend/src/features/event-gallery/eventGallery.route.js
@@ -114,7 +114,12 @@ router.post('/media/:mediaId/reject', authOnly, adminOnly, async (req, res) => {
       return res.status(400).json({ error: 'Invalid media identifier' });
     }
     const reason = req.body?.reason ? String(req.body.reason).trim() : '';
-    const media = await moderateMedia({ mediaId, action: 'reject', moderatorId: req.user.id, reason });
+    const media = await moderateMedia({
+      mediaId,
+      action: 'reject',
+      moderatorId: req.user.id,
+      reason,
+    });
     res.json({ media });
   } catch (error) {
     const status = error.statusCode || 500;

--- a/backend/src/features/event-management/eventManagement.route.js
+++ b/backend/src/features/event-management/eventManagement.route.js
@@ -177,9 +177,9 @@ router.post('/events/:eventId/tasks/assignments', async (req, res) => {
     const assignmentsPayload = Array.isArray(req.body?.assignments)
       ? req.body.assignments
       : Array.isArray(req.body)
-      ? req.body
-      : [];
-    const assignments = await assignVolunteersToTasks(eventId, assignmentsPayload, req.user);
+        ? req.body
+        : [];
+    const assignments = await assignVolunteersToTasks(eventId, assignmentsPayload);
     res.json({ assignments });
   } catch (error) {
     const status = error.statusCode || 500;

--- a/backend/src/features/event-management/eventManagement.service.js
+++ b/backend/src/features/event-management/eventManagement.service.js
@@ -71,9 +71,7 @@ function normalizeStringArray(input) {
     return [];
   }
   const list = Array.isArray(input) ? input : [input];
-  const cleaned = list
-    .map((value) => String(value || '').trim())
-    .filter(Boolean);
+  const cleaned = list.map((value) => String(value || '').trim()).filter(Boolean);
   return [...new Set(cleaned)];
 }
 
@@ -114,10 +112,7 @@ function describeLocation(event) {
 }
 
 function resolveAppBaseUrl() {
-  const base =
-    (config.app && config.app.baseUrl) ||
-    config.corsOrigin ||
-    'http://localhost:3000';
+  const base = (config.app && config.app.baseUrl) || config.corsOrigin || 'http://localhost:3000';
   return String(base).replace(/\/$/, '');
 }
 
@@ -146,11 +141,11 @@ function formatEventDateRange(event) {
 
   const startLabel = `${start.toLocaleDateString(undefined, dateOptions)} ${start.toLocaleTimeString(
     undefined,
-    timeOptions,
+    timeOptions
   )}`;
   const endLabel = `${end.toLocaleDateString(undefined, dateOptions)} ${end.toLocaleTimeString(
     undefined,
-    timeOptions,
+    timeOptions
   )}`;
   return `${startLabel} → ${endLabel}`;
 }
@@ -195,7 +190,10 @@ function buildProfileMatches(event, profile = {}) {
   const profileSkills = toStringArray(profile.skills);
   const skillMatches = eventSkills.filter((skill) => profileSkills.includes(skill));
   if (skillMatches.length) {
-    const label = skillMatches.length > 1 ? `skills (${skillMatches.join(', ')})` : `skill (${skillMatches[0]})`;
+    const label =
+      skillMatches.length > 1
+        ? `skills (${skillMatches.join(', ')})`
+        : `skill (${skillMatches[0]})`;
     matches.push(label);
   }
 
@@ -212,7 +210,9 @@ function buildProfileMatches(event, profile = {}) {
 
   const eventAvailability = toStringArray(event.requiredAvailability);
   const profileAvailability = toStringArray(profile.availability);
-  const availabilityMatches = eventAvailability.filter((availability) => profileAvailability.includes(availability));
+  const availabilityMatches = eventAvailability.filter((availability) =>
+    profileAvailability.includes(availability)
+  );
   if (availabilityMatches.length) {
     const label =
       availabilityMatches.length > 1
@@ -262,9 +262,7 @@ async function dispatchRoleEmails({ role, recipients, event, actor, baseUrl }) {
       : `New event "${event.title}" is ready for volunteers`;
 
   const heading =
-    role === 'SPONSOR'
-      ? 'Help this initiative take root'
-      : 'Be one of the first to RSVP';
+    role === 'SPONSOR' ? 'Help this initiative take root' : 'Be one of the first to RSVP';
 
   const ctaLabel = role === 'SPONSOR' ? 'Review event brief' : 'Review and RSVP';
 
@@ -273,7 +271,8 @@ async function dispatchRoleEmails({ role, recipients, event, actor, baseUrl }) {
       if (!recipient?.email) {
         return null;
       }
-      const firstName = recipient.name?.split(' ')[0] || (role === 'SPONSOR' ? 'partner' : 'volunteer');
+      const firstName =
+        recipient.name?.split(' ')[0] || (role === 'SPONSOR' ? 'partner' : 'volunteer');
       const personalizedNote = buildPersonalizedNote(event, recipient, role);
       const bodyLines = [
         `Hi ${firstName},`,
@@ -300,7 +299,7 @@ async function dispatchRoleEmails({ role, recipients, event, actor, baseUrl }) {
       bodyLines.push(
         role === 'SPONSOR'
           ? 'Review the brief to see how your sponsorship or network can accelerate this cause.'
-          : 'Tap below to read the full brief and claim your spot before it fills up.',
+          : 'Tap below to read the full brief and claim your spot before it fills up.'
       );
 
       return sendTemplatedEmail({
@@ -314,7 +313,7 @@ async function dispatchRoleEmails({ role, recipients, event, actor, baseUrl }) {
           url: eventUrl,
         },
       });
-    }),
+    })
   );
 
   results.forEach((result, index) => {
@@ -341,11 +340,12 @@ async function sendEventCreationEmails({ event, actor }) {
 
   const volunteers = recipients.filter(
     (recipient) =>
-      recipient.roles?.includes('VOLUNTEER') && recipient.id !== actorId && recipient.email,
+      recipient.roles?.includes('VOLUNTEER') && recipient.id !== actorId && recipient.email
   );
 
   const sponsors = recipients.filter(
-    (recipient) => recipient.roles?.includes('SPONSOR') && recipient.id !== actorId && recipient.email,
+    (recipient) =>
+      recipient.roles?.includes('SPONSOR') && recipient.id !== actorId && recipient.email
   );
 
   await Promise.all([
@@ -373,14 +373,14 @@ function normalizeEventPayload(payload = {}) {
   const title = String(payload.title || '').trim();
   const description = String(payload.description || '').trim();
   const categoryLabel = String(
-    payload.categoryLabel || payload.category_label || payload.category || '',
+    payload.categoryLabel || payload.category_label || payload.category || ''
   ).trim();
   const categoryValue = String(
-    payload.categoryValue || payload.category_value || payload.categoryOption?.value || '',
+    payload.categoryValue || payload.category_value || payload.categoryOption?.value || ''
   ).trim();
   const theme = payload.theme ? String(payload.theme).trim() : null;
   const locationNote = String(
-    payload.locationNote || payload.location_note || payload.location || payload.venue || '',
+    payload.locationNote || payload.location_note || payload.location || payload.venue || ''
   ).trim();
   const requirements = payload.requirements ? String(payload.requirements).trim() : null;
 
@@ -399,7 +399,9 @@ function normalizeEventPayload(payload = {}) {
   }
 
   const isOnline = toBooleanFlag(payload.isOnline ?? payload.is_online);
-  const stateCode = String(payload.stateCode || payload.state_code || '').trim().toUpperCase();
+  const stateCode = String(payload.stateCode || payload.state_code || '')
+    .trim()
+    .toUpperCase();
   const citySlug = String(payload.citySlug || payload.city_slug || '').trim();
   if (!isOnline) {
     if (!stateCode) {
@@ -431,7 +433,7 @@ function normalizeEventPayload(payload = {}) {
     requiredSkills: normalizeStringArray(payload.requiredSkills || payload.skills),
     requiredInterests: normalizeStringArray(payload.requiredInterests || payload.interests),
     requiredAvailability: normalizeStringArray(
-      payload.requiredAvailability || payload.availability,
+      payload.requiredAvailability || payload.availability
     ),
   };
 }
@@ -505,7 +507,9 @@ async function resolveLocation({ isOnline, stateCode, citySlug, locationNote }) 
     };
   }
 
-  const normalizedState = String(stateCode || '').trim().toUpperCase();
+  const normalizedState = String(stateCode || '')
+    .trim()
+    .toUpperCase();
   const normalizedCity = String(citySlug || '').trim();
 
   const stateRecord = await findStateByCode(normalizedState);
@@ -632,16 +636,16 @@ async function publishEvent(eventId, actor) {
 
   if (actor?.email) {
     try {
-          await sendTemplatedEmail({
-            to: actor.email,
-            subject: `Your event "${updated.title}" is now live`,
-            heading: 'Event published successfully',
-            bodyLines: [
-              `Great news, ${actor.name?.split(' ')[0] || 'there'}!`,
-              `Your event <strong>${updated.title}</strong> has been published and is now visible to volunteers.`,
-              `Capacity: ${updated.capacity} · Location: ${describeLocation(updated)}`,
-            ],
-          });
+      await sendTemplatedEmail({
+        to: actor.email,
+        subject: `Your event "${updated.title}" is now live`,
+        heading: 'Event published successfully',
+        bodyLines: [
+          `Great news, ${actor.name?.split(' ')[0] || 'there'}!`,
+          `Your event <strong>${updated.title}</strong> has been published and is now visible to volunteers.`,
+          `Capacity: ${updated.capacity} · Location: ${describeLocation(updated)}`,
+        ],
+      });
     } catch (error) {
       logger.warn('Failed to send publish confirmation email', {
         eventId,
@@ -683,13 +687,15 @@ async function getEventAssignments(eventId) {
   return listAssignmentsForEvent(eventId);
 }
 
-async function assignVolunteersToTasks(eventId, assignments, actor) {
-  const result = await assignVolunteers(eventId, assignments, { assignedBy: actor?.id || null });
+async function assignVolunteersToTasks(eventId, assignments) {
+  const result = await assignVolunteers(eventId, assignments);
   const assignmentDetails = result.assignments;
   const newAssignmentIds = new Set(result.newAssignments.map((item) => item.assignmentId));
   const event = await findEventById(eventId);
 
-  const notifications = assignmentDetails.filter((assignment) => newAssignmentIds.has(assignment.id));
+  const notifications = assignmentDetails.filter((assignment) =>
+    newAssignmentIds.has(assignment.id)
+  );
 
   await Promise.all(
     notifications.map(async (assignment) => {
@@ -715,7 +721,7 @@ async function assignVolunteersToTasks(eventId, assignments, actor) {
           error: error.message,
         });
       }
-    }),
+    })
   );
 
   return assignmentDetails;

--- a/backend/src/features/health/health.route.js
+++ b/backend/src/features/health/health.route.js
@@ -1,32 +1,32 @@
-const express = require("express");
+const express = require('express');
 const router = express.Router();
-const pool = require("../common/db");
-const minioClient = require("../common/minio");
-const config = require("../../config");
-const logger = require("../../utils/logger");
+const pool = require('../common/db');
+const minioClient = require('../common/minio');
+const config = require('../../config');
+const logger = require('../../utils/logger');
 
-router.get("/api/health", async (req, res) => {
+router.get('/api/health', async (req, res) => {
   try {
-    const dbRes = await pool.query("SELECT NOW() as time");
+    const dbRes = await pool.query('SELECT NOW() as time');
 
     let bucketExists = null;
     if (config.minio.bucket) {
       bucketExists = await minioClient.bucketExists(config.minio.bucket);
     }
 
-    logger.info("Health check successful", {
+    logger.info('Health check successful', {
       dbTime: dbRes.rows[0].time,
       minioBucket: bucketExists,
     });
 
     res.json({
-      status: "ok",
+      status: 'ok',
       dbTime: dbRes.rows[0].time,
       minioBucket: bucketExists,
     });
   } catch (err) {
-    logger.error("Health check failed", { error: err.message });
-    res.status(500).json({ error: "Connection failed", details: err.message });
+    logger.error('Health check failed', { error: err.message });
+    res.status(500).json({ error: 'Connection failed', details: err.message });
   }
 });
 

--- a/backend/src/features/impact/impact.service.js
+++ b/backend/src/features/impact/impact.service.js
@@ -43,7 +43,8 @@ function formatStoryForResponse(story) {
   if (!story) {
     return null;
   }
-  const excerpt = story.body && story.body.length > 220 ? `${story.body.slice(0, 217)}…` : story.body;
+  const excerpt =
+    story.body && story.body.length > 220 ? `${story.body.slice(0, 217)}…` : story.body;
   return {
     ...story,
     excerpt,
@@ -65,7 +66,9 @@ async function submitImpactStory({ eventId, author, title, body, mediaIds = [] }
     throw error;
   }
   if (trimmedBody.length < 40) {
-    const error = new Error('Share at least a few sentences so the community can feel the impact (40+ characters).');
+    const error = new Error(
+      'Share at least a few sentences so the community can feel the impact (40+ characters).'
+    );
     error.statusCode = 400;
     throw error;
   }
@@ -200,7 +203,7 @@ async function notifySponsorsOfStory({ sponsors = [], story, event }) {
           sponsorId: sponsor.sponsorId,
         });
       }
-    }),
+    })
   );
 }
 
@@ -211,7 +214,11 @@ async function approveImpactStory({ storyId, moderator }) {
     throw error;
   }
   ensureUuid(storyId, 'Invalid story identifier');
-  const updated = await updateStoryStatus({ storyId, status: 'APPROVED', moderatorId: moderator.id });
+  const updated = await updateStoryStatus({
+    storyId,
+    status: 'APPROVED',
+    moderatorId: moderator.id,
+  });
   if (!updated) {
     const error = new Error('Story not found');
     error.statusCode = 404;
@@ -275,22 +282,29 @@ async function loadImpactAnalytics({ recordView = true } = {}) {
   if (recordView) {
     await incrementDailyMetric({ metricKey: 'analytics_dashboard_views', amount: 1 });
   }
-  const [storyCounts, volunteerHours, participation, gallery, sponsorImpact, usage, recentMetrics] = await Promise.all([
-    getStoryCountsByStatus(),
-    getVolunteerHoursAggregate(),
-    getEventParticipationSummary(),
-    getGalleryEngagementSummary(),
-    getSponsorImpactSummary(),
-    getAnalyticsUsageSummary(),
-    listRecentMetrics({ days: 45 }),
-  ]);
-  const totalStories = Object.values(storyCounts).reduce((sum, value) => sum + Number(value || 0), 0);
+  const [storyCounts, volunteerHours, participation, gallery, sponsorImpact, usage, recentMetrics] =
+    await Promise.all([
+      getStoryCountsByStatus(),
+      getVolunteerHoursAggregate(),
+      getEventParticipationSummary(),
+      getGalleryEngagementSummary(),
+      getSponsorImpactSummary(),
+      getAnalyticsUsageSummary(),
+      listRecentMetrics({ days: 45 }),
+    ]);
+  const totalStories = Object.values(storyCounts).reduce(
+    (sum, value) => sum + Number(value || 0),
+    0
+  );
   const volunteerHoursTotal = volunteerHours.totalMinutes || 0;
   const retentionDelta = computeRetentionChange(volunteerHours);
   return {
     stories: {
       total: totalStories,
-      submitted: Number(storyCounts.PENDING || 0) + Number(storyCounts.APPROVED || 0) + Number(storyCounts.REJECTED || 0),
+      submitted:
+        Number(storyCounts.PENDING || 0) +
+        Number(storyCounts.APPROVED || 0) +
+        Number(storyCounts.REJECTED || 0),
       approved: Number(storyCounts.APPROVED || 0),
       pending: Number(storyCounts.PENDING || 0),
       rejected: Number(storyCounts.REJECTED || 0),
@@ -326,20 +340,76 @@ function buildAnalyticsReportCsv(overview) {
     ['Stories', 'Approved', formatNumber(overview.stories.approved)],
     ['Stories', 'Pending review', formatNumber(overview.stories.pending)],
     ['Stories', 'Rejected', formatNumber(overview.stories.rejected)],
-    ['Volunteer engagement', 'Total hours logged', formatNumber(overview.volunteerEngagement.totalHours)],
-    ['Volunteer engagement', 'Active volunteers (90d)', formatNumber(overview.volunteerEngagement.activeLast90Days)],
-    ['Volunteer engagement', 'Retention change vs prev 90d', `${(overview.volunteerEngagement.retentionDelta * 100).toFixed(2)}%`],
-    ['Event participation', 'Total signups', formatNumber(overview.eventParticipation.totalSignups)],
-    ['Event participation', 'Unique volunteers', formatNumber(overview.eventParticipation.uniqueVolunteers)],
-    ['Event participation', 'Events supported', formatNumber(overview.eventParticipation.eventsSupported)],
-    ['Gallery engagement', 'Gallery views recorded', formatNumber(overview.galleryEngagement.totalViews)],
-    ['Gallery engagement', 'Events with gallery analytics', formatNumber(overview.galleryEngagement.trackedEvents)],
-    ['Gallery engagement', 'Approved media assets', formatNumber(overview.galleryEngagement.approvedMedia)],
-    ['Sponsor impact', 'Approved sponsorships', formatNumber(overview.sponsorImpact.approvedSponsorships)],
-    ['Sponsor impact', 'Approved sponsorship amount', formatNumber(overview.sponsorImpact.approvedAmount)],
-    ['Sponsor impact', 'Sponsor mentions in galleries', formatNumber(overview.sponsorImpact.sponsorMentions)],
-    ['Analytics usage', 'Dashboard views (30d)', formatNumber(overview.analyticsUsage.viewsLast30Days)],
-    ['Analytics usage', 'Dashboard views recorded', formatNumber(overview.analyticsUsage.totalRecordedViews)],
+    [
+      'Volunteer engagement',
+      'Total hours logged',
+      formatNumber(overview.volunteerEngagement.totalHours),
+    ],
+    [
+      'Volunteer engagement',
+      'Active volunteers (90d)',
+      formatNumber(overview.volunteerEngagement.activeLast90Days),
+    ],
+    [
+      'Volunteer engagement',
+      'Retention change vs prev 90d',
+      `${(overview.volunteerEngagement.retentionDelta * 100).toFixed(2)}%`,
+    ],
+    [
+      'Event participation',
+      'Total signups',
+      formatNumber(overview.eventParticipation.totalSignups),
+    ],
+    [
+      'Event participation',
+      'Unique volunteers',
+      formatNumber(overview.eventParticipation.uniqueVolunteers),
+    ],
+    [
+      'Event participation',
+      'Events supported',
+      formatNumber(overview.eventParticipation.eventsSupported),
+    ],
+    [
+      'Gallery engagement',
+      'Gallery views recorded',
+      formatNumber(overview.galleryEngagement.totalViews),
+    ],
+    [
+      'Gallery engagement',
+      'Events with gallery analytics',
+      formatNumber(overview.galleryEngagement.trackedEvents),
+    ],
+    [
+      'Gallery engagement',
+      'Approved media assets',
+      formatNumber(overview.galleryEngagement.approvedMedia),
+    ],
+    [
+      'Sponsor impact',
+      'Approved sponsorships',
+      formatNumber(overview.sponsorImpact.approvedSponsorships),
+    ],
+    [
+      'Sponsor impact',
+      'Approved sponsorship amount',
+      formatNumber(overview.sponsorImpact.approvedAmount),
+    ],
+    [
+      'Sponsor impact',
+      'Sponsor mentions in galleries',
+      formatNumber(overview.sponsorImpact.sponsorMentions),
+    ],
+    [
+      'Analytics usage',
+      'Dashboard views (30d)',
+      formatNumber(overview.analyticsUsage.viewsLast30Days),
+    ],
+    [
+      'Analytics usage',
+      'Dashboard views recorded',
+      formatNumber(overview.analyticsUsage.totalRecordedViews),
+    ],
   ];
   const csv = rows
     .map((row) =>
@@ -351,7 +421,7 @@ function buildAnalyticsReportCsv(overview) {
           }
           return cell;
         })
-        .join(','),
+        .join(',')
     )
     .join('\n');
   return csv;

--- a/backend/src/features/sponsors/sponsor.route.js
+++ b/backend/src/features/sponsors/sponsor.route.js
@@ -137,7 +137,10 @@ router.patch('/sponsorships/:sponsorshipId/status', authOnly, adminOnly, async (
     if (!uuidPattern.test(sponsorshipId)) {
       return res.status(400).json({ error: 'Invalid sponsorship identifier' });
     }
-    const sponsorship = await updateSponsorshipApproval({ sponsorshipId, status: req.body?.status });
+    const sponsorship = await updateSponsorshipApproval({
+      sponsorshipId,
+      status: req.body?.status,
+    });
     res.json({ sponsorship });
   } catch (error) {
     const status = error.statusCode || 500;

--- a/backend/src/features/sponsors/sponsor.service.js
+++ b/backend/src/features/sponsors/sponsor.service.js
@@ -15,7 +15,10 @@ const {
   markReportDelivered,
 } = require('./sponsor.repository');
 const { findUserById, replaceUserRoles } = require('../auth/auth.repository');
-const { generateEventReport, findEventById } = require('../event-management/eventManagement.repository');
+const {
+  generateEventReport,
+  findEventById,
+} = require('../event-management/eventManagement.repository');
 const { getGalleryMetrics } = require('../event-gallery/eventGallery.repository');
 const { sendTemplatedEmail } = require('../email/email.service');
 
@@ -53,15 +56,14 @@ function sanitizeBrandAssets(payload) {
       .filter((entry) => entry.length);
   }
   if (Array.isArray(files)) {
-    result.files = files
-      .map((entry) => String(entry || '').trim())
-      .filter((entry) => entry.length);
+    result.files = files.map((entry) => String(entry || '').trim()).filter((entry) => entry.length);
   }
   return result;
 }
 
 function ensureSponsorRole(user) {
-  const roles = Array.isArray(user.roles) && user.roles.length ? [...user.roles] : user.role ? [user.role] : [];
+  const roles =
+    Array.isArray(user.roles) && user.roles.length ? [...user.roles] : user.role ? [user.role] : [];
   if (!roles.includes('SPONSOR')) {
     roles.push('SPONSOR');
   }
@@ -102,11 +104,17 @@ async function applyForSponsor({
   });
 
   const desiredRoles = ensureSponsorRole(user);
-  if (desiredRoles.length !== (user.roles || []).length || !desiredRoles.every((role, index) => role === (user.roles || [])[index])) {
+  if (
+    desiredRoles.length !== (user.roles || []).length ||
+    !desiredRoles.every((role, index) => role === (user.roles || [])[index])
+  ) {
     try {
       await replaceUserRoles({ userId, roles: desiredRoles });
     } catch (error) {
-      logger.warn('Failed to refresh roles while applying as sponsor', { userId, error: error.message });
+      logger.warn('Failed to refresh roles while applying as sponsor', {
+        userId,
+        error: error.message,
+      });
     }
   }
 
@@ -138,13 +146,16 @@ async function updateProfile({ userId, updates }) {
     orgName: updates.orgName !== undefined ? sanitizeString(updates.orgName) : undefined,
     website: updates.website !== undefined ? sanitizeString(updates.website) : undefined,
     logoUrl: updates.logoUrl !== undefined ? sanitizeString(updates.logoUrl) : undefined,
-    contactName: updates.contactName !== undefined ? sanitizeString(updates.contactName) : undefined,
+    contactName:
+      updates.contactName !== undefined ? sanitizeString(updates.contactName) : undefined,
     contactEmail:
       updates.contactEmail !== undefined
         ? sanitizeString(updates.contactEmail) || user?.email
         : undefined,
-    contactPhone: updates.contactPhone !== undefined ? sanitizeString(updates.contactPhone) : undefined,
-    brandAssets: updates.brandAssets !== undefined ? sanitizeBrandAssets(updates.brandAssets) : undefined,
+    contactPhone:
+      updates.contactPhone !== undefined ? sanitizeString(updates.contactPhone) : undefined,
+    brandAssets:
+      updates.brandAssets !== undefined ? sanitizeBrandAssets(updates.brandAssets) : undefined,
   });
   logger.info('Sponsor profile updated', { userId });
   return next;
@@ -162,7 +173,10 @@ async function resolveSponsorContact(profile) {
   try {
     user = await findUserById(profile.userId);
   } catch (error) {
-    logger.warn('Failed to resolve sponsor user contact', { sponsorId: profile.userId, error: error.message });
+    logger.warn('Failed to resolve sponsor user contact', {
+      sponsorId: profile.userId,
+      error: error.message,
+    });
   }
   const email = sanitizeString(profile.contactEmail) || (user ? user.email : null);
   const name =
@@ -270,9 +284,9 @@ async function pledgeSponsorship({ sponsorId, eventId, type, amount, notes }) {
         subject: `Thanks for pledging support for ${event.title}`,
         heading: 'We received your pledge',
         bodyLines: [
-        `Hi ${contact.name},`,
-        `Thank you for offering ${normalizedType === 'FUNDS' ? `₹${normalizedAmount?.toLocaleString('en-IN')}` : 'in-kind resources'} to <strong>${event.title}</strong>.`,
-        'Our team will review and confirm the sponsorship shortly.',
+          `Hi ${contact.name},`,
+          `Thank you for offering ${normalizedType === 'FUNDS' ? `₹${normalizedAmount?.toLocaleString('en-IN')}` : 'in-kind resources'} to <strong>${event.title}</strong>.`,
+          'Our team will review and confirm the sponsorship shortly.',
         ],
         cta: {
           url: `${APP_BASE_URL}/app`,
@@ -337,7 +351,10 @@ async function updateSponsorshipApproval({ sponsorshipId, status }) {
           previewText: 'Sponsorship confirmed',
         });
       } catch (error) {
-        logger.warn('Failed to send sponsorship approval email', { sponsorshipId, error: error.message });
+        logger.warn('Failed to send sponsorship approval email', {
+          sponsorshipId,
+          error: error.message,
+        });
       }
     } else if (contact.email && sponsorship.status === 'DECLINED') {
       try {
@@ -353,7 +370,10 @@ async function updateSponsorshipApproval({ sponsorshipId, status }) {
           previewText: 'Update on your sponsorship',
         });
       } catch (error) {
-        logger.warn('Failed to send sponsorship decline email', { sponsorshipId, error: error.message });
+        logger.warn('Failed to send sponsorship decline email', {
+          sponsorshipId,
+          error: error.message,
+        });
       }
     }
   }
@@ -402,7 +422,11 @@ async function getSponsorDashboard({ sponsorId }) {
     try {
       impacts.set(eventId, await buildEventImpact(eventId));
     } catch (error) {
-      logger.warn('Failed to build impact snapshot for sponsor dashboard', { sponsorId, eventId, error: error.message });
+      logger.warn('Failed to build impact snapshot for sponsor dashboard', {
+        sponsorId,
+        eventId,
+        error: error.message,
+      });
     }
   }
 
@@ -467,10 +491,19 @@ async function getSponsorReports({ sponsorId }) {
   }
 
   if (reports.length) {
-    const totalHours = reports.reduce((sum, report) => sum + Number(report.totals.totalHours || 0), 0);
-    const totalViews = reports.reduce((sum, report) => sum + Number(report.gallery.viewCount || 0), 0);
+    const totalHours = reports.reduce(
+      (sum, report) => sum + Number(report.totals.totalHours || 0),
+      0
+    );
+    const totalViews = reports.reduce(
+      (sum, report) => sum + Number(report.gallery.viewCount || 0),
+      0
+    );
     const totalFunds = reports
-      .filter((report) => report.contribution.type === 'FUNDS' && typeof report.contribution.amount === 'number')
+      .filter(
+        (report) =>
+          report.contribution.type === 'FUNDS' && typeof report.contribution.amount === 'number'
+      )
       .reduce((sum, report) => sum + report.contribution.amount, 0);
 
     const contact = await resolveSponsorContact(profile);
@@ -481,22 +514,25 @@ async function getSponsorReports({ sponsorId }) {
           subject: 'Your latest Onkur impact report',
           heading: 'Impact snapshot ready',
           bodyLines: [
-          `Hi ${contact.name},`,
-          `Approved sponsorships covered <strong>${reports.length}</strong> event${reports.length === 1 ? '' : 's'}.`,
-          `Volunteers delivered <strong>${Math.round(totalHours * 100) / 100}</strong> hours and the galleries earned <strong>${totalViews}</strong> views.`,
-          totalFunds
-            ? `Direct funds contributed: <strong>₹${Math.round(totalFunds * 100) / 100}</strong>.`
-            : 'In-kind support amplified every moment shared in the galleries.',
-        ],
-        cta: {
-          url: `${APP_BASE_URL}/app`,
-          label: 'Review detailed reports',
-        },
-        previewText: 'Your sponsorship impact snapshot is ready',
+            `Hi ${contact.name},`,
+            `Approved sponsorships covered <strong>${reports.length}</strong> event${reports.length === 1 ? '' : 's'}.`,
+            `Volunteers delivered <strong>${Math.round(totalHours * 100) / 100}</strong> hours and the galleries earned <strong>${totalViews}</strong> views.`,
+            totalFunds
+              ? `Direct funds contributed: <strong>₹${Math.round(totalFunds * 100) / 100}</strong>.`
+              : 'In-kind support amplified every moment shared in the galleries.',
+          ],
+          cta: {
+            url: `${APP_BASE_URL}/app`,
+            label: 'Review detailed reports',
+          },
+          previewText: 'Your sponsorship impact snapshot is ready',
         });
         await markReportDelivered({ sponsorId });
       } catch (error) {
-        logger.warn('Failed to send sponsor impact report email', { sponsorId, error: error.message });
+        logger.warn('Failed to send sponsor impact report email', {
+          sponsorId,
+          error: error.message,
+        });
       }
     }
   }

--- a/backend/src/features/volunteer-journey/profile.bootstrap.js
+++ b/backend/src/features/volunteer-journey/profile.bootstrap.js
@@ -27,7 +27,7 @@ const INTEREST_SEEDS = [
   { value: 'education access', label: 'Education Access' },
   { value: 'rural development', label: 'Rural Development' },
   { value: 'climate advocacy', label: 'Climate Advocacy' },
-  { value: 'women empowerment', label: "Women Empowerment" },
+  { value: 'women empowerment', label: 'Women Empowerment' },
   { value: 'youth leadership', label: 'Youth Leadership' },
   { value: 'health camps', label: 'Health Camps' },
   { value: 'disaster relief', label: 'Disaster Relief' },

--- a/backend/src/features/volunteer-journey/volunteerJourney.service.js
+++ b/backend/src/features/volunteer-journey/volunteerJourney.service.js
@@ -151,8 +151,8 @@ function mapProfileRow(row, fallbackUserId) {
   const combinedLocation = row.location
     ? row.location
     : cityName && stateName
-    ? `${cityName}, ${stateName}`
-    : cityName || stateName || '';
+      ? `${cityName}, ${stateName}`
+      : cityName || stateName || '';
   return {
     userId: row.user_id,
     skills: Array.isArray(row.skills) ? row.skills : [],
@@ -173,7 +173,9 @@ function mapProfileRow(row, fallbackUserId) {
 function mapEventRow(event) {
   const signupCount = Number(event.signup_count || 0);
   const hasAvailable = event.available_slots !== undefined && event.available_slots !== null;
-  const availableSlots = hasAvailable ? Number(event.available_slots) : Math.max(event.capacity - signupCount, 0);
+  const availableSlots = hasAvailable
+    ? Number(event.available_slots)
+    : Math.max(event.capacity - signupCount, 0);
   return {
     id: event.id,
     title: event.title,
@@ -198,7 +200,9 @@ function mapEventRow(event) {
 function mapSignupRow(row) {
   const signupCount = Number(row.signup_count || 0);
   const hasAvailable = row.available_slots !== undefined && row.available_slots !== null;
-  const availableSlots = hasAvailable ? Number(row.available_slots) : Math.max(row.capacity - signupCount, 0);
+  const availableSlots = hasAvailable
+    ? Number(row.available_slots)
+    : Math.max(row.capacity - signupCount, 0);
   const assignments = Array.isArray(row.assignments)
     ? row.assignments.map((assignment) => ({
         assignmentId: assignment.assignmentId,
@@ -314,7 +318,15 @@ async function getProfile(userId) {
   return mapProfileRow(row, userId);
 }
 
-async function updateProfile({ userId, skills, interests, availability, stateCode, citySlug, bio }) {
+async function updateProfile({
+  userId,
+  skills,
+  interests,
+  availability,
+  stateCode,
+  citySlug,
+  bio,
+}) {
   const normalizedSkills = normalizeStringArray(skills);
   const normalizedInterests = normalizeStringArray(interests);
   const normalizedAvailability = normalizeSlug(availability);
@@ -333,7 +345,9 @@ async function updateProfile({ userId, skills, interests, availability, stateCod
   if (normalizedAvailability) {
     const option = await findAvailabilityOption(normalizedAvailability);
     if (!option) {
-      throw Object.assign(new Error('Select an availability option from the list'), { statusCode: 400 });
+      throw Object.assign(new Error('Select an availability option from the list'), {
+        statusCode: 400,
+      });
     }
     availabilityValue = option.value;
   }
@@ -365,11 +379,11 @@ async function updateProfile({ userId, skills, interests, availability, stateCod
   const locationDisplay = cityRecord
     ? `${cityRecord.name}${stateRecord ? `, ${stateRecord.name}` : ''}`
     : stateRecord
-    ? stateRecord.name
-    : null;
+      ? stateRecord.name
+      : null;
   const sanitizedLocation = sanitizeText(locationDisplay);
 
-  const updated = await upsertVolunteerProfile({
+  await upsertVolunteerProfile({
     userId,
     skills: normalizedSkills,
     interests: normalizedInterests,
@@ -618,12 +632,16 @@ async function recordVolunteerHours({ userId, eventId, minutes, note }) {
     throw Object.assign(new Error('Logged minutes must be greater than zero'), { statusCode: 400 });
   }
   if (!eventId) {
-    throw Object.assign(new Error('Event identifier is required to log hours'), { statusCode: 400 });
+    throw Object.assign(new Error('Event identifier is required to log hours'), {
+      statusCode: 400,
+    });
   }
 
   const hasRegistration = await hasSignup({ userId, eventId });
   if (!hasRegistration) {
-    throw Object.assign(new Error('You must join the event before logging hours'), { statusCode: 400 });
+    throw Object.assign(new Error('You must join the event before logging hours'), {
+      statusCode: 400,
+    });
   }
 
   const entry = await logVolunteerHours({

--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -1,15 +1,15 @@
-const fs = require("fs");
-const path = require("path");
-const logger = require("../utils/logger");
+const fs = require('fs');
+const path = require('path');
+const logger = require('../utils/logger');
 
 const isRouter = (candidate) =>
-  candidate && typeof candidate === "function" && typeof candidate.use === "function";
+  candidate && typeof candidate === 'function' && typeof candidate.use === 'function';
 
 const registerRoutes = (app) => {
-  const featuresDir = path.join(__dirname, "..", "features");
+  const featuresDir = path.join(__dirname, '..', 'features');
 
   if (!fs.existsSync(featuresDir)) {
-    logger.warn("Features directory not found. No routes were registered.");
+    logger.warn('Features directory not found. No routes were registered.');
     return;
   }
 
@@ -24,21 +24,25 @@ const registerRoutes = (app) => {
           return;
         }
 
-        if (!entry.isFile() || !entry.name.endsWith(".route.js")) {
+        if (!entry.isFile() || !entry.name.endsWith('.route.js')) {
           return;
         }
 
         const routeModule = require(fullPath);
         const router = routeModule.router || routeModule;
-        const basePath = routeModule.basePath || "/";
+        const basePath = routeModule.basePath || '/';
 
         if (!isRouter(router)) {
-          logger.warn(`Skipped registering route at ${fullPath} because it did not export an Express router.`);
+          logger.warn(
+            `Skipped registering route at ${fullPath} because it did not export an Express router.`
+          );
           return;
         }
 
         app.use(basePath, router);
-        logger.info(`Registered router from ${path.relative(featuresDir, fullPath)} at base path '${basePath}'.`);
+        logger.info(
+          `Registered router from ${path.relative(featuresDir, fullPath)} at base path '${basePath}'.`
+        );
       });
   };
 

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -1,20 +1,20 @@
-const app = require("./app");
-const config = require("./config");
-const logger = require("./utils/logger");
-const { ensureAdminUser } = require("./features/auth/admin.bootstrap");
-const { seedVolunteerProfileLookups } = require("./features/volunteer-journey/profile.bootstrap");
+const app = require('./app');
+const config = require('./config');
+const logger = require('./utils/logger');
+const { ensureAdminUser } = require('./features/auth/admin.bootstrap');
+const { seedVolunteerProfileLookups } = require('./features/volunteer-journey/profile.bootstrap');
 
 async function startServer() {
   try {
     await ensureAdminUser();
   } catch (error) {
-    logger.error("Admin bootstrap failed", { error: error.message });
+    logger.error('Admin bootstrap failed', { error: error.message });
   }
 
   try {
     await seedVolunteerProfileLookups();
   } catch (error) {
-    logger.error("Volunteer profile lookup bootstrap failed", { error: error.message });
+    logger.error('Volunteer profile lookup bootstrap failed', { error: error.message });
   }
 
   app.listen(config.port, () => {

--- a/backend/src/utils/logger.js
+++ b/backend/src/utils/logger.js
@@ -1,7 +1,7 @@
-const fs = require("fs");
-const path = require("path");
-const winston = require("winston");
-const config = require("../config");
+const fs = require('fs');
+const path = require('path');
+const winston = require('winston');
+const config = require('../config');
 
 const transports = [
   new winston.transports.Console({
@@ -29,7 +29,7 @@ const logger = winston.createLogger({
   format: winston.format.combine(
     winston.format.timestamp(),
     winston.format.printf(({ timestamp, level, message, ...meta }) => {
-      const metaString = Object.keys(meta).length ? ` ${JSON.stringify(meta)}` : "";
+      const metaString = Object.keys(meta).length ? ` ${JSON.stringify(meta)}` : '';
       return `${timestamp} [${level}] ${message}${metaString}`;
     })
   ),

--- a/backend/src/utils/test-db.js
+++ b/backend/src/utils/test-db.js
@@ -1,16 +1,16 @@
-const pool = require("../features/common/db");
-const logger = require("./logger");
+const pool = require('../features/common/db');
+const logger = require('./logger');
 
 (async () => {
   try {
     const client = await pool.connect();
-    logger.info("✅ Connected to Postgres");
-    const result = await client.query("SELECT NOW() AS time");
-    logger.info("Current Postgres time", { time: result.rows[0].time });
+    logger.info('✅ Connected to Postgres');
+    const result = await client.query('SELECT NOW() AS time');
+    logger.info('Current Postgres time', { time: result.rows[0].time });
     client.release();
     process.exit(0);
   } catch (err) {
-    logger.error("❌ Postgres connection failed", { error: err.message });
+    logger.error('❌ Postgres connection failed', { error: err.message });
     process.exit(1);
   }
 })();

--- a/backend/src/utils/test-minio.js
+++ b/backend/src/utils/test-minio.js
@@ -1,11 +1,11 @@
-const minioClient = require("../features/common/minio");
-const config = require("../config");
-const logger = require("./logger");
+const minioClient = require('../features/common/minio');
+const config = require('../config');
+const logger = require('./logger');
 
 (async () => {
   try {
     if (!config.minio.bucket) {
-      logger.warn("MINIO_BUCKET is not configured. Skipping bucket existence check.");
+      logger.warn('MINIO_BUCKET is not configured. Skipping bucket existence check.');
       process.exit(0);
       return;
     }
@@ -14,7 +14,7 @@ const logger = require("./logger");
     logger.info(`✅ MinIO bucket '${config.minio.bucket}' exists`, { exists });
     process.exit(0);
   } catch (err) {
-    logger.error("❌ MinIO test failed", { error: err.message });
+    logger.error('❌ MinIO test failed', { error: err.message });
     process.exit(1);
   }
 })();

--- a/backend/tests/auth.service.test.js
+++ b/backend/tests/auth.service.test.js
@@ -45,9 +45,10 @@ describe('auth.service', () => {
     expect(signupResult.user.roles).toEqual(['VOLUNTEER']);
     expect(signupResult.requiresEmailVerification).toBe(true);
 
-    const tokenRow = await pool.query('SELECT token FROM email_verification_tokens WHERE user_id = $1', [
-      signupResult.user.id,
-    ]);
+    const tokenRow = await pool.query(
+      'SELECT token FROM email_verification_tokens WHERE user_id = $1',
+      [signupResult.user.id]
+    );
     expect(tokenRow.rows[0]?.token).toBeTruthy();
 
     await authService.verifyEmail({ token: tokenRow.rows[0].token });
@@ -107,9 +108,10 @@ describe('auth.service', () => {
       password: 'password123',
     });
 
-    const tokenRow = await pool.query('SELECT token FROM email_verification_tokens WHERE user_id = $1', [
-      signupResult.user.id,
-    ]);
+    const tokenRow = await pool.query(
+      'SELECT token FROM email_verification_tokens WHERE user_id = $1',
+      [signupResult.user.id]
+    );
     await authService.verifyEmail({ token: tokenRow.rows[0].token });
 
     const { token, jti, user } = await authService.login({
@@ -122,7 +124,10 @@ describe('auth.service', () => {
 
     const payloadSegment = token.split('.')[1];
     const normalized = payloadSegment.replace(/-/g, '+').replace(/_/g, '/');
-    const payloadBuffer = Buffer.from(normalized + '==='.slice((normalized.length + 3) % 4), 'base64');
+    const payloadBuffer = Buffer.from(
+      normalized + '==='.slice((normalized.length + 3) % 4),
+      'base64'
+    );
     const decoded = JSON.parse(payloadBuffer.toString());
     const expiresAt = new Date(decoded.exp * 1000).toISOString();
 

--- a/backend/tests/impact.service.test.js
+++ b/backend/tests/impact.service.test.js
@@ -161,7 +161,7 @@ describe('impact.service', () => {
     });
 
     const analytics = await pool.query(
-      "SELECT value FROM analytics_daily WHERE metric_key = 'stories_submitted'",
+      "SELECT value FROM analytics_daily WHERE metric_key = 'stories_submitted'"
     );
     expect(Number(analytics.rows[0]?.value)).toBe(1);
   });
@@ -223,19 +223,19 @@ describe('impact.service', () => {
 
     await pool.query(
       'INSERT INTO sponsor_profiles (user_id, org_name, contact_name, contact_email, status) VALUES ($1,$2,$3,$4,$5)',
-      [sponsorA, 'Green Roots', 'Riya', 'riya@greenroots.org', 'APPROVED'],
+      [sponsorA, 'Green Roots', 'Riya', 'riya@greenroots.org', 'APPROVED']
     );
     await pool.query(
       'INSERT INTO sponsor_profiles (user_id, org_name, contact_name, contact_email, status) VALUES ($1,$2,$3,$4,$5)',
-      [sponsorB, 'Eco Friends', 'Dev', null, 'APPROVED'],
+      [sponsorB, 'Eco Friends', 'Dev', null, 'APPROVED']
     );
     await pool.query(
       'INSERT INTO sponsorships (id, sponsor_id, event_id, status, amount) VALUES ($1,$2,$3,$4,$5)',
-      [randomUUID(), sponsorA, eventId, 'APPROVED', 5000],
+      [randomUUID(), sponsorA, eventId, 'APPROVED', 5000]
     );
     await pool.query(
       'INSERT INTO sponsorships (id, sponsor_id, event_id, status, amount) VALUES ($1,$2,$3,$4,$5)',
-      [randomUUID(), sponsorB, eventId, 'APPROVED', 2500],
+      [randomUUID(), sponsorB, eventId, 'APPROVED', 2500]
     );
 
     sendTemplatedEmailMock.mockClear();
@@ -249,7 +249,7 @@ describe('impact.service', () => {
     expect(sendTemplatedEmailMock).toHaveBeenCalledTimes(3);
 
     const publishedMetric = await pool.query(
-      "SELECT value FROM analytics_daily WHERE metric_key = 'stories_published'",
+      "SELECT value FROM analytics_daily WHERE metric_key = 'stories_published'"
     );
     expect(Number(publishedMetric.rows[0]?.value)).toBe(1);
   });
@@ -298,7 +298,7 @@ describe('impact.service', () => {
       ]),
     ]);
 
-    const pending = await impactService.submitImpactStory({
+    await impactService.submitImpactStory({
       eventId,
       author: { id: authorId },
       title: 'Mangroves breathing again',
@@ -320,57 +320,64 @@ describe('impact.service', () => {
       mediaIds: [],
     });
 
-    await impactService.approveImpactStory({ storyId: approved.story.id, moderator: { id: moderatorId } });
-    await impactService.rejectImpactStory({ storyId: rejected.story.id, moderator: { id: moderatorId }, reason: 'Needs edits' });
+    await impactService.approveImpactStory({
+      storyId: approved.story.id,
+      moderator: { id: moderatorId },
+    });
+    await impactService.rejectImpactStory({
+      storyId: rejected.story.id,
+      moderator: { id: moderatorId },
+      reason: 'Needs edits',
+    });
 
     await pool.query(
-      'INSERT INTO volunteer_hours (id, user_id, event_id, minutes, created_at) VALUES ($1,$2,$3,$4, NOW() - INTERVAL \'15 days\')',
-      [randomUUID(), authorId, eventId, 180],
+      "INSERT INTO volunteer_hours (id, user_id, event_id, minutes, created_at) VALUES ($1,$2,$3,$4, NOW() - INTERVAL '15 days')",
+      [randomUUID(), authorId, eventId, 180]
     );
     await pool.query(
-      'INSERT INTO volunteer_hours (id, user_id, event_id, minutes, created_at) VALUES ($1,$2,$3,$4, NOW() - INTERVAL \'60 days\')',
-      [randomUUID(), authorId, otherEventId, 120],
+      "INSERT INTO volunteer_hours (id, user_id, event_id, minutes, created_at) VALUES ($1,$2,$3,$4, NOW() - INTERVAL '60 days')",
+      [randomUUID(), authorId, otherEventId, 120]
     );
     await pool.query(
-      'INSERT INTO volunteer_hours (id, user_id, event_id, minutes, created_at) VALUES ($1,$2,$3,$4, NOW() - INTERVAL \'120 days\')',
-      [randomUUID(), authorId, eventId, 90],
+      "INSERT INTO volunteer_hours (id, user_id, event_id, minutes, created_at) VALUES ($1,$2,$3,$4, NOW() - INTERVAL '120 days')",
+      [randomUUID(), authorId, eventId, 90]
     );
 
     await pool.query(
-      'INSERT INTO event_signups (id, event_id, user_id, created_at) VALUES ($1,$2,$3,NOW() - INTERVAL \'2 days\')',
-      [randomUUID(), eventId, authorId],
+      "INSERT INTO event_signups (id, event_id, user_id, created_at) VALUES ($1,$2,$3,NOW() - INTERVAL '2 days')",
+      [randomUUID(), eventId, authorId]
     );
     await pool.query(
-      'INSERT INTO event_signups (id, event_id, user_id, created_at) VALUES ($1,$2,$3,NOW() - INTERVAL \'10 days\')',
-      [randomUUID(), otherEventId, authorId],
+      "INSERT INTO event_signups (id, event_id, user_id, created_at) VALUES ($1,$2,$3,NOW() - INTERVAL '10 days')",
+      [randomUUID(), otherEventId, authorId]
     );
 
     await pool.query(
       'INSERT INTO event_media (id, event_id, caption, status, sponsor_mentions) VALUES ($1,$2,$3,$4,$5)',
-      [randomUUID(), eventId, 'Gallery highlight', 'APPROVED', 4],
+      [randomUUID(), eventId, 'Gallery highlight', 'APPROVED', 4]
     );
     await pool.query(
       'INSERT INTO event_media (id, event_id, caption, status, sponsor_mentions) VALUES ($1,$2,$3,$4,$5)',
-      [randomUUID(), otherEventId, 'Garden photo', 'APPROVED', 2],
+      [randomUUID(), otherEventId, 'Garden photo', 'APPROVED', 2]
     );
 
     await pool.query(
-      'INSERT INTO event_gallery_metrics (event_id, view_count, last_viewed_at) VALUES ($1,$2,NOW() - INTERVAL \'1 day\')',
-      [eventId, 120],
+      "INSERT INTO event_gallery_metrics (event_id, view_count, last_viewed_at) VALUES ($1,$2,NOW() - INTERVAL '1 day')",
+      [eventId, 120]
     );
     await pool.query(
-      'INSERT INTO event_gallery_metrics (event_id, view_count, last_viewed_at) VALUES ($1,$2,NOW() - INTERVAL \'4 days\')',
-      [otherEventId, 45],
+      "INSERT INTO event_gallery_metrics (event_id, view_count, last_viewed_at) VALUES ($1,$2,NOW() - INTERVAL '4 days')",
+      [otherEventId, 45]
     );
 
     await pool.query(
-      "INSERT INTO analytics_daily (date, metric_key, value) VALUES (CURRENT_DATE, 'analytics_dashboard_views', 4)",
+      "INSERT INTO analytics_daily (date, metric_key, value) VALUES (CURRENT_DATE, 'analytics_dashboard_views', 4)"
     );
     await pool.query(
-      "INSERT INTO analytics_daily (date, metric_key, value) VALUES (CURRENT_DATE - INTERVAL '10 days', 'analytics_dashboard_views', 3)",
+      "INSERT INTO analytics_daily (date, metric_key, value) VALUES (CURRENT_DATE - INTERVAL '10 days', 'analytics_dashboard_views', 3)"
     );
     await pool.query(
-      "INSERT INTO analytics_daily (date, metric_key, value) VALUES (CURRENT_DATE - INTERVAL '40 days', 'analytics_dashboard_views', 2)",
+      "INSERT INTO analytics_daily (date, metric_key, value) VALUES (CURRENT_DATE - INTERVAL '40 days', 'analytics_dashboard_views', 2)"
     );
 
     const overview = await impactService.getImpactAnalyticsOverview();

--- a/docs/Wiki.md
+++ b/docs/Wiki.md
@@ -1,26 +1,37 @@
 # Dynamic gallery URL resolution
+
 - **Date:** 2025-10-13
 - **Change:** Introduced a shared gallery storage URL helper that always rebuilds public media links from the live MinIO/S3 configuration and wired repository mappers to consume it while keeping inline fallbacks intact.
 - **Impact:** Updating `MINIO_ENDPOINT`, port, or TLS settings now retroactively adjusts previously uploaded gallery image URLs without backfilling the database, ensuring legacy media keeps working after storage host changes.
 
 # Onkur Change Log
 
+## Repository hygiene & CI refresh
+
+- **Date:** 2025-10-14
+- **Change:** Removed committed dependency directories, introduced workspace `.gitignore` rules, added Prettier/ESLint configs for backend and frontend, wired Vitest smoke coverage for the app shell, and provisioned `.env.example` templates. Established GitHub Actions CI to run formatting checks, linting, tests, and production builds on every push.
+- **Impact:** Contributors work from a predictable baseline with reproducible installs, automated quality gates, and documentation that points to the new contribution, conduct, and license policies.
+
 ## Dev server cache headers for React integrity
+
 - **Date:** 2025-10-12
 - **Change:** Configured the Vite dev server to emit `no-store` cache headers so module requests bypass browser caches after container restarts and documented the requirement in the frontend agent guide.
 - **Impact:** Prevents stale React vendor chunks from lingering in browser caches, eliminating the "Invalid hook call" errors that previously required a manual cache clear before the dashboard would load again.
 
 ## Impact analytics rollup hardening
+
 - **Date:** 2025-10-11
 - **Change:** Hardened the impact analytics repository to sum recorded dashboard views instead of counting rows, expanded the Jest suite with in-memory database coverage for story submission, moderation notifications, and overview export math, and refreshed impact feature guidelines to keep future changes aligned.
 - **Impact:** Stakeholders now see accurate analytics usage totals, regression coverage guards the end-to-end story pipeline, and future impact work has a documented testing contract.
 
 ## Phase 7 impact storytelling & analytics
+
 - **Date:** 2025-10-10
 - **Change:** Delivered the Phase 7 impact layer: beneficiaries can submit rich stories tied to events, admins moderate approvals with sponsor + author notifications, the gallery now renders approved impact stories, and a consolidated analytics API/CSV export surfaces volunteer hours, participation, gallery reach, and sponsor impressions. Volunteer dashboards show a new community highlights card.
 - **Impact:** Storytelling now travels from submission through approval to public display, sponsors get notified when spotlighted, and admins plus stakeholders can export platform-wide impact metrics while volunteers see how their hours move the needle.
 
 ## Audit log metadata defaults
+
 - **Date:** 2025-10-09
 - **Change:** Normalized the backend audit logging helper to always persist an empty JSON object when optional metadata is
   omitted, aligning inserts with the database `metadata` column's `NOT NULL` constraint and preventing login attempts from
@@ -29,16 +40,19 @@
   reach the dashboard even when no supplemental metadata accompanies the audit entry.
 
 ## React 18.3 alignment for auth hooks
+
 - **Date:** 2025-10-07
 - **Change:** Upgraded the frontend to `react@18.3.1` and `react-dom@18.3.1`, refreshed the lockfile, and enforced `npm dedupe` guidance so the Auth context resolves hooks against a single React dispatcher.
 - **Impact:** Logged-in sessions no longer trigger the "Invalid hook call" error inside `AuthProvider`, restoring dashboard access while keeping the Vite dedupe safeguards documented for future dependency work.
 
 ## Layout Suspense loader overlay
+
 - **Date:** 2025-10-06
 - **Change:** Wrapped the layout content area in its own `Suspense` boundary that renders the shared `LoadingScreen` and adjusted the loader container sizing so route-to-route navigation always presents an inline progress indicator without collapsing the spinner.
 - **Impact:** Volunteers, sponsors, and admins now see immediate feedback when navigating between dashboard sections, confirming their interactions while lazy-loaded routes stream in.
 
 ## React dedupe for hook stability
+
 - **Date:** 2025-10-05
 - **Change:** Configured Vite to deduplicate `react` and `react-dom` module resolution so the dev server and production build alw
   ays share a single React instance.
@@ -46,208 +60,237 @@
   or that prevented the landing page from rendering.
 
 ## Direct main bundle loading
+
 - **Date:** 2025-10-04
 - **Change:** Updated the frontend entry script to load `src/main.js` directly, replaced the JSX entry module with a JavaScript
   module to avoid redirects, and refreshed the Vite HTML transform so Rocket Loader keeps the correct crossorigin attributes.
 - **Impact:** Browsers now request the dashboard bundle without following `main.jsx` detours, trimming an extra roundtrip when t
-he app boots under the CDN.
+  he app boots under the CDN.
 
 ## Event report downloads stay in app
+
 - **Date:** 2025-10-04
 - **Change:** Converted the event report export into an authenticated blob download so managers save CSVs without opening new tabs, and replaced the volunteer guidance CTA with an in-app link to avoid full page reloads.
 - **Impact:** Event managers can grab analytics without context switches while volunteers jump to the events hub instantly with client-side routing.
 
 ## Desktop navigation parity
+
 - **Date:** 2025-09-18
 - **Change:** Introduced a desktop header navigation that mirrors the mobile bottom menu, centralized the navigation config, and wired menu items to new `/app/events`, `/app/gallery`, and `/app/profile` routes.
 - **Impact:** Authenticated users can now move between dashboard sections on both mobile and desktop, with dedicated views for events, gallery spotlights, and profile management.
 
 ## Volunteer dashboard API routing fix
+
 - **Date:** 2025-09-18
 - **Change:** Updated the volunteer journey router to register its endpoints relative to the `/api` base path so that dashboard requests such as `/api/me/dashboard` resolve correctly after login.
 - **Impact:** Volunteers can now load their dashboard without receiving the generic "Request failed" error because the routes map to the expected URLs.
 
 ## Phase 3 event manager workflows
+
 - **Date:** 2025-09-19
 - **Change:** Introduced a dedicated event management feature set: managers can draft, update, publish, and complete events; define task boards; assign registered volunteers; process attendance with automatic hour logging; and generate shareable CSV impact reports. The frontend dashboard now surfaces a full workspace for these flows.
 - **Impact:** Event managers can coordinate end-to-end logistics from the dashboard while volunteers immediately see published events, their assignments, and updated hours when checked in on site.
 
-
 ## README roadmap refresh
+
 - **Date:** 2025-09-20
 - **Change:** Expanded the public README to reflect the completed three-phase rollout, covering volunteer profiles, discovery, event management, and supporting tooling while pointing to the canonical wiki file.
 - **Impact:** Stakeholders and contributors now have an at-a-glance summary of Onkur's Phase 1–3 capabilities without diving into internal docs.
 
 ## Role-aware registration and directories
+
 - **Date:** 2025-09-20
 - **Change:** Expanded signup to let new members pick multiple roles (volunteer, event manager, sponsor) via accessible checkboxes, persisted through a new `user_roles` join table. Admin tooling now edits multi-role assignments, and all auth responses expose a normalized `roles` array alongside the primary role.
 - **Impact:** Members can express every way they want to contribute from day one, and admin workflows stay in sync with richer role data across the platform.
+
 ## Branded email foundation
+
 - **Date:** 2025-09-21
 - **Change:** Refreshed the Nodemailer service with a reusable Onkur theme that injects a responsive CSS layout, standardized the `[Onkur]` subject prefix, and added a `npm run send:test-email` utility for verifying SMTP credentials via the new template.
 - **Impact:** Contributors have a modern baseline for transactional emails and a simple script to confirm delivery without duplicating setup work.
+
 ## Admin bootstrap configuration
+
 - **Date:** 2025-09-21
 - **Change:** Added startup logic that seeds a default admin account whenever `ADMIN_NAME`, `ADMIN_EMAIL`, and `ADMIN_PASSWORD` are provided. The bootstrapper promotes existing records to the ADMIN role or creates a verified admin using the configured credentials.
 - **Impact:** Deployments now guarantee an ADMIN user without manual SQL, ensuring future admin-only features have an account ready for use.
 
-
 ## Email verification handoff improvements
+
 - **Date:** 2025-09-22
 - **Change:** The signup API now returns the configured admin contact address alongside the verification prompt, and the frontend guides new members to a dedicated "Check your email" screen that preserves their address, explains the confirmation step, and surfaces the admin email for support.
 - **Impact:** Fresh registrants immediately understand that email verification is required before logging in and know how to reach an administrator if the confirmation message does not arrive.
 
 ## Configurable verification support contact
+
 - **Date:** 2025-09-22
 - **Change:** Centralized the admin support email so both the API and post-signup UX read from environment variables (`ADMIN_EMAIL` and `VITE_ADMIN_EMAIL`), trimming and formatting comma-separated addresses for display.
 - **Impact:** Operations teams can change the contact mailbox without redeploying code, and registrants always see the up-to-date support email after signing up.
+
 ## Unified multi-role dashboard priority
+
 - **Date:** 2025-09-22
 - **Change:** Centralized role-priority helpers on the backend and dashboard so users holding multiple roles always expose a deterministic `primaryRole`, ensuring dashboards, galleries, and profiles tailor their intros correctly while preserving all role badges.
 - **Impact:** Members who are simultaneously volunteers, event managers, and sponsors now see the full toolset without losing access to any experience, and administrators reuse a single helper when adjusting role order.
+
 ## Volunteer home focuses on commitments
+
 - **Date:** 2025-09-22
 - **Change:** Removed the in-dashboard profile editor for volunteers and expanded the upcoming commitments card to span the dashboard width so all roles treat profile updates through the dedicated profile page.
 - **Impact:** Volunteers manage their profiles from the Profile menu while the dashboard highlights schedules and logged impact without split attention.
 
 ## Volunteer dashboard event discovery removal
+
 - **Date:** 2025-09-22
 - **Change:** Retired the "Discover new events" panel from the volunteer home view so the dashboard centers on commitments and impact tracking while directing discovery traffic to the dedicated events hub.
 - **Impact:** Volunteers see a streamlined home focused on what they’ve scheduled and accomplished, using the events hub when they’re ready to browse new opportunities.
 
 ## Profile completion reminder on volunteer home
+
 - **Date:** 2025-09-23
 - **Change:** Added a volunteer dashboard call-to-action that surfaces when profile data is incomplete, showing percent completion, highlighting missing sections, and linking directly to the profile editor.
 - **Impact:** Volunteers understand why finishing their profile matters and can jump straight to the editor, helping event managers match the right people to upcoming opportunities.
 
 ## Role-aware profile completion prompts
+
 - **Date:** 2025-09-23
 - **Change:** Extended the profile completion call-to-action to event manager and sponsor dashboards, centralizing the UI so each role reuses the same visual pattern while customizing motivational copy.
 - **Impact:** Coordinators and partners now receive tailored encouragement to complete their profiles, improving trust with volunteers and giving the team better context for recognition efforts.
 
 ## Sponsor & manager profile CTA data fix
+
 - **Date:** 2025-09-23
 - **Change:** Updated the auth service to include volunteer profile payloads in public user responses so sponsor and event manager dashboards can measure completion progress immediately after login.
 - **Impact:** Non-volunteer roles now see the profile completion prompts that were previously scoped to volunteers, keeping the cross-role guidance consistent.
 
 ## Lookup-driven profile editor
+
 - **Date:** 2025-09-24
 - **Change:** Replaced free-form profile fields with curated lookup selectors for skills, interests, availability, and location. The backend now seeds Indian-centric reference data for these lookups, exposes authenticated endpoints to fetch cascaded state/city lists, and persists selections alongside optional custom skills or interests.
 - **Impact:** Volunteers and other members update their profiles faster with consistent terminology, coordinators can filter against normalized data, and deployments automatically receive the seeded options without manual database scripts.
 
 ## Profile editor primary action buttons
+
 - **Date:** 2025-09-25
 - **Change:** Promoted the custom skill and interest buttons on the volunteer profile editor to use the primary button style and documented the expectation in the volunteer frontend guidelines.
 - **Impact:** The calls-to-action to add new skills or interests now stand out visually, guiding members to enrich their profiles without hunting for the controls.
 
-
 ## Event manager lookup-driven event logging
+
 - **Date:** 2025-09-26
 - **Change:** Event drafting now relies on reference data: categories persist to a new `event_categories` table, state/city fields reference the Indian lookup tables, an `isOnline` flag drives mode-specific validation, and optional skill/interest/availability arrays capture ideal volunteers. The manager workspace fetches these lookups, offers inline category creation, and reshapes the form/UI to surface online mode and location chips.
 - **Impact:** Managers log events with consistent taxonomy, can flag virtual sessions, and share richer expectations with volunteers without duplicating reference data or free-form text.
 
 ## Hours logging requires event participation
+
 - **Date:** 2025-09-25
 - **Change:** Updated the volunteer hours tracker to hide the logging form when a volunteer has not joined any events, replacing it with guidance to explore the events hub. Documented the pattern in the volunteer frontend guidelines.
 - **Impact:** Volunteers understand they must RSVP to an event before logging time and are directed to the appropriate place to do so, preventing empty submissions.
 
 ## Volunteer events CTA width refinement
+
 - **Date:** 2025-09-25
 - **Change:** Adjusted the volunteer hours tracker events hub link to use a self-starting primary button so the CTA renders at its standard width instead of stretching across the card. Added the expectation to the volunteer frontend guidelines.
 - **Impact:** Volunteers see a tidy guidance card that matches other dashboard buttons while still drawing attention to the events hub when they need to join an opportunity before logging hours.
 
 ## Event launch outreach automation
+
 - **Date:** 2025-09-26
 - **Change:** Event creation now schedules branded emails to every volunteer and sponsor in the background, tailoring the message, CTA, and impact notes when their profile skills, interests, availability, or location align with the opportunity.
 - **Impact:** Event managers publish without waiting on email dispatch while volunteers and sponsors receive timely, personalized nudges that highlight why the event matters to them.
 
 ## Idempotent event lookup constraints
+
 - **Date:** 2025-09-27
 - **Change:** Hardened the volunteer journey bootstrapper to check for foreign key constraints before adding them to the `events` table so schema setup can run multiple times without raising duplicate constraint errors.
 - **Impact:** Local development and container restarts no longer crash during startup when the lookup seeding runs after the schema has already been upgraded.
 
 ## Event creation placeholder alignment
+
 - **Date:** 2025-09-27
 - **Change:** Fixed the event creation repository insert statement to provide parameter placeholders for every column so the database receives the required availability and creator values alongside the draft status default.
 - **Impact:** Event managers can save drafts without encountering the "INSERT has more target columns than expressions" error.
 
-
 ## Manager notifications on volunteer signups
+
 - **Date:** 2025-09-28
 - **Change:** Updated the volunteer signup service to look up an event's manager and send them a branded notification email whenever a volunteer registers, while preserving the primary confirmation flow if the manager email fails.
 - **Impact:** Event managers now receive timely awareness of new volunteers joining their events, letting them review rosters and plan assignments without monitoring the dashboard constantly.
 
 ## Volunteer event departures reset impact
+
 - **Date:** 2025-09-28
 - **Change:** Added a `DELETE /api/events/:eventId/signup` endpoint that uses a transactional `cancelEventSignup` helper to remove assignments, attendance, and logged hours before emailing the event manager via the branded template. The volunteer dashboard and events hub now surface "Leave event" actions with inline feedback and refresh all summary panels after success.
 - **Impact:** Volunteers can bow out of commitments at any time, their impact totals drop to zero for that event, and managers receive immediate notice to rebalance coverage.
 
 ## Phase 4 gallery storytelling
+
 - **Date:** 2025-09-29
 - **Change:** Introduced an end-to-end event gallery system: uploads pass through a moderated pipeline with EXIF-stripping image processing, MinIO/S3 storage, role-aware tagging, sponsor/community notifications, public `/gallery` browsing, infinite-scroll viewing, and an admin moderation queue. Dashboard gallery tooling now lets participants submit photos, review approved stories, and admins oversee queues.
 - **Impact:** Onkur can showcase event impact through rich, mobile-first visuals. Volunteers and managers highlight participants and sponsors, admins guard quality, sponsors are alerted when featured, and visitors explore live galleries with quick load times.
 
-
 ## Event gallery runtime compatibility
+
 - **Date:** 2025-09-29
 - **Change:** Updated the gallery upload service to lazy-load the `file-type` detector through an ES module import so Node 20 resolves the dependency without triggering the "No exports main defined" error during startup.
 - **Impact:** Backend containers boot cleanly again, keeping gallery moderation, uploads, and notifications online for admins and event teams.
 
-
 ## Mobile header compaction
+
 - **Date:** 2025-09-30
 - **Change:** Slimmed the authenticated dashboard header with tighter spacing, hid the subtitle on mobile, and relocated the logout action to the sticky bottom navigation.
 - **Impact:** Mobile users regain vertical space for content while still accessing logout from the persistent footer, and desktop retains the prominent logout control.
 
-
 ## Earthy brown branding refresh
+
 - **Date:** 2025-09-30
 - **Change:** Recolored the shared Tailwind palette and home page theme styles to center on earthy browns and ambers, updating gradients, shadows, and button treatments to match the new direction.
 - **Impact:** The web experience now carries a cohesive warm visual identity that aligns with the refreshed Onkur brand guidelines without disrupting existing layout structure.
 
-
-
 ## Phase 5 sponsor partnerships
+
 - **Date:** 2025-10-01
 - **Change:** Introduced the sponsor workflow end to end: sponsors apply for approval, admins moderate applications, approved sponsors pledge funds or in-kind support to events, and dashboards surface live sponsorships with ROI-ready metrics and impact reports.
 - **Impact:** Sponsors gain a dedicated workspace to support events, see their logos across event and gallery experiences, and receive automated summaries of volunteer hours, attendance, and gallery visibility tied to their contributions.
 
 ## Phase 6 admin oversight
+
 - **Date:** 2025-10-08
 - **Change:** Delivered a comprehensive admin console with moderation queues for events, sponsors, and gallery media; approval/rejection APIs that log before/after snapshots; user management to toggle roles and deactivate accounts; and downloadable reports with CSV/Excel output plus refreshed metrics tiles.
 - **Impact:** Admins can govern the entire platform from one screen, keep audit trails for every action, notify submitters automatically, and download system-wide datasets for compliance or analytics without touching the database.
 
-
 ## Sponsor event discovery guardrails
+
 - **Date:** 2025-10-02
 - **Change:** Hardened the shared event discovery component to treat sponsor metadata as optional, guarding array access and action handlers so the volunteer and sponsor dashboards no longer crash when the API omits sponsorship details.
 - **Impact:** Event lists now render reliably for every role, giving sponsors and volunteers uninterrupted access to filters, signups, and pledge actions even while data loads or profiles await approval.
 
-
 ## GTmetrix bundle optimizations
+
 - **Date:** 2025-10-02
 - **Change:** Swapped top-level routes and dashboard surfaces to `React.lazy` + Suspense fallbacks so React Router pages load on demand, and tuned `vite.config.js` to leverage Terser minification, drop console/debugger statements, and emit manual vendor chunks for React and router packages.
 - **Impact:** Initial page loads download smaller JavaScript payloads while subsequent navigation streams feature-specific code, aligning the dashboard with GTmetrix recommendations for minification, unused code removal, and bundle splitting.
 
-
 ## Rocket Loader preload credential alignment
+
 - **Date:** 2025-10-02
 - **Change:** Added a Vite HTML transform that injects `crossorigin="anonymous"` on the dev client preload and entry module scripts while updating `index.html` to mark the root bundle with the same attribute.
 - **Impact:** Cloudflare Rocket Loader now reuses the preload for `@vite/client` without warning about credential mode mismatches, keeping browser consoles clean during development.
 
 ## CSS delivery optimizations
+
 - **Date:** 2025-10-03
 - **Change:** Moved Google Font loading from a CSS `@import` into `<link>` tags within `index.html` and introduced cssnano into the PostCSS pipeline so production builds ship minified stylesheets.
 - **Impact:** The dashboard avoids render-blocking stylesheet imports while trimming roughly 2KB from the compiled CSS bundle, improving page load performance.
 
 ## Google Fonts swap delivery
+
 - **Date:** 2025-10-03
 - **Change:** Swapped the dashboard back to Google Fonts, loading Inter and Nunito weights through `<link>` tags that request latin subsets with `display=swap` while removing the bundled WOFF2 assets and `fonts.css` entrypoint.
 - **Impact:** The build avoids binary font commits while still shipping non-blocking typography with the lighter latin-focused families the UI expects.
 
 ## Landing LCP fallback removal
+
 - **Date:** 2025-10-03
 - **Change:** Inlined the public `HomePage` in `App.jsx` instead of lazy loading it so first impressions avoid the Suspense spinner and the hero content can render with the initial bundle.
 - **Impact:** Largest Contentful Paint on the marketing home now depends on the first script payload alone, eliminating the extra network hop that pushed GTmetrix LCP near 5.5 seconds.
-
-

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,2 +1,2 @@
-VITE_API_BASE_URL=http://localhost:1011
-VITE_ADMIN_EMAIL=admin@example.com
+VITE_API_BASE_URL=http://localhost:5000
+VITE_ADMIN_EMAIL=support@example.com

--- a/frontend/.eslintignore
+++ b/frontend/.eslintignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -1,0 +1,29 @@
+module.exports = {
+  root: true,
+  env: {
+    browser: true,
+    es2022: true,
+  },
+  extends: [
+    'eslint:recommended',
+    'plugin:react/recommended',
+    'plugin:react-hooks/recommended',
+    'plugin:jsx-a11y/recommended',
+    'prettier',
+  ],
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+  plugins: ['react', 'react-hooks', 'jsx-a11y'],
+  settings: {
+    react: {
+      version: 'detect',
+    },
+  },
+  rules: {
+    'react/react-in-jsx-scope': 'off',
+    'react/prop-types': 'off',
+    'react-hooks/exhaustive-deps': 'off',
+  },
+};

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,19 +8,37 @@
       "name": "frontend",
       "version": "1.0.0",
       "dependencies": {
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1",
-        "react-router-dom": "^7.9.1"
+        "react": "18.3.1",
+        "react-dom": "18.3.1",
+        "react-router-dom": "7.9.1"
       },
       "devDependencies": {
-        "@vitejs/plugin-react": "^4.7.0",
-        "autoprefixer": "^10.4.21",
-        "cssnano": "^6.1.2",
-        "postcss": "^8.5.6",
-        "tailwindcss": "^3.4.10",
-        "terser": "^5.44.0",
-        "vite": "^4.0.0"
+        "@testing-library/jest-dom": "6.6.3",
+        "@testing-library/react": "16.1.0",
+        "@testing-library/user-event": "14.5.2",
+        "@vitejs/plugin-react": "4.3.4",
+        "autoprefixer": "10.4.21",
+        "cssnano": "6.1.2",
+        "eslint": "8.57.0",
+        "eslint-config-prettier": "9.1.0",
+        "eslint-plugin-jsx-a11y": "6.8.0",
+        "eslint-plugin-react": "7.37.1",
+        "eslint-plugin-react-hooks": "4.6.2",
+        "jsdom": "25.0.1",
+        "postcss": "8.5.6",
+        "prettier": "3.3.3",
+        "tailwindcss": "3.4.10",
+        "terser": "5.44.0",
+        "vite": "5.4.20",
+        "vitest": "2.1.9"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -34,6 +52,27 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -269,6 +308,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.27.2",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
@@ -317,10 +366,142 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.10.tgz",
+      "integrity": "sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
-      "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.10.tgz",
+      "integrity": "sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==",
       "cpu": [
         "arm"
       ],
@@ -331,13 +512,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
-      "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.10.tgz",
+      "integrity": "sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==",
       "cpu": [
         "arm64"
       ],
@@ -348,13 +529,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
-      "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.10.tgz",
+      "integrity": "sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==",
       "cpu": [
         "x64"
       ],
@@ -365,13 +546,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
-      "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.10.tgz",
+      "integrity": "sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==",
       "cpu": [
         "arm64"
       ],
@@ -382,13 +563,13 @@
         "darwin"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
-      "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.10.tgz",
+      "integrity": "sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==",
       "cpu": [
         "x64"
       ],
@@ -399,13 +580,13 @@
         "darwin"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
-      "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==",
       "cpu": [
         "arm64"
       ],
@@ -416,13 +597,13 @@
         "freebsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
-      "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.10.tgz",
+      "integrity": "sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==",
       "cpu": [
         "x64"
       ],
@@ -433,13 +614,13 @@
         "freebsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
-      "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.10.tgz",
+      "integrity": "sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==",
       "cpu": [
         "arm"
       ],
@@ -450,13 +631,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
-      "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.10.tgz",
+      "integrity": "sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==",
       "cpu": [
         "arm64"
       ],
@@ -467,13 +648,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
-      "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.10.tgz",
+      "integrity": "sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==",
       "cpu": [
         "ia32"
       ],
@@ -484,13 +665,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
-      "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.10.tgz",
+      "integrity": "sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==",
       "cpu": [
         "loong64"
       ],
@@ -501,13 +682,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
-      "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.10.tgz",
+      "integrity": "sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==",
       "cpu": [
         "mips64el"
       ],
@@ -518,13 +699,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
-      "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.10.tgz",
+      "integrity": "sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==",
       "cpu": [
         "ppc64"
       ],
@@ -535,13 +716,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
-      "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.10.tgz",
+      "integrity": "sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==",
       "cpu": [
         "riscv64"
       ],
@@ -552,13 +733,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
-      "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.10.tgz",
+      "integrity": "sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==",
       "cpu": [
         "s390x"
       ],
@@ -569,13 +750,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
-      "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.10.tgz",
+      "integrity": "sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==",
       "cpu": [
         "x64"
       ],
@@ -586,13 +767,30 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
-      "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==",
       "cpu": [
         "x64"
       ],
@@ -603,13 +801,30 @@
         "netbsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
-      "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==",
       "cpu": [
         "x64"
       ],
@@ -620,13 +835,30 @@
         "openbsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.10.tgz",
+      "integrity": "sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
-      "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.10.tgz",
+      "integrity": "sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==",
       "cpu": [
         "x64"
       ],
@@ -637,13 +869,13 @@
         "sunos"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
-      "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.10.tgz",
+      "integrity": "sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==",
       "cpu": [
         "arm64"
       ],
@@ -654,13 +886,13 @@
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
-      "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.10.tgz",
+      "integrity": "sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==",
       "cpu": [
         "ia32"
       ],
@@ -671,13 +903,13 @@
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
-      "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.10.tgz",
+      "integrity": "sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==",
       "cpu": [
         "x64"
       ],
@@ -688,8 +920,157 @@
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
+      "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.6.0",
+        "globals": "^13.19.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
+      "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array": {
+      "version": "0.11.14",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
+      "integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
+      "deprecated": "Use @eslint/config-array instead",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^2.0.2",
+        "debug": "^4.3.1",
+        "minimatch": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/object-schema": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+      "deprecated": "Use @eslint/object-schema instead",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -819,12 +1200,404 @@
         "node": ">=14"
       }
     },
-    "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-beta.27",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
-      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.0.tgz",
+      "integrity": "sha512-VxDYCDqOaR7NXzAtvRx7G1u54d2kEHopb28YH/pKzY6y0qmogP3gG7CSiWsq9WvDFxOQMpNEyjVAHZFXfH3o/A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.0.tgz",
+      "integrity": "sha512-pqDirm8koABIKvzL59YI9W9DWbRlTX7RWhN+auR8HXJxo89m4mjqbah7nJZjeKNTNYopqL+yGg+0mhCpf3xZtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.0.tgz",
+      "integrity": "sha512-YCdWlY/8ltN6H78HnMsRHYlPiKvqKagBP1r+D7SSylxX+HnsgXGCmLiV3Y4nSyY9hW8qr8U9LDUx/Lo7M6MfmQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.0.tgz",
+      "integrity": "sha512-z4nw6y1j+OOSGzuVbSWdIp1IUks9qNw4dc7z7lWuWDKojY38VMWBlEN7F9jk5UXOkUcp97vA1N213DF+Lz8BRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.0.tgz",
+      "integrity": "sha512-Q/dv9Yvyr5rKlK8WQJZVrp5g2SOYeZUs9u/t2f9cQ2E0gJjYB/BWoedXfUT0EcDJefi2zzVfhcOj8drWCzTviw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.0.tgz",
+      "integrity": "sha512-kdBsLs4Uile/fbjZVvCRcKB4q64R+1mUq0Yd7oU1CMm1Av336ajIFqNFovByipciuUQjBCPMxwJhCgfG2re3rg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.0.tgz",
+      "integrity": "sha512-aL6hRwu0k7MTUESgkg7QHY6CoqPgr6gdQXRJI1/VbFlUMwsSzPGSR7sG5d+MCbYnJmJwThc2ol3nixj1fvI/zQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.0.tgz",
+      "integrity": "sha512-BTs0M5s1EJejgIBJhCeiFo7GZZ2IXWkFGcyZhxX4+8usnIo5Mti57108vjXFIQmmJaRyDwmV59Tw64Ap1dkwMw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.0.tgz",
+      "integrity": "sha512-uj672IVOU9m08DBGvoPKPi/J8jlVgjh12C9GmjjBxCTQc3XtVmRkRKyeHSmIKQpvJ7fIm1EJieBUcnGSzDVFyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.0.tgz",
+      "integrity": "sha512-/+IVbeDMDCtB/HP/wiWsSzduD10SEGzIZX2945KSgZRNi4TSkjHqRJtNTVtVb8IRwhJ65ssI56krlLik+zFWkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.0.tgz",
+      "integrity": "sha512-U1vVzvSWtSMWKKrGoROPBXMh3Vwn93TA9V35PldokHGqiUbF6erSzox/5qrSMKp6SzakvyjcPiVF8yB1xKr9Pg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.0.tgz",
+      "integrity": "sha512-X/4WfuBAdQRH8cK3DYl8zC00XEE6aM472W+QCycpQJeLWVnHfkv7RyBFVaTqNUMsTgIX8ihMjCvFF9OUgeABzw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.0.tgz",
+      "integrity": "sha512-xIRYc58HfWDBZoLmWfWXg2Sq8VCa2iJ32B7mqfWnkx5mekekl0tMe7FHpY8I72RXEcUkaWawRvl3qA55og+cwQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.0.tgz",
+      "integrity": "sha512-mbsoUey05WJIOz8U1WzNdf+6UMYGwE3fZZnQqsM22FZ3wh1N887HT6jAOjXs6CNEK3Ntu2OBsyQDXfIjouI4dw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.0.tgz",
+      "integrity": "sha512-qP6aP970bucEi5KKKR4AuPFd8aTx9EF6BvutvYxmZuWLJHmnq4LvBfp0U+yFDMGwJ+AIJEH5sIP+SNypauMWzg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.0.tgz",
+      "integrity": "sha512-nmSVN+F2i1yKZ7rJNKO3G7ZzmxJgoQBQZ/6c4MuS553Grmr7WqR7LLDcYG53Z2m9409z3JLt4sCOhLdbKQ3HmA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.0.tgz",
+      "integrity": "sha512-2d0qRo33G6TfQVjaMR71P+yJVGODrt5V6+T0BDYH4EMfGgdC/2HWDVjSSFw888GSzAZUwuska3+zxNUCDco6rQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.0.tgz",
+      "integrity": "sha512-A1JalX4MOaFAAyGgpO7XP5khquv/7xKzLIyLmhNrbiCxWpMlnsTYr8dnsWM7sEeotNmxvSOEL7F65j0HXFcFsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.0.tgz",
+      "integrity": "sha512-YQugafP/rH0eOOHGjmNgDURrpYHrIX0yuojOI8bwCyXwxC9ZdTd3vYkmddPX0oHONLXu9Rb1dDmT0VNpjkzGGw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.0.tgz",
+      "integrity": "sha512-zYdUYhi3Qe2fndujBqL5FjAFzvNeLxtIqfzNEVKD1I7C37/chv1VxhscWSQHTNfjPCrBFQMnynwA3kpZpZ8w4A==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.0.tgz",
+      "integrity": "sha512-fGk03kQylNaCOQ96HDMeT7E2n91EqvCDd3RwvT5k+xNdFCeMGnj5b5hEgTGrQuyidqSsD3zJDQ21QIaxXqTBJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.0.tgz",
+      "integrity": "sha512-6iKDCVSIUQ8jPMoIV0OytRKniaYyy5EbY/RRydmLW8ZR3cEBhxbWl5ro0rkUNe0ef6sScvhbY79HrjRm8i3vDQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.6.3.tgz",
+      "integrity": "sha512-IteBhl4XqYNkM54f4ejhLRJiZNqcSCoXUOG2CPK7qbD322KjQozM4kHQOfkG2oln9b9HTYqs+Sae8vBATubxxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "chalk": "^3.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "lodash": "^4.17.21",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.1.0.tgz",
+      "integrity": "sha512-Q2ToPvg0KsVL0ohND9A3zLJWcOXXcO8IDu3fj11KhNt0UlCWyFyvnCIBkd12tidB2lkiVRG8VFqdhcqhqnAQtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.5.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.5.2.tgz",
+      "integrity": "sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
     },
     "node_modules/@trysound/sax": {
       "version": "0.2.0",
@@ -835,6 +1608,14 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -881,25 +1662,151 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/@vitejs/plugin-react": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
-      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.3.4.tgz",
+      "integrity": "sha512-SCCPBJtYLdE8PX/7ZQAs1QAZ8Jqwih+0VBLum1EGqmCCQal+MIUqLCzj3ZUy8ufbC0cAM4LRlSTm7IQJwWT4ug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/core": "^7.28.0",
-        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
-        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
-        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@babel/core": "^7.26.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.25.9",
+        "@babel/plugin-transform-react-jsx-source": "^7.25.9",
         "@types/babel__core": "^7.20.5",
-        "react-refresh": "^0.17.0"
+        "react-refresh": "^0.14.2"
       },
       "engines": {
         "node": "^14.18.0 || >=16.0.0"
       },
       "peerDependencies": {
-        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/acorn": {
@@ -913,6 +1820,43 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/ansi-regex": {
@@ -969,6 +1913,195 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-includes": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
+      "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.0",
+        "es-object-atoms": "^1.1.1",
+        "get-intrinsic": "^1.3.0",
+        "is-string": "^1.1.1",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.findlast": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
+      "integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flat": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
+      "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flatmap": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
+      "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.tosorted": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
+      "integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3",
+        "es-errors": "^1.3.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-types-flow": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
+      "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.21",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
@@ -1005,6 +2138,42 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.7.0.tgz",
+      "integrity": "sha512-M0JtH+hlOL5pLQwHOLNYZaXuhqmvS8oExsqB1SBYgA4Dk7u/xx+YdGHXaK5pyUfed5mYXdlYiphWq3G8cRi5JQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.2.4.tgz",
+      "integrity": "sha512-aPTElBrbifBU1krmZxGZOlBkslORe7Ll7+BDnI50Wy4LgOt69luMgevkDfTq1O/ZgprooPCtWpjCwKSZw/iZ4A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/balanced-match": {
@@ -1108,6 +2277,76 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/camelcase-css": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
@@ -1151,6 +2390,63 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chalk/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
     },
     "node_modules/chokidar": {
       "version": "3.6.0",
@@ -1217,6 +2513,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -1226,6 +2535,13 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -1314,6 +2630,13 @@
       "funding": {
         "url": "https://github.com/sponsors/fb55"
       }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
@@ -1456,6 +2779,102 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/damerau-levenshtein": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
+      "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-view-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/inspect-js"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1474,6 +2893,86 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
@@ -1487,6 +2986,27 @@
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -1547,6 +3067,21 @@
         "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -1581,10 +3116,194 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/es-abstract": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.0.tgz",
+      "integrity": "sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "get-symbol-description": "^1.1.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
+        "is-callable": "^1.2.7",
+        "is-data-view": "^1.0.2",
+        "is-negative-zero": "^2.0.3",
+        "is-regex": "^1.2.1",
+        "is-set": "^2.0.3",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.1",
+        "math-intrinsics": "^1.1.0",
+        "object-inspect": "^1.13.4",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
+        "regexp.prototype.flags": "^1.5.4",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "stop-iteration-iterator": "^1.1.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.19"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-iterator-helpers": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.2.1.tgz",
+      "integrity": "sha512-uDn+FE1yrDzyC0pCo961B2IHbdM8y/ACZsKD4dG6WqrjV53BADjwa7D+1aom2rsNVfLyDgU/eigvlJGJ08OQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.6",
+        "es-errors": "^1.3.0",
+        "es-set-tostringtag": "^2.0.3",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.6",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "iterator.prototype": "^1.1.4",
+        "safe-array-concat": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-shim-unscopables": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
+      "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
+      "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7",
+        "is-date-object": "^1.0.5",
+        "is-symbol": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/esbuild": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
-      "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.10.tgz",
+      "integrity": "sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -1592,31 +3311,35 @@
         "esbuild": "bin/esbuild"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/android-arm": "0.18.20",
-        "@esbuild/android-arm64": "0.18.20",
-        "@esbuild/android-x64": "0.18.20",
-        "@esbuild/darwin-arm64": "0.18.20",
-        "@esbuild/darwin-x64": "0.18.20",
-        "@esbuild/freebsd-arm64": "0.18.20",
-        "@esbuild/freebsd-x64": "0.18.20",
-        "@esbuild/linux-arm": "0.18.20",
-        "@esbuild/linux-arm64": "0.18.20",
-        "@esbuild/linux-ia32": "0.18.20",
-        "@esbuild/linux-loong64": "0.18.20",
-        "@esbuild/linux-mips64el": "0.18.20",
-        "@esbuild/linux-ppc64": "0.18.20",
-        "@esbuild/linux-riscv64": "0.18.20",
-        "@esbuild/linux-s390x": "0.18.20",
-        "@esbuild/linux-x64": "0.18.20",
-        "@esbuild/netbsd-x64": "0.18.20",
-        "@esbuild/openbsd-x64": "0.18.20",
-        "@esbuild/sunos-x64": "0.18.20",
-        "@esbuild/win32-arm64": "0.18.20",
-        "@esbuild/win32-ia32": "0.18.20",
-        "@esbuild/win32-x64": "0.18.20"
+        "@esbuild/aix-ppc64": "0.25.10",
+        "@esbuild/android-arm": "0.25.10",
+        "@esbuild/android-arm64": "0.25.10",
+        "@esbuild/android-x64": "0.25.10",
+        "@esbuild/darwin-arm64": "0.25.10",
+        "@esbuild/darwin-x64": "0.25.10",
+        "@esbuild/freebsd-arm64": "0.25.10",
+        "@esbuild/freebsd-x64": "0.25.10",
+        "@esbuild/linux-arm": "0.25.10",
+        "@esbuild/linux-arm64": "0.25.10",
+        "@esbuild/linux-ia32": "0.25.10",
+        "@esbuild/linux-loong64": "0.25.10",
+        "@esbuild/linux-mips64el": "0.25.10",
+        "@esbuild/linux-ppc64": "0.25.10",
+        "@esbuild/linux-riscv64": "0.25.10",
+        "@esbuild/linux-s390x": "0.25.10",
+        "@esbuild/linux-x64": "0.25.10",
+        "@esbuild/netbsd-arm64": "0.25.10",
+        "@esbuild/netbsd-x64": "0.25.10",
+        "@esbuild/openbsd-arm64": "0.25.10",
+        "@esbuild/openbsd-x64": "0.25.10",
+        "@esbuild/openharmony-arm64": "0.25.10",
+        "@esbuild/sunos-x64": "0.25.10",
+        "@esbuild/win32-arm64": "0.25.10",
+        "@esbuild/win32-ia32": "0.25.10",
+        "@esbuild/win32-x64": "0.25.10"
       }
     },
     "node_modules/escalade": {
@@ -1628,6 +3351,446 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
+      "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.57.0",
+        "@humanwhocodes/config-array": "^0.11.14",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
+        "@ungap/structured-clone": "^1.2.0",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
+        "esquery": "^1.4.2",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "globals": "^13.19.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3",
+        "strip-ansi": "^6.0.1",
+        "text-table": "^0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
+      "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.8.0.tgz",
+      "integrity": "sha512-Hdh937BS3KdwwbBaKd5+PLCOmYY6U4f2h9Z2ktwtNKvIdIEu137rjYbcb9ApSbVJfWxANNuiKTD/9tOKjK9qOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2",
+        "aria-query": "^5.3.0",
+        "array-includes": "^3.1.7",
+        "array.prototype.flatmap": "^1.3.2",
+        "ast-types-flow": "^0.0.8",
+        "axe-core": "=4.7.0",
+        "axobject-query": "^3.2.1",
+        "damerau-levenshtein": "^1.0.8",
+        "emoji-regex": "^9.2.2",
+        "es-iterator-helpers": "^1.0.15",
+        "hasown": "^2.0.0",
+        "jsx-ast-utils": "^3.3.5",
+        "language-tags": "^1.0.9",
+        "minimatch": "^3.1.2",
+        "object.entries": "^1.1.7",
+        "object.fromentries": "^2.0.7"
+      },
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/eslint-plugin-react": {
+      "version": "7.37.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.1.tgz",
+      "integrity": "sha512-xwTnwDqzbDRA8uJ7BMxPs/EXRB3i8ZfnOIp8BsxEQkT0nHPp+WWceqGgo6rKb9ctNi8GJLDT4Go5HAWELa/WMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.8",
+        "array.prototype.findlast": "^1.2.5",
+        "array.prototype.flatmap": "^1.3.2",
+        "array.prototype.tosorted": "^1.1.4",
+        "doctrine": "^2.1.0",
+        "es-iterator-helpers": "^1.0.19",
+        "estraverse": "^5.3.0",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+        "minimatch": "^3.1.2",
+        "object.entries": "^1.1.8",
+        "object.fromentries": "^2.0.8",
+        "object.values": "^1.2.0",
+        "prop-types": "^15.8.1",
+        "resolve": "^2.0.0-next.5",
+        "semver": "^6.3.1",
+        "string.prototype.matchall": "^4.0.11",
+        "string.prototype.repeat": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz",
+      "integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/resolve": {
+      "version": "2.0.0-next.5",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
+      "integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.13.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eslint/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/eslint/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/espree": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.9.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
+      "integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -1659,6 +3822,20 @@
         "node": ">= 6"
       }
     },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -1667,6 +3844,19 @@
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^3.0.4"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
       }
     },
     "node_modules/fill-range": {
@@ -1680,6 +3870,61 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.3",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/foreground-child": {
@@ -1699,6 +3944,23 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fraction.js": {
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
@@ -1712,6 +3974,13 @@
         "type": "patreon",
         "url": "https://github.com/sponsors/rawify"
       }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -1738,6 +4007,37 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/function.prototype.name": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "functions-have-names": "^1.2.3",
+        "hasown": "^2.0.2",
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -1746,6 +4046,63 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/glob": {
@@ -1782,6 +4139,140 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -1795,6 +4286,195 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-async-function": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-function": "^1.0.0",
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -1806,6 +4486,36 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-core-module": {
@@ -1824,6 +4534,41 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-data-view": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -1834,6 +4579,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-finalizationregistry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -1842,6 +4603,25 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
+      "integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.0",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-glob": {
@@ -1857,6 +4637,32 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -1867,12 +4673,216 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/iterator.prototype": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
+      "integrity": "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "get-proto": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
@@ -1906,6 +4916,60 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
     },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.1.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -1919,6 +4983,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -1930,6 +5015,66 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsx-ast-utils": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
+      "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.6",
+        "array.prototype.flat": "^1.3.1",
+        "object.assign": "^4.1.4",
+        "object.values": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/language-subtag-registry": {
+      "version": "0.3.23",
+      "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
+      "integrity": "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/language-tags": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.9.tgz",
+      "integrity": "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "language-subtag-registry": "^0.3.20"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/lilconfig": {
@@ -1949,10 +5094,40 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1975,6 +5150,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -1983,6 +5165,37 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.19",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
+      "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/mdn-data": {
@@ -2014,6 +5227,39 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -2080,6 +5326,13 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/node-releases": {
       "version": "2.0.21",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.21.tgz",
@@ -2120,6 +5373,13 @@
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.22",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.22.tgz",
+      "integrity": "sha512-ujSMe1OWVn55euT1ihwCI1ZcAaAU3nxUiDwfDQldc51ZXaB9m2AyOn6/jh1BLe2t/G8xd6uKG1UBF2aZJeg2SQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -2140,12 +5400,247 @@
         "node": ">= 6"
       }
     },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.entries": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.9.tgz",
+      "integrity": "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.fromentries": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
+      "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.values": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
+      "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/own-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.6",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/path-key": {
       "version": "3.1.1",
@@ -2188,6 +5683,23 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -2226,6 +5738,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/postcss": {
@@ -2831,6 +6353,102 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -2877,10 +6495,18 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/react-refresh": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
-      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
+      "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2948,6 +6574,64 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/reflect.getprototypeof": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
@@ -2969,6 +6653,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -2980,22 +6674,117 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/rollup": {
-      "version": "3.29.5",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.5.tgz",
-      "integrity": "sha512-GVsDdsbJzzy4S/v3dqWPJ7EfvZJfCHiDqe80IyrF59LYuP+e6U1LJoUqeuqRbwAWoMNoXivMNeNAOf5E22VA1w==",
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.0.tgz",
+      "integrity": "sha512-+IuescNkTJQgX7AkIDtITipZdIGcWF0pnVvZTWStiazUmcGA2ag8dfg0urest2XlXUi9kuhfQ+qmdc5Stc3z7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
       "bin": {
         "rollup": "dist/bin/rollup"
       },
       "engines": {
-        "node": ">=14.18.0",
+        "node": ">=18.0.0",
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.52.0",
+        "@rollup/rollup-android-arm64": "4.52.0",
+        "@rollup/rollup-darwin-arm64": "4.52.0",
+        "@rollup/rollup-darwin-x64": "4.52.0",
+        "@rollup/rollup-freebsd-arm64": "4.52.0",
+        "@rollup/rollup-freebsd-x64": "4.52.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.52.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.52.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.52.0",
+        "@rollup/rollup-linux-arm64-musl": "4.52.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.52.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.52.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.52.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.52.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.52.0",
+        "@rollup/rollup-linux-x64-gnu": "4.52.0",
+        "@rollup/rollup-linux-x64-musl": "4.52.0",
+        "@rollup/rollup-openharmony-arm64": "4.52.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.52.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.52.0",
+        "@rollup/rollup-win32-x64-gnu": "4.52.0",
+        "@rollup/rollup-win32-x64-msvc": "4.52.0",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -3019,6 +6808,81 @@
       "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safe-array-concat": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
+      "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "has-symbols": "^1.1.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -3046,6 +6910,55 @@
       "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
       "license": "MIT"
     },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -3068,6 +6981,89 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/signal-exit": {
       "version": "4.1.0",
@@ -3111,6 +7107,34 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+      "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/string-width": {
@@ -3177,6 +7201,104 @@
         "node": ">=8"
       }
     },
+    "node_modules/string.prototype.matchall": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
+      "integrity": "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.6",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "regexp.prototype.flags": "^1.5.3",
+        "set-function-name": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.repeat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
+      "integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
+      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-object-atoms": "^1.0.0",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
+      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
@@ -3217,6 +7339,32 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/stylehacks": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-6.1.1.tgz",
@@ -3255,6 +7403,19 @@
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {
@@ -3305,6 +7466,13 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "3.4.10",
@@ -3370,6 +7538,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -3393,6 +7568,70 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -3406,12 +7645,161 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-byte-offset": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-length": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
+      "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "is-typed-array": "^1.1.13",
+        "possible-typed-array-names": "^1.0.0",
+        "reflect.getprototypeof": "^1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",
@@ -3444,6 +7832,16 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -3452,33 +7850,34 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "4.5.14",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.14.tgz",
-      "integrity": "sha512-+v57oAaoYNnO3hIu5Z/tJRZjq5aHM2zDve9YZ8HngVHbhk66RStobhb1sqPMIPEleV6cNKYK4eGrAbE9Ulbl2g==",
+      "version": "5.4.20",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.20.tgz",
+      "integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.18.10",
-        "postcss": "^8.4.27",
-        "rollup": "^3.27.1"
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
       },
       "bin": {
         "vite": "bin/vite.js"
       },
       "engines": {
-        "node": "^14.18.0 || >=16.0.0"
+        "node": "^18.0.0 || >=20.0.0"
       },
       "funding": {
         "url": "https://github.com/vitejs/vite?sponsor=1"
       },
       "optionalDependencies": {
-        "fsevents": "~2.3.2"
+        "fsevents": "~2.3.3"
       },
       "peerDependencies": {
-        "@types/node": ">= 14",
+        "@types/node": "^18.0.0 || >=20.0.0",
         "less": "*",
         "lightningcss": "^1.21.0",
         "sass": "*",
+        "sass-embedded": "*",
         "stylus": "*",
         "sugarss": "*",
         "terser": "^5.4.0"
@@ -3496,6 +7895,9 @@
         "sass": {
           "optional": true
         },
+        "sass-embedded": {
+          "optional": true
+        },
         "stylus": {
           "optional": true
         },
@@ -3505,6 +7907,155 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {
@@ -3521,6 +8072,122 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.1.0",
+        "is-finalizationregistry": "^1.1.0",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.2.1",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.1.0",
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
+      "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/wrap-ansi": {
@@ -3621,6 +8288,52 @@
         "node": ">=8"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -3639,6 +8352,19 @@
       },
       "engines": {
         "node": ">= 14.6"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,20 +5,40 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "eslint \"src/**/*.{js,jsx}\"",
+    "lint:fix": "npm run lint -- --fix",
+    "format": "prettier --write \"src/**/*.{js,jsx}\"",
+    "format:check": "prettier --check \"src/**/*.{js,jsx}\""
   },
   "dependencies": {
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
-    "react-router-dom": "^7.9.1"
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
+    "react-router-dom": "7.9.1"
   },
   "devDependencies": {
-    "@vitejs/plugin-react": "^4.7.0",
-    "autoprefixer": "^10.4.21",
-    "cssnano": "^6.1.2",
-    "postcss": "^8.5.6",
-    "tailwindcss": "^3.4.10",
-    "terser": "^5.44.0",
-    "vite": "^4.0.0"
+    "@testing-library/jest-dom": "6.6.3",
+    "@testing-library/react": "16.1.0",
+    "@testing-library/user-event": "14.5.2",
+    "@vitejs/plugin-react": "4.3.4",
+    "autoprefixer": "10.4.21",
+    "cssnano": "6.1.2",
+    "eslint": "8.57.0",
+    "eslint-config-prettier": "9.1.0",
+    "eslint-plugin-jsx-a11y": "6.8.0",
+    "eslint-plugin-react": "7.37.1",
+    "eslint-plugin-react-hooks": "4.6.2",
+    "jsdom": "25.0.1",
+    "postcss": "8.5.6",
+    "prettier": "3.3.3",
+    "tailwindcss": "3.4.10",
+    "terser": "5.44.0",
+    "vite": "5.4.20",
+    "vitest": "2.1.9"
+  },
+  "overrides": {
+    "esbuild": "0.25.10"
   }
 }

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -5,9 +5,5 @@ const cssnano = require('cssnano');
 const isProduction = process.env.NODE_ENV === 'production';
 
 module.exports = {
-  plugins: [
-    tailwindcss,
-    autoprefixer,
-    ...(isProduction ? [cssnano({ preset: 'default' })] : []),
-  ],
+  plugins: [tailwindcss, autoprefixer, ...(isProduction ? [cssnano({ preset: 'default' })] : [])],
 };

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { render, screen } from '@testing-library/react';
+import App from './App';
+
+vi.mock('./features/layout/AppLayout', () => ({
+  default: ({ children }) => <div data-testid="app-layout">{children}</div>,
+}));
+
+vi.mock('./features/auth/ProtectedRoute', () => ({
+  default: ({ children }) => <div data-testid="protected-route">{children}</div>,
+}));
+
+vi.mock('./features/auth/PublicOnlyRoute', () => ({
+  default: ({ children }) => <div data-testid="public-only-route">{children}</div>,
+}));
+
+vi.mock('./features/dashboard/DashboardRouter', () => ({
+  default: () => <div>Dashboard router</div>,
+}));
+
+vi.mock('./features/auth/LoginPage', () => ({
+  default: () => <div>Login page</div>,
+}));
+
+vi.mock('./features/auth/SignupPage', () => ({
+  default: () => <div>Signup page</div>,
+}));
+
+vi.mock('./features/auth/CheckEmailPage', () => ({
+  default: () => <div>Check email page</div>,
+}));
+
+vi.mock('./features/auth/VerifyEmailPage', () => ({
+  default: () => <div>Verify email page</div>,
+}));
+
+vi.mock('./features/event-gallery/PublicGalleryPage', () => ({
+  default: () => <div>Public gallery page</div>,
+}));
+
+vi.mock('./features/landing/HomePage', () => ({
+  default: () => <div>Home page content</div>,
+}));
+
+vi.mock('./features/auth/AuthContext', () => ({
+  useAuth: () => ({ isAuthenticated: false }),
+}));
+
+describe('App routing', () => {
+  it('renders the gallery route inside the shared layout', async () => {
+    render(
+      <MemoryRouter initialEntries={['/gallery']}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('Public gallery page')).toBeInTheDocument();
+    expect(screen.getByTestId('app-layout')).toBeInTheDocument();
+    expect(screen.queryByTestId('protected-route')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/admin/AdminOverviewCards.jsx
+++ b/frontend/src/features/admin/AdminOverviewCards.jsx
@@ -49,13 +49,16 @@ export default function AdminOverviewCards({ overview, loading = false, error = 
       >
         <ul className="m-0 list-none space-y-1.5 p-0 text-sm text-brand-muted">
           <li>
-            Active users: <strong className="text-brand-forest">{overview.users?.active ?? 0}</strong>
+            Active users:{' '}
+            <strong className="text-brand-forest">{overview.users?.active ?? 0}</strong>
           </li>
           <li>
-            Inactive users: <strong className="text-brand-forest">{overview.users?.inactive ?? 0}</strong>
+            Inactive users:{' '}
+            <strong className="text-brand-forest">{overview.users?.inactive ?? 0}</strong>
           </li>
           <li>
-            Total accounts: <strong className="text-brand-forest">{overview.users?.total ?? 0}</strong>
+            Total accounts:{' '}
+            <strong className="text-brand-forest">{overview.users?.total ?? 0}</strong>
           </li>
           {roleEntries.length ? (
             <li>
@@ -78,16 +81,20 @@ export default function AdminOverviewCards({ overview, loading = false, error = 
       >
         <ul className="m-0 list-none space-y-1.5 p-0 text-sm text-brand-muted">
           <li>
-            Pending approval: <strong className="text-brand-forest">{overview.events?.pendingApproval ?? 0}</strong>
+            Pending approval:{' '}
+            <strong className="text-brand-forest">{overview.events?.pendingApproval ?? 0}</strong>
           </li>
           <li>
-            Published: <strong className="text-brand-forest">{overview.events?.published ?? 0}</strong>
+            Published:{' '}
+            <strong className="text-brand-forest">{overview.events?.published ?? 0}</strong>
           </li>
           <li>
-            Upcoming: <strong className="text-brand-forest">{overview.events?.upcoming ?? 0}</strong>
+            Upcoming:{' '}
+            <strong className="text-brand-forest">{overview.events?.upcoming ?? 0}</strong>
           </li>
           <li>
-            Completed: <strong className="text-brand-forest">{overview.events?.completed ?? 0}</strong>
+            Completed:{' '}
+            <strong className="text-brand-forest">{overview.events?.completed ?? 0}</strong>
           </li>
         </ul>
       </DashboardCard>
@@ -98,16 +105,22 @@ export default function AdminOverviewCards({ overview, loading = false, error = 
       >
         <ul className="m-0 list-none space-y-1.5 p-0 text-sm text-brand-muted">
           <li>
-            Approved sponsors: <strong className="text-brand-forest">{overview.sponsors?.approved ?? 0}</strong>
+            Approved sponsors:{' '}
+            <strong className="text-brand-forest">{overview.sponsors?.approved ?? 0}</strong>
           </li>
           <li>
-            Pending reviews: <strong className="text-brand-forest">{overview.sponsors?.pending ?? 0}</strong>
+            Pending reviews:{' '}
+            <strong className="text-brand-forest">{overview.sponsors?.pending ?? 0}</strong>
           </li>
           <li>
-            Declined applications: <strong className="text-brand-forest">{overview.sponsors?.declined ?? 0}</strong>
+            Declined applications:{' '}
+            <strong className="text-brand-forest">{overview.sponsors?.declined ?? 0}</strong>
           </li>
           <li>
-            Approved funds: <strong className="text-brand-forest">₹{Number(overview.sponsors?.approvedFunds || 0).toLocaleString()}</strong>
+            Approved funds:{' '}
+            <strong className="text-brand-forest">
+              ₹{Number(overview.sponsors?.approvedFunds || 0).toLocaleString()}
+            </strong>
           </li>
         </ul>
       </DashboardCard>
@@ -118,17 +131,24 @@ export default function AdminOverviewCards({ overview, loading = false, error = 
       >
         <ul className="m-0 list-none space-y-1.5 p-0 text-sm text-brand-muted">
           <li>
-            Volunteer hours logged: <strong className="text-brand-forest">{formatMinutes(overview.volunteers?.totalMinutes)}</strong>
+            Volunteer hours logged:{' '}
+            <strong className="text-brand-forest">
+              {formatMinutes(overview.volunteers?.totalMinutes)}
+            </strong>
           </li>
           <li>
             Active volunteers (30 days):{' '}
-            <strong className="text-brand-forest">{overview.volunteers?.activeLast30Days ?? 0}</strong>
+            <strong className="text-brand-forest">
+              {overview.volunteers?.activeLast30Days ?? 0}
+            </strong>
           </li>
           <li>
-            Gallery items pending: <strong className="text-brand-forest">{overview.gallery?.pending ?? 0}</strong>
+            Gallery items pending:{' '}
+            <strong className="text-brand-forest">{overview.gallery?.pending ?? 0}</strong>
           </li>
           <li>
-            Approvals last week: <strong className="text-brand-forest">{overview.audits?.actionsLast7Days ?? 0}</strong>
+            Approvals last week:{' '}
+            <strong className="text-brand-forest">{overview.audits?.actionsLast7Days ?? 0}</strong>
           </li>
         </ul>
       </DashboardCard>

--- a/frontend/src/features/admin/ImpactAnalyticsPanel.jsx
+++ b/frontend/src/features/admin/ImpactAnalyticsPanel.jsx
@@ -4,7 +4,14 @@ function formatNumber(value, { maximumFractionDigits = 1 } = {}) {
   return Number(value || 0).toLocaleString('en-US', { maximumFractionDigits });
 }
 
-export default function ImpactAnalyticsPanel({ metrics, state, onRefresh, onExport, exporting, exportError }) {
+export default function ImpactAnalyticsPanel({
+  metrics,
+  state,
+  onRefresh,
+  onExport,
+  exporting,
+  exportError,
+}) {
   const loading = state?.status === 'loading';
   const error = state?.error || '';
   const actions = [
@@ -30,58 +37,85 @@ export default function ImpactAnalyticsPanel({ metrics, state, onRefresh, onExpo
       {loading && !metrics ? (
         <p className="m-0 text-sm text-brand-muted">Loading analytics…</p>
       ) : null}
-      {error ? (
-        <p className="m-0 text-sm font-medium text-red-600">{error}</p>
-      ) : null}
+      {error ? <p className="m-0 text-sm font-medium text-red-600">{error}</p> : null}
       {metrics ? (
         <div className="grid gap-4 md:grid-cols-2">
           <section className="flex flex-col gap-2">
-            <h4 className="m-0 text-sm font-semibold uppercase tracking-[0.2em] text-brand-muted">Stories & volunteers</h4>
+            <h4 className="m-0 text-sm font-semibold uppercase tracking-[0.2em] text-brand-muted">
+              Stories & volunteers
+            </h4>
             <ul className="m-0 list-none space-y-1.5 p-0 text-sm text-brand-muted">
               <li>
-                <span className="font-semibold text-brand-forest">{formatNumber(metrics.stories?.approved ?? 0, { maximumFractionDigits: 0 })}</span>{' '}
-                stories approved ({formatNumber(metrics.stories?.pending ?? 0, { maximumFractionDigits: 0 })} pending).
+                <span className="font-semibold text-brand-forest">
+                  {formatNumber(metrics.stories?.approved ?? 0, { maximumFractionDigits: 0 })}
+                </span>{' '}
+                stories approved (
+                {formatNumber(metrics.stories?.pending ?? 0, { maximumFractionDigits: 0 })}{' '}
+                pending).
               </li>
               <li>
-                <span className="font-semibold text-brand-forest">{formatNumber(metrics.volunteerEngagement?.totalHours ?? 0)}</span>{' '}
-                volunteer hours logged, {formatNumber(metrics.volunteerEngagement?.activeLast90Days ?? 0, { maximumFractionDigits: 0 })} active in 90 days.
+                <span className="font-semibold text-brand-forest">
+                  {formatNumber(metrics.volunteerEngagement?.totalHours ?? 0)}
+                </span>{' '}
+                volunteer hours logged,{' '}
+                {formatNumber(metrics.volunteerEngagement?.activeLast90Days ?? 0, {
+                  maximumFractionDigits: 0,
+                })}{' '}
+                active in 90 days.
               </li>
               <li>
-                Retention trend: <span className="font-semibold text-brand-forest">{((metrics.volunteerEngagement?.retentionDelta ?? 0) * 100).toFixed(1)}%</span>
+                Retention trend:{' '}
+                <span className="font-semibold text-brand-forest">
+                  {((metrics.volunteerEngagement?.retentionDelta ?? 0) * 100).toFixed(1)}%
+                </span>
               </li>
             </ul>
           </section>
           <section className="flex flex-col gap-2">
-            <h4 className="m-0 text-sm font-semibold uppercase tracking-[0.2em] text-brand-muted">Galleries & sponsors</h4>
+            <h4 className="m-0 text-sm font-semibold uppercase tracking-[0.2em] text-brand-muted">
+              Galleries & sponsors
+            </h4>
             <ul className="m-0 list-none space-y-1.5 p-0 text-sm text-brand-muted">
               <li>
                 Galleries collected{' '}
-                <span className="font-semibold text-brand-forest">{formatNumber(metrics.galleryEngagement?.totalViews ?? 0, {
+                <span className="font-semibold text-brand-forest">
+                  {formatNumber(metrics.galleryEngagement?.totalViews ?? 0, {
+                    maximumFractionDigits: 0,
+                  })}
+                </span>{' '}
+                views across{' '}
+                {formatNumber(metrics.galleryEngagement?.trackedEvents ?? 0, {
                   maximumFractionDigits: 0,
-                })}</span>{' '}
-                views across {formatNumber(metrics.galleryEngagement?.trackedEvents ?? 0, { maximumFractionDigits: 0 })} events.
+                })}{' '}
+                events.
               </li>
               <li>
                 Sponsors featured{' '}
-                <span className="font-semibold text-brand-forest">{formatNumber(metrics.sponsorImpact?.sponsorMentions ?? 0, {
+                <span className="font-semibold text-brand-forest">
+                  {formatNumber(metrics.sponsorImpact?.sponsorMentions ?? 0, {
+                    maximumFractionDigits: 0,
+                  })}
+                </span>{' '}
+                times with{' '}
+                {formatNumber(metrics.sponsorImpact?.approvedSponsorships ?? 0, {
                   maximumFractionDigits: 0,
-                })}</span>{' '}
-                times with {formatNumber(metrics.sponsorImpact?.approvedSponsorships ?? 0, { maximumFractionDigits: 0 })} active pledges.
+                })}{' '}
+                active pledges.
               </li>
               <li>
                 Analytics dashboard opened{' '}
-                <span className="font-semibold text-brand-forest">{formatNumber(metrics.analyticsUsage?.viewsLast30Days ?? 0, {
-                  maximumFractionDigits: 0,
-                })}</span>{' '}
+                <span className="font-semibold text-brand-forest">
+                  {formatNumber(metrics.analyticsUsage?.viewsLast30Days ?? 0, {
+                    maximumFractionDigits: 0,
+                  })}
+                </span>{' '}
                 times in the last 30 days.
               </li>
             </ul>
           </section>
         </div>
       ) : null}
-      {exportError ? (
-        <p className="mt-3 text-sm font-medium text-red-600">{exportError}</p>
-      ) : null}
+      {exportError ? <p className="mt-3 text-sm font-medium text-red-600">{exportError}</p> : null}
     </DashboardCard>
   );
 }

--- a/frontend/src/features/admin/ModerationQueues.jsx
+++ b/frontend/src/features/admin/ModerationQueues.jsx
@@ -65,7 +65,10 @@ export default function ModerationQueues({
         {items.map((item) => {
           const noteValue = notes[item.id] || '';
           return (
-            <li key={item.id} className="rounded-xl border border-brand-green/30 bg-white/90 p-4 shadow-sm">
+            <li
+              key={item.id}
+              className="rounded-xl border border-brand-green/30 bg-white/90 p-4 shadow-sm"
+            >
               <header className="flex flex-col gap-1 border-b border-brand-green/20 pb-3">
                 <h3 className="m-0 font-display text-lg font-semibold text-brand-forest">
                   {activeType === 'events' && item.title}
@@ -82,8 +85,13 @@ export default function ModerationQueues({
               <div className="mt-3 space-y-2 text-sm text-brand-muted">
                 {activeType === 'events' ? (
                   <>
-                    <p className="m-0">Submitted by: {item.createdByName || 'Unknown'} · {item.createdByEmail || 'N/A'}</p>
-                    <p className="m-0">Schedule: {formatDate(item.dateStart)} → {formatDate(item.dateEnd)}</p>
+                    <p className="m-0">
+                      Submitted by: {item.createdByName || 'Unknown'} ·{' '}
+                      {item.createdByEmail || 'N/A'}
+                    </p>
+                    <p className="m-0">
+                      Schedule: {formatDate(item.dateStart)} → {formatDate(item.dateEnd)}
+                    </p>
                     <p className="m-0">Location: {item.location || 'TBD'}</p>
                     {item.approvalNote ? (
                       <p className="m-0 text-amber-700">Previous note: {item.approvalNote}</p>
@@ -93,7 +101,9 @@ export default function ModerationQueues({
 
                 {activeType === 'sponsors' ? (
                   <>
-                    <p className="m-0">Contact: {item.contactName || 'Team lead'} · {item.contactEmail || 'N/A'}</p>
+                    <p className="m-0">
+                      Contact: {item.contactName || 'Team lead'} · {item.contactEmail || 'N/A'}
+                    </p>
                     <p className="m-0">Applied on: {formatDate(item.appliedAt)}</p>
                   </>
                 ) : null}
@@ -114,7 +124,9 @@ export default function ModerationQueues({
                     type="text"
                     value={noteValue}
                     onChange={(event) => onNoteChange(item.id, event.target.value)}
-                    placeholder={activeType === 'events' ? 'Optional feedback for managers' : 'Optional note'}
+                    placeholder={
+                      activeType === 'events' ? 'Optional feedback for managers' : 'Optional note'
+                    }
                     className="mt-1 w-full rounded-md border border-brand-green/40 bg-white px-3 py-2 text-sm text-brand-forest focus:border-brand-green focus:outline-none focus:ring-2 focus:ring-brand-green/40"
                   />
                 </label>

--- a/frontend/src/features/admin/ReportingPanel.jsx
+++ b/frontend/src/features/admin/ReportingPanel.jsx
@@ -55,8 +55,8 @@ export default function ReportingPanel({ onExport, exportState, format, onFormat
       ) : null}
 
       <p className="mt-4 text-xs text-brand-muted">
-        Exports include UTC timestamps. CSV opens in any spreadsheet, and the Excel option ships a ready-to-open workbook for
-        stakeholders who prefer .xls files.
+        Exports include UTC timestamps. CSV opens in any spreadsheet, and the Excel option ships a
+        ready-to-open workbook for stakeholders who prefer .xls files.
       </p>
     </DashboardCard>
   );

--- a/frontend/src/features/admin/UserManagementPanel.jsx
+++ b/frontend/src/features/admin/UserManagementPanel.jsx
@@ -57,7 +57,9 @@ export default function UserManagementPanel({
                 htmlFor={inputId}
                 className="flex items-center justify-between gap-3 rounded-md border border-brand-green/40 bg-white/80 px-3 py-2"
               >
-                <span className="text-sm font-medium text-brand-forest">{role.replace('_', ' ')}</span>
+                <span className="text-sm font-medium text-brand-forest">
+                  {role.replace('_', ' ')}
+                </span>
                 <input
                   id={inputId}
                   type="checkbox"
@@ -87,13 +89,11 @@ export default function UserManagementPanel({
         </label>
 
         {state.error ? <p className="text-sm font-medium text-red-600">{state.error}</p> : null}
-        {state.message ? <p className="text-sm font-semibold text-brand-green">{state.message}</p> : null}
+        {state.message ? (
+          <p className="text-sm font-semibold text-brand-green">{state.message}</p>
+        ) : null}
 
-        <button
-          type="submit"
-          className="btn-primary"
-          disabled={state.status === 'loading'}
-        >
+        <button type="submit" className="btn-primary" disabled={state.status === 'loading'}>
           {state.status === 'loading' ? 'Saving…' : 'Update user'}
         </button>
       </form>

--- a/frontend/src/features/auth/AuthContext.jsx
+++ b/frontend/src/features/auth/AuthContext.jsx
@@ -54,7 +54,13 @@ export function AuthProvider({ children }) {
       const stored = localStorage.getItem(STORAGE_KEY);
       if (!stored) {
         if (isMounted) {
-          setAuth({ status: 'unauthenticated', user: null, token: null, jti: null, expiresAt: null });
+          setAuth({
+            status: 'unauthenticated',
+            user: null,
+            token: null,
+            jti: null,
+            expiresAt: null,
+          });
         }
         return;
       }
@@ -73,7 +79,13 @@ export function AuthProvider({ children }) {
       } catch (error) {
         clearSessionStorage();
         if (isMounted) {
-          setAuth({ status: 'unauthenticated', user: null, token: null, jti: null, expiresAt: null });
+          setAuth({
+            status: 'unauthenticated',
+            user: null,
+            token: null,
+            jti: null,
+            expiresAt: null,
+          });
         }
       }
     })();

--- a/frontend/src/features/auth/CheckEmailPage.jsx
+++ b/frontend/src/features/auth/CheckEmailPage.jsx
@@ -72,8 +72,8 @@ export default function CheckEmailPage() {
         ) : null}
         <div className="mt-6 space-y-2 text-sm text-brand-muted">
           <p>
-            If you can’t find the email within a few minutes, check your spam folder or request another link from the
-            login page.
+            If you can’t find the email within a few minutes, check your spam folder or request
+            another link from the login page.
           </p>
           <p>
             Need help? Reach out to our admin at{' '}

--- a/frontend/src/features/auth/LoginPage.jsx
+++ b/frontend/src/features/auth/LoginPage.jsx
@@ -41,7 +41,9 @@ export default function LoginPage() {
         role="form"
       >
         <div className="space-y-2 text-center sm:text-left">
-          <h2 className="m-0 font-display text-2xl font-semibold text-brand-green">Welcome back to Onkur</h2>
+          <h2 className="m-0 font-display text-2xl font-semibold text-brand-green">
+            Welcome back to Onkur
+          </h2>
           <p className="m-0 text-sm text-brand-muted sm:text-base">
             Reconnect with the community and track the impact you are creating.
           </p>

--- a/frontend/src/features/auth/SignupPage.jsx
+++ b/frontend/src/features/auth/SignupPage.jsx
@@ -140,7 +140,9 @@ export default function SignupPage() {
         role="form"
       >
         <div className="space-y-2 text-center sm:text-left">
-          <h2 className="m-0 font-display text-2xl font-semibold text-brand-green">Join the Onkur movement</h2>
+          <h2 className="m-0 font-display text-2xl font-semibold text-brand-green">
+            Join the Onkur movement
+          </h2>
           <p className="m-0 text-sm text-brand-muted sm:text-base">
             Create an account to discover events, earn eco-badges, and follow your impact story.
           </p>
@@ -229,11 +231,15 @@ export default function SignupPage() {
                     key={role}
                     htmlFor={inputId}
                     className={`flex cursor-pointer flex-col gap-1 rounded-md border px-3 py-3 transition focus-within:outline focus-within:outline-2 focus-within:outline-offset-2 focus-within:outline-brand-green/50 ${
-                      checked ? 'border-brand-green bg-white shadow-[0_10px_22px_rgba(47,133,90,0.12)]' : 'border-brand-green/30 bg-white/80'
+                      checked
+                        ? 'border-brand-green bg-white shadow-[0_10px_22px_rgba(47,133,90,0.12)]'
+                        : 'border-brand-green/30 bg-white/80'
                     }`}
                   >
                     <div className="flex items-center justify-between gap-3">
-                      <span className="text-base font-semibold text-brand-forest">{detail.label}</span>
+                      <span className="text-base font-semibold text-brand-forest">
+                        {detail.label}
+                      </span>
                       <input
                         id={inputId}
                         type="checkbox"

--- a/frontend/src/features/dashboard/AdminDashboard.jsx
+++ b/frontend/src/features/dashboard/AdminDashboard.jsx
@@ -26,7 +26,12 @@ export default function AdminDashboard() {
   const [users, setUsers] = useState([]);
   const [userState, setUserState] = useState({ status: 'idle', error: '', message: '' });
   const [userForm, setUserForm] = useState({ userId: '', roles: [], isActive: true });
-  const [exportState, setExportState] = useState({ entity: '', format: 'csv', status: 'idle', error: '' });
+  const [exportState, setExportState] = useState({
+    entity: '',
+    format: 'csv',
+    status: 'idle',
+    error: '',
+  });
   const [exportFormat, setExportFormat] = useState('csv');
   const [impactAnalytics, setImpactAnalytics] = useState(null);
   const [impactState, setImpactState] = useState({ status: 'idle', error: '' });
@@ -55,7 +60,10 @@ export default function AdminDashboard() {
       setImpactAnalytics(response.overview || null);
       setImpactState({ status: 'success', error: '' });
     } catch (error) {
-      setImpactState({ status: 'error', error: error.message || 'Unable to load impact analytics' });
+      setImpactState({
+        status: 'error',
+        error: error.message || 'Unable to load impact analytics',
+      });
     }
   }, [token]);
 
@@ -67,7 +75,11 @@ export default function AdminDashboard() {
         const data = await fetchModerationQueue({ token, type: typeToLoad });
         setQueueState({ status: 'success', error: '', data });
       } catch (error) {
-        setQueueState({ status: 'error', error: error.message || 'Unable to load moderation queue', data: { items: [] } });
+        setQueueState({
+          status: 'error',
+          error: error.message || 'Unable to load moderation queue',
+          data: { items: [] },
+        });
       }
     },
     [queueType, token]
@@ -81,7 +93,11 @@ export default function AdminDashboard() {
       setUsers(Array.isArray(fetched) ? fetched : []);
       setUserState((prev) => ({ ...prev, status: 'idle' }));
     } catch (error) {
-      setUserState({ status: 'error', error: error.message || 'Unable to load users', message: '' });
+      setUserState({
+        status: 'error',
+        error: error.message || 'Unable to load users',
+        message: '',
+      });
     }
   }, [fetchUsers]);
 
@@ -159,7 +175,11 @@ export default function AdminDashboard() {
 
   const handleFormChange = useCallback(
     (changes) => {
-      setUserState((prev) => ({ ...prev, message: '', error: prev.status === 'error' ? prev.error : '' }));
+      setUserState((prev) => ({
+        ...prev,
+        message: '',
+        error: prev.status === 'error' ? prev.error : '',
+      }));
       setUserForm((prev) => {
         if (Object.prototype.hasOwnProperty.call(changes, 'userId')) {
           const selected = users.find((entry) => entry.id === changes.userId);
@@ -169,8 +189,8 @@ export default function AdminDashboard() {
               selected && Array.isArray(selected.roles) && selected.roles.length
                 ? selected.roles
                 : roleOptions.length
-                ? [roleOptions[0]]
-                : [],
+                  ? [roleOptions[0]]
+                  : [],
             isActive: selected ? selected.isActive !== false : true,
           };
         }
@@ -184,7 +204,11 @@ export default function AdminDashboard() {
     async (event) => {
       event.preventDefault();
       if (!userForm.userId || !userForm.roles.length) {
-        setUserState({ status: 'error', error: 'Select a user and at least one role', message: '' });
+        setUserState({
+          status: 'error',
+          error: 'Select a user and at least one role',
+          message: '',
+        });
         return;
       }
       if (!token) {
@@ -200,11 +224,17 @@ export default function AdminDashboard() {
           isActive: userForm.isActive,
         });
         const updated = response.user;
-        setUsers((prev) => prev.map((entry) => (entry.id === updated.id ? { ...entry, ...updated } : entry)));
+        setUsers((prev) =>
+          prev.map((entry) => (entry.id === updated.id ? { ...entry, ...updated } : entry))
+        );
         setUserState({ status: 'idle', error: '', message: 'User updated successfully.' });
         loadOverview();
       } catch (error) {
-        setUserState({ status: 'error', error: error.message || 'Unable to update user', message: '' });
+        setUserState({
+          status: 'error',
+          error: error.message || 'Unable to update user',
+          message: '',
+        });
       }
     },
     [token, userForm, loadOverview]
@@ -228,7 +258,12 @@ export default function AdminDashboard() {
         URL.revokeObjectURL(url);
         setExportState({ entity: '', format: formatToUse, status: 'idle', error: '' });
       } catch (error) {
-        setExportState({ entity: '', format: formatToUse, status: 'error', error: error.message || 'Export failed' });
+        setExportState({
+          entity: '',
+          format: formatToUse,
+          status: 'error',
+          error: error.message || 'Export failed',
+        });
       }
     },
     [token, exportFormat]
@@ -249,7 +284,10 @@ export default function AdminDashboard() {
       URL.revokeObjectURL(url);
       setImpactExportState({ status: 'idle', error: '' });
     } catch (error) {
-      setImpactExportState({ status: 'error', error: error.message || 'Unable to export analytics' });
+      setImpactExportState({
+        status: 'error',
+        error: error.message || 'Unable to export analytics',
+      });
     }
   }, [token]);
 
@@ -261,7 +299,9 @@ export default function AdminDashboard() {
   return (
     <div className="grid gap-5 md:[grid-template-columns:repeat(auto-fit,minmax(320px,1fr))]">
       <header className="flex flex-col gap-2 md:col-span-full">
-        <h2 className="m-0 font-display text-2xl font-semibold text-brand-forest">Operations center 🌿</h2>
+        <h2 className="m-0 font-display text-2xl font-semibold text-brand-forest">
+          Operations center 🌿
+        </h2>
         <p className="m-0 text-sm text-brand-muted sm:text-base">
           Review submissions, steer sponsorships, and keep the community roster current.
         </p>

--- a/frontend/src/features/dashboard/DashboardCard.jsx
+++ b/frontend/src/features/dashboard/DashboardCard.jsx
@@ -1,4 +1,10 @@
-export default function DashboardCard({ title, description, children, actions = [], className = '' }) {
+export default function DashboardCard({
+  title,
+  description,
+  children,
+  actions = [],
+  className = '',
+}) {
   const baseClasses =
     'flex h-full flex-col gap-3 rounded-[20px] bg-white p-6 shadow-[0_12px_28px_rgba(47,133,90,0.15)]';
   const combinedClasses = className ? `${baseClasses} ${className}` : baseClasses;

--- a/frontend/src/features/dashboard/DashboardRouter.jsx
+++ b/frontend/src/features/dashboard/DashboardRouter.jsx
@@ -29,19 +29,19 @@ function resolveHome(role) {
 export default function DashboardRouter() {
   const { user } = useAuth();
 
-  if (!user) {
-    return null;
-  }
-
   const normalizedRoles = useMemo(
-    () => normalizeRoles(user.roles, user.role),
-    [user.roles, user.role]
+    () => normalizeRoles(user?.roles ?? [], user?.role ?? null),
+    [user?.roles, user?.role]
   );
 
   const primaryRole = useMemo(
-    () => determinePrimaryRole(normalizedRoles, user.role),
-    [normalizedRoles, user.role]
+    () => determinePrimaryRole(normalizedRoles, user?.role ?? null),
+    [normalizedRoles, user?.role]
   );
+
+  if (!user) {
+    return null;
+  }
 
   const HomeComponent = resolveHome(primaryRole);
 
@@ -49,10 +49,7 @@ export default function DashboardRouter() {
     <Suspense fallback={<LoadingScreen label="Loading your dashboard" />}>
       <Routes>
         <Route index element={<HomeComponent />} />
-        <Route
-          path="events"
-          element={<EventsPage role={primaryRole} roles={normalizedRoles} />}
-        />
+        <Route path="events" element={<EventsPage role={primaryRole} roles={normalizedRoles} />} />
         <Route
           path="gallery"
           element={<GalleryPage role={primaryRole} roles={normalizedRoles} />}

--- a/frontend/src/features/dashboard/EventManagerDashboard.jsx
+++ b/frontend/src/features/dashboard/EventManagerDashboard.jsx
@@ -10,15 +10,14 @@ export default function EventManagerDashboard() {
   const firstName = user?.name?.split(' ')[0] || 'manager';
   useDocumentTitle(`Onkur | Welcome back, ${firstName} 🌱`);
 
-  const profileProgress = useMemo(
-    () => calculateProfileProgress(user?.profile),
-    [user?.profile]
-  );
+  const profileProgress = useMemo(() => calculateProfileProgress(user?.profile), [user?.profile]);
 
   return (
     <div className="flex flex-col gap-6">
       <header className="flex flex-col gap-2">
-        <h2 className="m-0 font-display text-2xl font-semibold text-brand-forest">Welcome back, {firstName} 🌱</h2>
+        <h2 className="m-0 font-display text-2xl font-semibold text-brand-forest">
+          Welcome back, {firstName} 🌱
+        </h2>
         <p className="m-0 text-sm text-brand-muted sm:text-base">
           Launch events, guide your volunteer crews, and share the impact your team creates.
         </p>

--- a/frontend/src/features/dashboard/EventsPage.jsx
+++ b/frontend/src/features/dashboard/EventsPage.jsx
@@ -49,14 +49,8 @@ export default function EventsPage({ role, roles = [] }) {
   const [supportStatus, setSupportStatus] = useState({ state: 'idle', message: '' });
 
   const firstName = useMemo(() => user?.name?.split(' ')[0] || 'friend', [user?.name]);
-  const activeRole = useMemo(
-    () => determinePrimaryRole(roles, role),
-    [roles, role]
-  );
-  const intro = useMemo(
-    () => buildIntro(activeRole, firstName),
-    [activeRole, firstName]
-  );
+  const activeRole = useMemo(() => determinePrimaryRole(roles, role), [roles, role]);
+  const intro = useMemo(() => buildIntro(activeRole, firstName), [activeRole, firstName]);
 
   const sponsorProfile = user?.sponsorProfile || null;
   const sponsorApproved = sponsorProfile?.status === 'APPROVED';
@@ -144,12 +138,14 @@ export default function EventsPage({ role, roles = [] }) {
         <p className="m-0 text-sm text-brand-muted sm:text-base">{intro.description}</p>
       </header>
       {status.phase === 'error' ? (
-        <p className="m-0 rounded-2xl border border-red-200 bg-red-50 p-4 text-sm text-red-700">{status.message}</p>
+        <p className="m-0 rounded-2xl border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+          {status.message}
+        </p>
       ) : null}
       {isSponsorMode && !sponsorApproved ? (
         <p className="m-0 rounded-2xl border border-brand-forest/20 bg-brand-sand/50 p-4 text-sm text-brand-muted">
-          Submit or update your sponsor profile to start pledging support for events. Admin approval is required before your
-          logo appears on event pages.
+          Submit or update your sponsor profile to start pledging support for events. Admin approval
+          is required before your logo appears on event pages.
         </p>
       ) : null}
       <DashboardCard
@@ -186,7 +182,9 @@ export default function EventsPage({ role, roles = [] }) {
         />
       ) : null}
       {supportStatus.state === 'error' ? (
-        <p className="m-0 rounded-2xl border border-red-200 bg-red-50 p-3 text-sm text-red-700">{supportStatus.message}</p>
+        <p className="m-0 rounded-2xl border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+          {supportStatus.message}
+        </p>
       ) : null}
       {supportStatus.state === 'success' ? (
         <p className="m-0 rounded-2xl border border-brand-green/20 bg-brand-sand/70 p-3 text-sm text-brand-forest">

--- a/frontend/src/features/dashboard/GalleryPage.jsx
+++ b/frontend/src/features/dashboard/GalleryPage.jsx
@@ -58,7 +58,10 @@ export default function GalleryPage({ role, roles = [] }) {
   const { user, token } = useAuth();
   const firstName = useMemo(() => user?.name?.split(' ')[0] || 'friend', [user?.name]);
   const normalizedRoles = useMemo(() => normalizeRoles(roles, role), [roles, role]);
-  const activeRole = useMemo(() => determinePrimaryRole(normalizedRoles, role), [normalizedRoles, role]);
+  const activeRole = useMemo(
+    () => determinePrimaryRole(normalizedRoles, role),
+    [normalizedRoles, role]
+  );
   const intro = useMemo(() => buildIntro(activeRole, firstName), [activeRole, firstName]);
 
   const [uploadableEvents, setUploadableEvents] = useState([]);
@@ -73,15 +76,15 @@ export default function GalleryPage({ role, roles = [] }) {
 
   const canUpload = useMemo(
     () => normalizedRoles.includes('VOLUNTEER') || normalizedRoles.includes('EVENT_MANAGER'),
-    [normalizedRoles],
+    [normalizedRoles]
   );
 
   const canSubmitStory = useMemo(
     () =>
       normalizedRoles.some((roleName) =>
-        ['VOLUNTEER', 'EVENT_MANAGER', 'SPONSOR', 'ADMIN'].includes(roleName),
+        ['VOLUNTEER', 'EVENT_MANAGER', 'SPONSOR', 'ADMIN'].includes(roleName)
       ),
-    [normalizedRoles],
+    [normalizedRoles]
   );
 
   useEffect(() => {
@@ -97,15 +100,18 @@ export default function GalleryPage({ role, roles = [] }) {
         if (normalizedRoles.includes('VOLUNTEER')) {
           requests.push(
             apiRequest('/api/me/signups', { token }).then((response) =>
-              (response.signups || []).map((signup) => ({ id: signup.event_id || signup.eventId, title: signup.title })),
-            ),
+              (response.signups || []).map((signup) => ({
+                id: signup.event_id || signup.eventId,
+                title: signup.title,
+              }))
+            )
           );
         }
         if (normalizedRoles.includes('EVENT_MANAGER') || normalizedRoles.includes('ADMIN')) {
           requests.push(
             apiRequest('/api/manager/events', { token }).then((response) =>
-              (response.events || []).map((event) => ({ id: event.id, title: event.title })),
-            ),
+              (response.events || []).map((event) => ({ id: event.id, title: event.title }))
+            )
           );
         }
         const resolved = await Promise.all(requests);
@@ -113,7 +119,7 @@ export default function GalleryPage({ role, roles = [] }) {
         const merged = uniqEvents(resolved.flat());
         setUploadableEvents(merged);
         setUploadStatus({ state: 'success', message: '' });
-        setSelectedEventId((current) => (current || (merged[0] ? merged[0].id : '')));
+        setSelectedEventId((current) => current || (merged[0] ? merged[0].id : ''));
       } catch (error) {
         if (!isMounted) return;
         setUploadStatus({ state: 'error', message: error.message || 'Unable to load your events' });
@@ -131,7 +137,7 @@ export default function GalleryPage({ role, roles = [] }) {
       const events = response.events || [];
       setGalleryEvents(events);
       setGalleryStatus({ state: 'success', message: '' });
-      setSelectedEventId((current) => (current || (events[0] ? events[0].id : '')));
+      setSelectedEventId((current) => current || (events[0] ? events[0].id : ''));
     } catch (error) {
       setGalleryStatus({ state: 'error', message: error.message || 'Unable to load galleries' });
     }
@@ -149,7 +155,7 @@ export default function GalleryPage({ role, roles = [] }) {
       }
       loadGalleryEvents();
     },
-    [loadGalleryEvents],
+    [loadGalleryEvents]
   );
 
   const handleStorySubmitted = useCallback(() => {
@@ -160,7 +166,10 @@ export default function GalleryPage({ role, roles = [] }) {
     setStoryCount(Array.isArray(stories) ? stories.length : 0);
   }, []);
 
-  const viewerEvents = useMemo(() => galleryEvents.filter((event) => event && event.id), [galleryEvents]);
+  const viewerEvents = useMemo(
+    () => galleryEvents.filter((event) => event && event.id),
+    [galleryEvents]
+  );
   const isAdmin = normalizedRoles.includes('ADMIN');
 
   return (
@@ -176,7 +185,11 @@ export default function GalleryPage({ role, roles = [] }) {
 
       {canSubmitStory && selectedEventId ? (
         <div className="flex flex-col gap-2">
-          <ImpactStoryComposer eventId={selectedEventId} token={token} onSubmitted={handleStorySubmitted} />
+          <ImpactStoryComposer
+            eventId={selectedEventId}
+            token={token}
+            onSubmitted={handleStorySubmitted}
+          />
           <p className="m-0 text-xs text-brand-muted">
             {storyCount
               ? `${storyCount} approved impact stor${storyCount === 1 ? 'y' : 'ies'} featured for this event.`

--- a/frontend/src/features/dashboard/ProfileCompletionCallout.jsx
+++ b/frontend/src/features/dashboard/ProfileCompletionCallout.jsx
@@ -11,10 +11,7 @@ export default function ProfileCompletionCallout({
     return null;
   }
 
-  const sectionClassName = [
-    'rounded-3xl border border-amber-200 bg-amber-50 p-5',
-    className,
-  ]
+  const sectionClassName = ['rounded-3xl border border-amber-200 bg-amber-50 p-5', className]
     .filter(Boolean)
     .join(' ');
 

--- a/frontend/src/features/dashboard/ProfilePage.jsx
+++ b/frontend/src/features/dashboard/ProfilePage.jsx
@@ -45,18 +45,17 @@ export default function ProfilePage({ role, roles = [] }) {
   const { token, user, refreshProfile } = useAuth();
   const [profile, setProfile] = useState(null);
   const [status, setStatus] = useState({ phase: 'loading', message: '' });
-  const [lookups, setLookups] = useState({ skills: [], interests: [], availability: [], states: [] });
+  const [lookups, setLookups] = useState({
+    skills: [],
+    interests: [],
+    availability: [],
+    states: [],
+  });
   const [citiesByState, setCitiesByState] = useState({});
 
   const firstName = useMemo(() => user?.name?.split(' ')[0] || 'there', [user?.name]);
-  const activeRole = useMemo(
-    () => determinePrimaryRole(roles, role),
-    [roles, role]
-  );
-  const intro = useMemo(
-    () => buildIntro(activeRole, firstName),
-    [activeRole, firstName]
-  );
+  const activeRole = useMemo(() => determinePrimaryRole(roles, role), [roles, role]);
+  const intro = useMemo(() => buildIntro(activeRole, firstName), [activeRole, firstName]);
 
   useDocumentTitle('Onkur | Profile');
 
@@ -77,16 +76,16 @@ export default function ProfilePage({ role, roles = [] }) {
 
     (async () => {
       try {
-        const [profileResponse] = await Promise.all([
-          fetchVolunteerProfile(token),
-          loadLookups(),
-        ]);
+        const [profileResponse] = await Promise.all([fetchVolunteerProfile(token), loadLookups()]);
         if (!active) return;
         setProfile(profileResponse);
         setStatus({ phase: 'ready', message: '' });
       } catch (error) {
         if (!active) return;
-        setStatus({ phase: 'error', message: error.message || 'Unable to load your profile right now.' });
+        setStatus({
+          phase: 'error',
+          message: error.message || 'Unable to load your profile right now.',
+        });
       }
     })();
 
@@ -146,7 +145,9 @@ export default function ProfilePage({ role, roles = [] }) {
         <p className="m-0 text-sm text-brand-muted sm:text-base">{intro.description}</p>
       </header>
       {status.phase === 'error' ? (
-        <p className="m-0 rounded-2xl border border-red-200 bg-red-50 p-4 text-sm text-red-700">{status.message}</p>
+        <p className="m-0 rounded-2xl border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+          {status.message}
+        </p>
       ) : null}
       <DashboardCard
         title="Profile & availability"
@@ -163,7 +164,9 @@ export default function ProfilePage({ role, roles = [] }) {
             initialCities={profile?.stateCode ? citiesByState[profile.stateCode] : []}
           />
         ) : (
-          <p className="m-0 text-sm text-brand-muted">We could not load your profile yet. Please try again shortly.</p>
+          <p className="m-0 text-sm text-brand-muted">
+            We could not load your profile yet. Please try again shortly.
+          </p>
         )}
       </DashboardCard>
     </div>

--- a/frontend/src/features/dashboard/SponsorDashboard.jsx
+++ b/frontend/src/features/dashboard/SponsorDashboard.jsx
@@ -27,10 +27,7 @@ export default function SponsorDashboard() {
   const firstName = user?.name?.split(' ')[0] || 'sponsor';
   useDocumentTitle(`Onkur | Thank you, ${firstName} 🌍`);
 
-  const profileProgress = useMemo(
-    () => calculateProfileProgress(user?.profile),
-    [user?.profile]
-  );
+  const profileProgress = useMemo(() => calculateProfileProgress(user?.profile), [user?.profile]);
 
   useEffect(() => {
     if (!token) {
@@ -83,8 +80,6 @@ export default function SponsorDashboard() {
       const response = await applyForSponsor(token, payload);
       setProfile(response.profile || response?.profile || null);
       await refreshDashboard();
-    } catch (submissionError) {
-      throw submissionError;
     } finally {
       setProfileSubmitting(false);
     }
@@ -99,8 +94,6 @@ export default function SponsorDashboard() {
       const response = await updateSponsorProfile(token, payload);
       setProfile(response.profile || response?.profile || null);
       await refreshDashboard();
-    } catch (updateError) {
-      throw updateError;
     } finally {
       setProfileSubmitting(false);
     }
@@ -117,9 +110,15 @@ export default function SponsorDashboard() {
       if (data.profile) {
         setProfile(data.profile);
       }
-      setReportStatus({ state: 'success', message: 'Latest impact report delivered to your inbox.' });
+      setReportStatus({
+        state: 'success',
+        message: 'Latest impact report delivered to your inbox.',
+      });
     } catch (reportError) {
-      setReportStatus({ state: 'error', message: reportError.message || 'Unable to refresh reports right now.' });
+      setReportStatus({
+        state: 'error',
+        message: reportError.message || 'Unable to refresh reports right now.',
+      });
     }
   };
 
@@ -152,7 +151,9 @@ export default function SponsorDashboard() {
         description="Introduce your organization, causes, and recognition preferences so we can celebrate your sponsorship the right way."
       />
       {error ? (
-        <p className="md:col-span-full m-0 rounded-2xl border border-red-200 bg-red-50 p-4 text-sm text-red-700">{error}</p>
+        <p className="md:col-span-full m-0 rounded-2xl border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+          {error}
+        </p>
       ) : null}
       {loading ? (
         <p className="md:col-span-full m-0 text-sm text-brand-muted">Loading sponsor workspace…</p>
@@ -183,7 +184,9 @@ export default function SponsorDashboard() {
               {reportStatus.state === 'loading' ? 'Refreshing…' : 'Email me an updated report'}
             </button>
             {reportStatus.state === 'error' ? (
-              <p className="m-0 rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-700">{reportStatus.message}</p>
+              <p className="m-0 rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+                {reportStatus.message}
+              </p>
             ) : null}
             {reportStatus.state === 'success' ? (
               <p className="m-0 rounded-xl border border-brand-green/20 bg-brand-sand/70 p-3 text-sm text-brand-forest">
@@ -194,8 +197,8 @@ export default function SponsorDashboard() {
               <ul className="m-0 list-disc space-y-2 pl-5 text-sm text-brand-muted">
                 {reports.map((report) => (
                   <li key={report.sponsorshipId}>
-                    {report.event?.title || 'Sponsored event'} · {report.totals?.totalHours || 0} volunteer hours ·{' '}
-                    {report.gallery?.viewCount || 0} gallery views
+                    {report.event?.title || 'Sponsored event'} · {report.totals?.totalHours || 0}{' '}
+                    volunteer hours · {report.gallery?.viewCount || 0} gallery views
                   </li>
                 ))}
               </ul>

--- a/frontend/src/features/dashboard/VolunteerDashboard.jsx
+++ b/frontend/src/features/dashboard/VolunteerDashboard.jsx
@@ -42,10 +42,7 @@ export default function VolunteerDashboard() {
   const [impactOverview, setImpactOverview] = useState(null);
   const [impactState, setImpactState] = useState({ status: 'idle', error: '' });
 
-  const profileProgress = useMemo(
-    () => calculateProfileProgress(dashboard?.profile),
-    [dashboard]
-  );
+  const profileProgress = useMemo(() => calculateProfileProgress(dashboard?.profile), [dashboard]);
 
   const totalBadgesEarned = useMemo(() => {
     if (!hoursSummary?.badges) return 0;
@@ -108,7 +105,10 @@ export default function VolunteerDashboard() {
       setImpactState({ status: 'success', error: '' });
     } catch (err) {
       if (!active) return;
-      setImpactState({ status: 'error', error: err.message || 'Unable to load community impact metrics.' });
+      setImpactState({
+        status: 'error',
+        error: err.message || 'Unable to load community impact metrics.',
+      });
     }
   }
 
@@ -125,8 +125,16 @@ export default function VolunteerDashboard() {
     try {
       await leaveEventRequest(token, eventId);
       setLeaveStatus((prev) => ({ ...prev, [eventId]: 'success' }));
-      setLeaveFeedback({ type: 'success', message: 'You left the event. We\u2019ll keep your calendar clear.' });
-      await Promise.all([refreshDashboard(token), refreshSignups(token), refreshHours(token), refreshImpact(token)]);
+      setLeaveFeedback({
+        type: 'success',
+        message: 'You left the event. We\u2019ll keep your calendar clear.',
+      });
+      await Promise.all([
+        refreshDashboard(token),
+        refreshSignups(token),
+        refreshHours(token),
+        refreshImpact(token),
+      ]);
     } catch (error) {
       setLeaveStatus((prev) => ({ ...prev, [eventId]: 'error' }));
       setLeaveFeedback({ type: 'error', message: error.message || 'Unable to leave this event.' });
@@ -144,7 +152,9 @@ export default function VolunteerDashboard() {
   return (
     <div className="grid gap-5 md:[grid-template-columns:repeat(auto-fit,minmax(280px,1fr))]">
       <header className="flex flex-col gap-2 md:col-span-full">
-        <h2 className="m-0 font-display text-2xl font-semibold text-brand-forest">Hi {firstName} 👋</h2>
+        <h2 className="m-0 font-display text-2xl font-semibold text-brand-forest">
+          Hi {firstName} 👋
+        </h2>
         <p className="m-0 text-sm text-brand-muted sm:text-base">
           {loading
             ? 'Loading your volunteer journey…'
@@ -198,7 +208,9 @@ export default function VolunteerDashboard() {
                   </button>
                 </div>
                 {leaveStatus[event.id] === 'error' ? (
-                  <p className="mt-2 text-xs text-red-600">We couldn’t update this signup. Try again.</p>
+                  <p className="mt-2 text-xs text-red-600">
+                    We couldn’t update this signup. Try again.
+                  </p>
                 ) : null}
               </li>
             ))}
@@ -215,10 +227,15 @@ export default function VolunteerDashboard() {
         ) : null}
         {pastEvents.length ? (
           <div className="mt-4 space-y-2">
-            <h5 className="m-0 text-xs font-semibold uppercase tracking-[0.14em] text-brand-muted">Recently completed</h5>
+            <h5 className="m-0 text-xs font-semibold uppercase tracking-[0.14em] text-brand-muted">
+              Recently completed
+            </h5>
             <ul className="m-0 list-none space-y-2 p-0 text-xs text-brand-muted">
               {pastEvents.slice(0, 3).map((event) => (
-                <li key={event.id} className="rounded-xl border border-brand-forest/10 bg-white px-3 py-2">
+                <li
+                  key={event.id}
+                  className="rounded-xl border border-brand-forest/10 bg-white px-3 py-2"
+                >
                   <span className="font-semibold text-brand-forest">{event.title}</span>
                   <span className="block">{formatShortDate(event.dateEnd)}</span>
                 </li>
@@ -249,22 +266,33 @@ export default function VolunteerDashboard() {
         {impactOverview ? (
           <ul className="m-0 list-none space-y-2 p-0 text-sm text-brand-muted">
             <li>
-              <strong className="text-brand-forest">{formatNumber(impactOverview.volunteerEngagement?.totalHours || 0)}</strong>{' '}
+              <strong className="text-brand-forest">
+                {formatNumber(impactOverview.volunteerEngagement?.totalHours || 0)}
+              </strong>{' '}
               volunteer hours recorded across the community.
             </li>
             <li>
-              {formatNumber(impactOverview.stories?.approved ?? 0, { maximumFractionDigits: 0 })} stories approved this season and{' '}
-              {formatNumber(impactOverview.eventParticipation?.eventsSupported ?? 0, { maximumFractionDigits: 0 })} events supported by volunteers.
+              {formatNumber(impactOverview.stories?.approved ?? 0, { maximumFractionDigits: 0 })}{' '}
+              stories approved this season and{' '}
+              {formatNumber(impactOverview.eventParticipation?.eventsSupported ?? 0, {
+                maximumFractionDigits: 0,
+              })}{' '}
+              events supported by volunteers.
             </li>
             <li>
-              Galleries reached {formatNumber(impactOverview.galleryEngagement?.totalViews || 0, { maximumFractionDigits: 0 })} views
-              and spotlighted sponsors {formatNumber(impactOverview.sponsorImpact?.sponsorMentions || 0, {
+              Galleries reached{' '}
+              {formatNumber(impactOverview.galleryEngagement?.totalViews || 0, {
+                maximumFractionDigits: 0,
+              })}{' '}
+              views and spotlighted sponsors{' '}
+              {formatNumber(impactOverview.sponsorImpact?.sponsorMentions || 0, {
                 maximumFractionDigits: 0,
               })}{' '}
               times.
             </li>
             <li>
-              Volunteer retention trend vs last quarter: <span className="font-semibold text-brand-forest">{retentionLabel}</span>
+              Volunteer retention trend vs last quarter:{' '}
+              <span className="font-semibold text-brand-forest">{retentionLabel}</span>
             </li>
           </ul>
         ) : null}

--- a/frontend/src/features/dashboard/roleUtils.js
+++ b/frontend/src/features/dashboard/roleUtils.js
@@ -16,13 +16,7 @@ export function normalizeRoles(roles, fallbackRole) {
   if (fallbackRole) {
     candidates.push(fallbackRole);
   }
-  const unique = Array.from(
-    new Set(
-      candidates
-        .map(normalizeRoleValue)
-        .filter(Boolean)
-    )
-  );
+  const unique = Array.from(new Set(candidates.map(normalizeRoleValue).filter(Boolean)));
   return unique.sort((a, b) => ROLE_PRIORITY.indexOf(a) - ROLE_PRIORITY.indexOf(b));
 }
 

--- a/frontend/src/features/event-gallery/EventGalleryViewer.jsx
+++ b/frontend/src/features/event-gallery/EventGalleryViewer.jsx
@@ -61,7 +61,9 @@ function GalleryGrid({ items, onSelect, isLoading }) {
     return (
       <div className="flex flex-col items-center gap-4 rounded-3xl border border-dashed border-brand-forest/20 bg-white/70 p-10 text-center">
         <span className="text-4xl">📸</span>
-        <p className="m-0 text-sm text-brand-muted">No approved media yet. Be the first to share impact from this event.</p>
+        <p className="m-0 text-sm text-brand-muted">
+          No approved media yet. Be the first to share impact from this event.
+        </p>
       </div>
     );
   }
@@ -114,7 +116,9 @@ export default function EventGalleryViewer({ eventId, token, refreshSignal = 0, 
           pageSize: 12,
           token,
         });
-        setItems((prev) => (nextPage === 1 ? response.media || [] : [...prev, ...(response.media || [])]));
+        setItems((prev) =>
+          nextPage === 1 ? response.media || [] : [...prev, ...(response.media || [])]
+        );
         setEventInfo(response.event || null);
         setMetrics(response.metrics || { viewCount: 0, lastViewedAt: null });
         setHasMore(Boolean(response.hasMore));
@@ -125,7 +129,7 @@ export default function EventGalleryViewer({ eventId, token, refreshSignal = 0, 
         setStatus('error');
       }
     },
-    [eventId, status, token],
+    [eventId, status, token]
   );
 
   useEffect(() => {
@@ -173,13 +177,16 @@ export default function EventGalleryViewer({ eventId, token, refreshSignal = 0, 
     if (observerRef.current) {
       observerRef.current.disconnect();
     }
-    observerRef.current = new IntersectionObserver((entries) => {
-      entries.forEach((entry) => {
-        if (entry.isIntersecting) {
-          loadPage(page + 1);
-        }
-      });
-    }, { threshold: 1 });
+    observerRef.current = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            loadPage(page + 1);
+          }
+        });
+      },
+      { threshold: 1 }
+    );
     observerRef.current.observe(sentinelRef.current);
     return () => {
       observerRef.current?.disconnect();
@@ -219,7 +226,11 @@ export default function EventGalleryViewer({ eventId, token, refreshSignal = 0, 
                   className="inline-flex items-center gap-2 rounded-full bg-brand-sand px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-brand-forest"
                 >
                   {sponsor.logoUrl ? (
-                    <img src={sponsor.logoUrl} alt={sponsor.orgName} className="h-5 w-5 rounded-full object-cover" />
+                    <img
+                      src={sponsor.logoUrl}
+                      alt={sponsor.orgName}
+                      className="h-5 w-5 rounded-full object-cover"
+                    />
                   ) : null}
                   {sponsor.orgName}
                 </span>
@@ -229,35 +240,48 @@ export default function EventGalleryViewer({ eventId, token, refreshSignal = 0, 
         </header>
       ) : null}
       {status === 'error' ? (
-        <div className="rounded-3xl border border-red-200 bg-red-50 p-4 text-sm text-red-700">{error}</div>
+        <div className="rounded-3xl border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+          {error}
+        </div>
       ) : null}
-      <GalleryGrid items={items} onSelect={(index) => setSelectedIndex(index)} isLoading={status === 'loading' && !items.length} />
-      {hasMore ? (
-        <div ref={sentinelRef} className="h-1 w-full" aria-hidden="true" />
-      ) : null}
+      <GalleryGrid
+        items={items}
+        onSelect={(index) => setSelectedIndex(index)}
+        isLoading={status === 'loading' && !items.length}
+      />
+      {hasMore ? <div ref={sentinelRef} className="h-1 w-full" aria-hidden="true" /> : null}
       {status === 'loading' ? (
         <p className="text-center text-sm text-brand-muted">Loading more moments…</p>
       ) : null}
       <section className="flex flex-col gap-3">
         <div className="flex flex-col gap-1">
           <h4 className="m-0 text-base font-semibold text-brand-forest">Impact stories</h4>
-          <p className="m-0 text-xs uppercase tracking-[0.24em] text-brand-muted">Community voices from this event</p>
+          <p className="m-0 text-xs uppercase tracking-[0.24em] text-brand-muted">
+            Community voices from this event
+          </p>
         </div>
         {storyState.status === 'error' ? (
-          <div className="rounded-3xl border border-red-200 bg-red-50 p-4 text-sm text-red-600">{storyState.error}</div>
+          <div className="rounded-3xl border border-red-200 bg-red-50 p-4 text-sm text-red-600">
+            {storyState.error}
+          </div>
         ) : null}
         {storyState.status === 'loading' && !stories.length ? (
           <div className="rounded-3xl border border-dashed border-brand-forest/15 bg-white/80 p-4 text-center text-sm text-brand-muted">
             Gathering stories…
           </div>
         ) : null}
-        <ImpactStoriesList stories={stories} emptyState="No stories yet. Share yours to inspire the next crew." />
+        <ImpactStoriesList
+          stories={stories}
+          emptyState="No stories yet. Share yours to inspire the next crew."
+        />
       </section>
       <GalleryLightbox
         media={activeMedia}
         onClose={() => setSelectedIndex(null)}
         onPrev={() => setSelectedIndex((prev) => (prev === null ? null : Math.max(0, prev - 1)))}
-        onNext={() => setSelectedIndex((prev) => (prev === null ? null : Math.min(items.length - 1, prev + 1)))}
+        onNext={() =>
+          setSelectedIndex((prev) => (prev === null ? null : Math.min(items.length - 1, prev + 1)))
+        }
       />
     </div>
   );

--- a/frontend/src/features/event-gallery/GalleryLightbox.jsx
+++ b/frontend/src/features/event-gallery/GalleryLightbox.jsx
@@ -2,10 +2,13 @@ import { useEffect } from 'react';
 
 function TagChip({ tag }) {
   if (!tag) return null;
-  const tone = tag.type === 'SPONSOR' ? 'bg-white text-brand-forest' : 'bg-brand-sand text-brand-forest';
+  const tone =
+    tag.type === 'SPONSOR' ? 'bg-white text-brand-forest' : 'bg-brand-sand text-brand-forest';
   const label = tag.label || tag.type;
   return (
-    <span className={`rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-[0.16em] ${tone}`}>
+    <span
+      className={`rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-[0.16em] ${tone}`}
+    >
       {label}
     </span>
   );

--- a/frontend/src/features/event-gallery/MediaUploadForm.jsx
+++ b/frontend/src/features/event-gallery/MediaUploadForm.jsx
@@ -20,7 +20,9 @@ function TagCheckboxList({ options, selected, onChange }) {
           <label
             key={id}
             className={`cursor-pointer rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] ${
-              isChecked ? 'border-brand-forest bg-brand-sand text-brand-forest' : 'border-brand-forest/20 text-brand-muted'
+              isChecked
+                ? 'border-brand-forest bg-brand-sand text-brand-forest'
+                : 'border-brand-forest/20 text-brand-muted'
             }`}
           >
             <input
@@ -30,7 +32,9 @@ function TagCheckboxList({ options, selected, onChange }) {
                 if (event.target.checked) {
                   onChange([...selected, option]);
                 } else {
-                  onChange(selected.filter((tag) => !(tag.id === option.id && tag.type === option.type)));
+                  onChange(
+                    selected.filter((tag) => !(tag.id === option.id && tag.type === option.type))
+                  );
                 }
               }}
               className="sr-only"
@@ -139,7 +143,10 @@ export default function MediaUploadForm({ token, events = [], onUploaded }) {
     };
   }, [selectedEvent, token]);
 
-  const canSubmit = useMemo(() => selectedEvent && file && status !== 'loading', [file, selectedEvent, status]);
+  const canSubmit = useMemo(
+    () => selectedEvent && file && status !== 'loading',
+    [file, selectedEvent, status]
+  );
 
   const handleFileChange = useCallback((event) => {
     const selected = event.target.files?.[0];
@@ -158,15 +165,12 @@ export default function MediaUploadForm({ token, events = [], onUploaded }) {
       }
       setCommunityTags([...communityTags, { type: 'COMMUNITY', id, label }]);
     },
-    [communityTags],
+    [communityTags]
   );
 
-  const handleRemoveCommunity = useCallback(
-    (id) => {
-      setCommunityTags((prev) => prev.filter((tag) => tag.id !== id));
-    },
-    [],
-  );
+  const handleRemoveCommunity = useCallback((id) => {
+    setCommunityTags((prev) => prev.filter((tag) => tag.id !== id));
+  }, []);
 
   const handleSubmit = useCallback(
     async (event) => {
@@ -185,7 +189,7 @@ export default function MediaUploadForm({ token, events = [], onUploaded }) {
             caption,
             tags,
           },
-          token,
+          token
         );
         setStatus('success');
         setMessage('Photo submitted for moderation. You will get an email when it is reviewed.');
@@ -202,14 +206,29 @@ export default function MediaUploadForm({ token, events = [], onUploaded }) {
         setMessage(error.message || 'Upload failed. Please try again.');
       }
     },
-    [canSubmit, caption, communityTags, file, onUploaded, selectedEvent, sponsorTags, token, volunteerTags],
+    [
+      canSubmit,
+      caption,
+      communityTags,
+      file,
+      onUploaded,
+      selectedEvent,
+      sponsorTags,
+      token,
+      volunteerTags,
+    ]
   );
 
   return (
-    <form onSubmit={handleSubmit} className="flex flex-col gap-5 rounded-3xl border border-brand-forest/10 bg-white/90 p-5">
+    <form
+      onSubmit={handleSubmit}
+      className="flex flex-col gap-5 rounded-3xl border border-brand-forest/10 bg-white/90 p-5"
+    >
       <header className="flex flex-col gap-1">
         <h3 className="m-0 text-lg font-semibold text-brand-forest">Share your impact story</h3>
-        <p className="m-0 text-sm text-brand-muted">Upload photos from events you attended so moderators can spotlight them.</p>
+        <p className="m-0 text-sm text-brand-muted">
+          Upload photos from events you attended so moderators can spotlight them.
+        </p>
       </header>
       <SelectField label="Event">
         <select
@@ -276,7 +295,9 @@ export default function MediaUploadForm({ token, events = [], onUploaded }) {
         {status === 'loading' ? 'Uploading…' : 'Submit for review'}
       </button>
       {message ? (
-        <p className={`m-0 text-sm ${status === 'error' ? 'text-red-600' : 'text-brand-forest'}`}>{message}</p>
+        <p className={`m-0 text-sm ${status === 'error' ? 'text-red-600' : 'text-brand-forest'}`}>
+          {message}
+        </p>
       ) : null}
     </form>
   );

--- a/frontend/src/features/event-gallery/ModerationQueue.jsx
+++ b/frontend/src/features/event-gallery/ModerationQueue.jsx
@@ -14,7 +14,9 @@ function ModerationCard({ item, onApprove, onReject }) {
         />
         <div className="flex flex-1 flex-col gap-2 text-sm text-brand-forest">
           <p className="m-0 font-semibold">{item.caption || 'No caption provided'}</p>
-          <p className="m-0 text-xs uppercase tracking-[0.24em] text-brand-muted">Uploaded {new Date(item.createdAt).toLocaleString()}</p>
+          <p className="m-0 text-xs uppercase tracking-[0.24em] text-brand-muted">
+            Uploaded {new Date(item.createdAt).toLocaleString()}
+          </p>
         </div>
       </div>
       <div className="flex flex-col gap-2">
@@ -80,7 +82,7 @@ export default function ModerationQueue({ token }) {
         setMessage(error.message || 'Approval failed');
       }
     },
-    [token],
+    [token]
   );
 
   const handleReject = useCallback(
@@ -92,7 +94,7 @@ export default function ModerationQueue({ token }) {
         setMessage(error.message || 'Rejection failed');
       }
     },
-    [token],
+    [token]
   );
 
   if (!token) {
@@ -103,16 +105,27 @@ export default function ModerationQueue({ token }) {
     <section className="flex flex-col gap-4 rounded-3xl border border-brand-forest/10 bg-brand-sand/40 p-5">
       <header className="flex flex-col gap-1">
         <h3 className="m-0 text-lg font-semibold text-brand-forest">Moderation queue</h3>
-        <p className="m-0 text-sm text-brand-muted">Approve or reject pending uploads so galleries stay safe and inspiring.</p>
+        <p className="m-0 text-sm text-brand-muted">
+          Approve or reject pending uploads so galleries stay safe and inspiring.
+        </p>
       </header>
-      {status === 'loading' ? <p className="text-sm text-brand-muted">Reviewing submissions…</p> : null}
+      {status === 'loading' ? (
+        <p className="text-sm text-brand-muted">Reviewing submissions…</p>
+      ) : null}
       {status === 'error' ? <p className="text-sm text-red-600">{message}</p> : null}
       {items.length === 0 && status === 'success' ? (
-        <p className="text-sm text-brand-muted">All clear! New submissions will appear here for review.</p>
+        <p className="text-sm text-brand-muted">
+          All clear! New submissions will appear here for review.
+        </p>
       ) : null}
       <div className="flex flex-col gap-3">
         {items.map((item) => (
-          <ModerationCard key={item.id} item={item} onApprove={handleApprove} onReject={handleReject} />
+          <ModerationCard
+            key={item.id}
+            item={item}
+            onApprove={handleApprove}
+            onReject={handleReject}
+          />
         ))}
       </div>
     </section>

--- a/frontend/src/features/event-gallery/PublicGalleryPage.jsx
+++ b/frontend/src/features/event-gallery/PublicGalleryPage.jsx
@@ -35,19 +35,26 @@ export default function PublicGalleryPage() {
     };
   }, []);
 
-  const selectedEvent = useMemo(() => events.find((event) => event.id === selectedEventId) || null, [events, selectedEventId]);
+  const selectedEvent = useMemo(
+    () => events.find((event) => event.id === selectedEventId) || null,
+    [events, selectedEventId]
+  );
 
   return (
     <div className="mx-auto flex w-full max-w-6xl flex-col gap-10 px-4 py-10 sm:px-6 lg:px-8">
       <header className="flex flex-col gap-3 text-center">
-        <h1 className="m-0 font-display text-3xl font-semibold text-brand-forest sm:text-4xl">Impact in full color</h1>
+        <h1 className="m-0 font-display text-3xl font-semibold text-brand-forest sm:text-4xl">
+          Impact in full color
+        </h1>
         <p className="m-0 text-base text-brand-muted sm:text-lg">
-          Browse approved galleries from recent Onkur events. Every story highlights volunteers, sponsors, and communities
-          thriving together.
+          Browse approved galleries from recent Onkur events. Every story highlights volunteers,
+          sponsors, and communities thriving together.
         </p>
       </header>
       {status === 'error' ? (
-        <div className="rounded-3xl border border-red-200 bg-red-50 p-4 text-sm text-red-600">{error}</div>
+        <div className="rounded-3xl border border-red-200 bg-red-50 p-4 text-sm text-red-600">
+          {error}
+        </div>
       ) : null}
       <section className="flex flex-col gap-4">
         <h2 className="m-0 text-lg font-semibold text-brand-forest">Featured galleries</h2>
@@ -67,7 +74,9 @@ export default function PublicGalleryPage() {
               <p className="m-0 text-xs uppercase tracking-[0.24em] text-brand-muted">
                 {event.mediaCount} photos · {event.theme || 'Community impact'}
               </p>
-              <p className="m-0 text-sm text-brand-muted">{event.location || 'Across our communities'}</p>
+              <p className="m-0 text-sm text-brand-muted">
+                {event.location || 'Across our communities'}
+              </p>
               {Array.isArray(event.sponsors) && event.sponsors.length ? (
                 <div className="flex flex-wrap items-center gap-2">
                   {event.sponsors.slice(0, 3).map((sponsor) => (
@@ -76,7 +85,11 @@ export default function PublicGalleryPage() {
                       className="inline-flex items-center gap-2 rounded-full bg-brand-sand px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-brand-forest"
                     >
                       {sponsor.logoUrl ? (
-                        <img src={sponsor.logoUrl} alt={sponsor.orgName} className="h-5 w-5 rounded-full object-cover" />
+                        <img
+                          src={sponsor.logoUrl}
+                          alt={sponsor.orgName}
+                          className="h-5 w-5 rounded-full object-cover"
+                        />
                       ) : null}
                       {sponsor.orgName}
                     </span>

--- a/frontend/src/features/event-manager/EventManagerWorkspace.jsx
+++ b/frontend/src/features/event-manager/EventManagerWorkspace.jsx
@@ -87,26 +87,23 @@ export default function EventManagerWorkspace() {
   const [newCategory, setNewCategory] = useState('');
   const [categoryState, setCategoryState] = useState({ status: 'idle', message: '' });
 
-  const authHeaders = useMemo(
-    () => ({ token }),
-    [token],
-  );
+  const authHeaders = useMemo(() => ({ token }), [token]);
 
   const skillMap = useMemo(
     () => new Map((lookups.skills || []).map((item) => [item.value, item.label])),
-    [lookups.skills],
+    [lookups.skills]
   );
   const interestMap = useMemo(
     () => new Map((lookups.interests || []).map((item) => [item.value, item.label])),
-    [lookups.interests],
+    [lookups.interests]
   );
   const availabilityMap = useMemo(
     () => new Map((lookups.availability || []).map((item) => [item.value, item.label])),
-    [lookups.availability],
+    [lookups.availability]
   );
   const cityOptions = useMemo(
     () => (form.stateCode && citiesStateCode === form.stateCode ? cities : []),
-    [form.stateCode, citiesStateCode, cities],
+    [form.stateCode, citiesStateCode, cities]
   );
 
   useEffect(() => {
@@ -124,7 +121,7 @@ export default function EventManagerWorkspace() {
           title: task.title,
           description: task.description || '',
           requiredCount: task.requiredCount || 1,
-        })),
+        }))
       );
     }
   }, [detail?.tasks]);
@@ -208,7 +205,8 @@ export default function EventManagerWorkspace() {
 
   const existingAssignments = useMemo(() => detail?.assignments || [], [detail?.assignments]);
 
-  const checkedInCount = detail?.signups?.filter((signup) => Boolean(signup.checkInAt))?.length || 0;
+  const checkedInCount =
+    detail?.signups?.filter((signup) => Boolean(signup.checkInAt))?.length || 0;
   const totalMinutes = detail?.event?.totalMinutes || 0;
 
   const handleFormChange = (event) => {
@@ -254,9 +252,7 @@ export default function EventManagerWorkspace() {
     event.preventDefault();
     setCreateState({ status: 'loading', message: '' });
     try {
-      const selectedCategory = lookups.categories.find(
-        (item) => item.value === form.categoryValue,
-      );
+      const selectedCategory = lookups.categories.find((item) => item.value === form.categoryValue);
       const payload = {
         title: form.title,
         description: form.description,
@@ -364,7 +360,11 @@ export default function EventManagerWorkspace() {
 
   const handleTaskFieldChange = (taskId, field, value) => {
     setTaskDrafts((prev) =>
-      prev.map((task) => (task.id === taskId ? { ...task, [field]: field === 'requiredCount' ? Number(value) : value } : task)),
+      prev.map((task) =>
+        task.id === taskId
+          ? { ...task, [field]: field === 'requiredCount' ? Number(value) : value }
+          : task
+      )
     );
   };
 
@@ -403,7 +403,7 @@ export default function EventManagerWorkspace() {
           title: task.title,
           description: task.description || '',
           requiredCount: task.requiredCount || 1,
-        })),
+        }))
       );
       setTaskState({ status: 'success', message: 'Tasks updated' });
       await refreshDetail(selectedId);
@@ -436,7 +436,10 @@ export default function EventManagerWorkspace() {
       setAssignmentState({ status: 'success', message: 'Volunteer assigned' });
       event.target.reset();
     } catch (error) {
-      setAssignmentState({ status: 'error', message: error.message || 'Unable to assign volunteer' });
+      setAssignmentState({
+        status: 'error',
+        message: error.message || 'Unable to assign volunteer',
+      });
     }
   };
 
@@ -444,11 +447,14 @@ export default function EventManagerWorkspace() {
     if (!selectedId) return;
     setAttendanceState((prev) => ({ ...prev, [signup.userId]: { status: 'loading' } }));
     try {
-      const response = await apiRequest(`/api/manager/events/${selectedId}/check-in/${signup.userId}`, {
-        ...authHeaders,
-        method: 'POST',
-        body: { action },
-      });
+      const response = await apiRequest(
+        `/api/manager/events/${selectedId}/check-in/${signup.userId}`,
+        {
+          ...authHeaders,
+          method: 'POST',
+          body: { action },
+        }
+      );
       const attendance = response.attendance;
       setDetail((prev) => {
         const updatedSignups = (prev.signups || []).map((item) =>
@@ -459,13 +465,13 @@ export default function EventManagerWorkspace() {
                 checkOutAt: attendance.checkOutAt,
                 minutes: attendance.minutes,
               }
-            : item,
+            : item
         );
         const updatedCheckedIn = updatedSignups.filter((item) => item.checkInAt).length;
         setEvents((eventsList) =>
           eventsList.map((event) =>
-            event.id === selectedId ? { ...event, checkedInCount: updatedCheckedIn } : event,
-          ),
+            event.id === selectedId ? { ...event, checkedInCount: updatedCheckedIn } : event
+          )
         );
         return {
           ...prev,
@@ -476,7 +482,10 @@ export default function EventManagerWorkspace() {
     } catch (error) {
       setAttendanceState((prev) => ({
         ...prev,
-        [signup.userId]: { status: 'error', message: error.message || 'Unable to update attendance' },
+        [signup.userId]: {
+          status: 'error',
+          message: error.message || 'Unable to update attendance',
+        },
       }));
     }
   };
@@ -515,7 +524,7 @@ export default function EventManagerWorkspace() {
         `${API_BASE}/api/manager/events/${selectedId}/report?format=csv`,
         {
           headers: { Authorization: `Bearer ${token}` },
-        },
+        }
       );
 
       if (!response.ok) {
@@ -564,7 +573,10 @@ export default function EventManagerWorkspace() {
             Draft the essentials now and publish when you&apos;re ready for volunteers to join.
           </p>
         </header>
-        <form className="grid gap-3 sm:[grid-template-columns:repeat(2,minmax(0,1fr))]" onSubmit={handleCreate}>
+        <form
+          className="grid gap-3 sm:[grid-template-columns:repeat(2,minmax(0,1fr))]"
+          onSubmit={handleCreate}
+        >
           {lookupsState.status === 'error' ? (
             <p className="sm:col-span-2 m-0 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-600">
               {lookupsState.error}
@@ -638,7 +650,7 @@ export default function EventManagerWorkspace() {
               className="min-h-[96px] rounded-lg border border-brand-forest/20 bg-brand-sand/30 px-3 py-2 text-sm shadow-sm focus:border-brand-green focus:outline-none"
               value={form.description}
               onChange={handleFormChange}
-              placeholder="Share the mission, who you&apos;re supporting, and what to expect."
+              placeholder="Share the mission, who you're supporting, and what to expect."
             />
           </label>
           <label className="flex flex-col gap-1 text-sm">
@@ -773,7 +785,9 @@ export default function EventManagerWorkspace() {
                 </option>
               ))}
             </select>
-            <span className="text-xs text-brand-muted">Select one or more focus skills that will help this event thrive.</span>
+            <span className="text-xs text-brand-muted">
+              Select one or more focus skills that will help this event thrive.
+            </span>
           </label>
           <label className="flex flex-col gap-1 text-sm sm:col-span-2">
             <span className="font-semibold text-brand-forest">Interest focus (optional)</span>
@@ -792,7 +806,9 @@ export default function EventManagerWorkspace() {
             </select>
           </label>
           <label className="flex flex-col gap-1 text-sm sm:col-span-2">
-            <span className="font-semibold text-brand-forest">Helpful availability windows (optional)</span>
+            <span className="font-semibold text-brand-forest">
+              Helpful availability windows (optional)
+            </span>
             <select
               multiple
               name="availability"
@@ -808,7 +824,11 @@ export default function EventManagerWorkspace() {
             </select>
           </label>
           <div className="flex flex-wrap items-center gap-3 sm:col-span-2">
-            <button type="submit" className="btn-primary" disabled={createState.status === 'loading'}>
+            <button
+              type="submit"
+              className="btn-primary"
+              disabled={createState.status === 'loading'}
+            >
               {createState.status === 'loading' ? 'Saving…' : 'Save draft'}
             </button>
             {createState.message ? (
@@ -828,11 +848,14 @@ export default function EventManagerWorkspace() {
         <header className="flex flex-col gap-1">
           <h3 className="m-0 text-xl font-semibold text-brand-forest">Your event pipeline</h3>
           <p className="m-0 text-sm text-brand-muted">
-            Monitor draft, published, and completed events in one glance. Volunteers see published events instantly.
+            Monitor draft, published, and completed events in one glance. Volunteers see published
+            events instantly.
           </p>
         </header>
         {listState.status === 'error' ? (
-          <p className="m-0 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{listState.error}</p>
+          <p className="m-0 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+            {listState.error}
+          </p>
         ) : null}
         <div className="grid gap-4 lg:[grid-template-columns:repeat(auto-fit,minmax(280px,1fr))]">
           {events.map((event) => {
@@ -933,15 +956,21 @@ export default function EventManagerWorkspace() {
             <div className="grid gap-5 lg:[grid-template-columns:360px_1fr]">
               <aside className="flex flex-col gap-4">
                 <div className="rounded-xl border border-brand-forest/10 bg-brand-sand/40 p-4">
-                  <h4 className="m-0 text-sm font-semibold uppercase tracking-wide text-brand-forest">Snapshot</h4>
+                  <h4 className="m-0 text-sm font-semibold uppercase tracking-wide text-brand-forest">
+                    Snapshot
+                  </h4>
                   <dl className="mt-3 space-y-2 text-sm text-brand-muted">
                     <div className="flex items-center justify-between">
                       <dt className="font-medium text-brand-forest">Status</dt>
-                      <dd className="m-0 uppercase text-xs font-semibold text-brand-green">{detail.event.status}</dd>
+                      <dd className="m-0 uppercase text-xs font-semibold text-brand-green">
+                        {detail.event.status}
+                      </dd>
                     </div>
                     <div className="flex flex-col gap-1">
                       <dt className="font-medium text-brand-forest">Location</dt>
-                      <dd className="m-0 text-sm text-brand-muted">{describeLocation(detail.event)}</dd>
+                      <dd className="m-0 text-sm text-brand-muted">
+                        {describeLocation(detail.event)}
+                      </dd>
                     </div>
                     <div className="flex items-center justify-between">
                       <dt className="font-medium text-brand-forest">Mode</dt>
@@ -966,12 +995,15 @@ export default function EventManagerWorkspace() {
                   </dl>
                   {detail.event.requirements ? (
                     <p className="mt-3 rounded-lg bg-white/70 p-3 text-xs text-brand-muted">
-                      <span className="font-semibold text-brand-forest">Requirements:</span> {detail.event.requirements}
+                      <span className="font-semibold text-brand-forest">Requirements:</span>{' '}
+                      {detail.event.requirements}
                     </p>
                   ) : null}
                   {detail.event.requiredSkills?.length ? (
                     <div className="mt-3 flex flex-col gap-2 text-xs">
-                      <span className="font-semibold uppercase tracking-wide text-brand-forest">Skills highlighted</span>
+                      <span className="font-semibold uppercase tracking-wide text-brand-forest">
+                        Skills highlighted
+                      </span>
                       <div className="flex flex-wrap gap-2">
                         {detail.event.requiredSkills.map((skill) => (
                           <span
@@ -986,7 +1018,9 @@ export default function EventManagerWorkspace() {
                   ) : null}
                   {detail.event.requiredInterests?.length ? (
                     <div className="mt-3 flex flex-col gap-2 text-xs">
-                      <span className="font-semibold uppercase tracking-wide text-brand-forest">Interest focus</span>
+                      <span className="font-semibold uppercase tracking-wide text-brand-forest">
+                        Interest focus
+                      </span>
                       <div className="flex flex-wrap gap-2">
                         {detail.event.requiredInterests.map((interest) => (
                           <span
@@ -1001,7 +1035,9 @@ export default function EventManagerWorkspace() {
                   ) : null}
                   {detail.event.requiredAvailability?.length ? (
                     <div className="mt-3 flex flex-col gap-2 text-xs">
-                      <span className="font-semibold uppercase tracking-wide text-brand-forest">Preferred availability</span>
+                      <span className="font-semibold uppercase tracking-wide text-brand-forest">
+                        Preferred availability
+                      </span>
                       <div className="flex flex-wrap gap-2">
                         {detail.event.requiredAvailability.map((slot) => (
                           <span
@@ -1017,7 +1053,9 @@ export default function EventManagerWorkspace() {
                 </div>
 
                 <div className="rounded-xl border border-brand-forest/10 bg-brand-sand/40 p-4">
-                  <h4 className="m-0 text-sm font-semibold uppercase tracking-wide text-brand-forest">Assignments</h4>
+                  <h4 className="m-0 text-sm font-semibold uppercase tracking-wide text-brand-forest">
+                    Assignments
+                  </h4>
                   <form className="mt-3 flex flex-col gap-3" onSubmit={handleAssign}>
                     <label className="flex flex-col gap-1 text-xs">
                       <span className="font-semibold text-brand-forest">Task</span>
@@ -1055,7 +1093,11 @@ export default function EventManagerWorkspace() {
                         ))}
                       </select>
                     </label>
-                    <button type="submit" className="btn-primary" disabled={assignmentState.status === 'loading'}>
+                    <button
+                      type="submit"
+                      className="btn-primary"
+                      disabled={assignmentState.status === 'loading'}
+                    >
                       {assignmentState.status === 'loading' ? 'Assigning…' : 'Assign volunteer'}
                     </button>
                     {assignmentState.message ? (
@@ -1071,7 +1113,9 @@ export default function EventManagerWorkspace() {
                 </div>
 
                 <div className="rounded-xl border border-brand-forest/10 bg-brand-sand/40 p-4">
-                  <h4 className="m-0 text-sm font-semibold uppercase tracking-wide text-brand-forest">Impact report</h4>
+                  <h4 className="m-0 text-sm font-semibold uppercase tracking-wide text-brand-forest">
+                    Impact report
+                  </h4>
                   <div className="mt-3 flex flex-col gap-2 text-xs text-brand-muted">
                     <button
                       type="button"
@@ -1096,20 +1140,22 @@ export default function EventManagerWorkspace() {
                       <span className="text-xs text-red-600">{reportState.downloadError}</span>
                     ) : null}
                     {reportState.downloadStatus === 'success' ? (
-                      <span className="text-xs font-semibold text-brand-green">Report downloaded.</span>
+                      <span className="text-xs font-semibold text-brand-green">
+                        Report downloaded.
+                      </span>
                     ) : null}
-                      {report ? (
-                        <div className="rounded-lg bg-white/80 p-3 text-xs text-brand-muted">
-                          <p className="m-0 font-semibold text-brand-forest">{report.event.title}</p>
-                          <p className="m-0">Signups: {report.totals.totalSignups}</p>
-                          <p className="m-0">Checked in: {report.totals.totalCheckedIn}</p>
-                          <p className="m-0">Attendance rate: {report.totals.attendanceRate}%</p>
-                          <p className="m-0">Total hours: {report.totals.totalHours}</p>
-                          <p className="m-0 text-[11px] text-brand-forest">
-                            CSV downloads include these metrics plus timestamps and attendee details.
-                          </p>
-                        </div>
-                      ) : null}
+                    {report ? (
+                      <div className="rounded-lg bg-white/80 p-3 text-xs text-brand-muted">
+                        <p className="m-0 font-semibold text-brand-forest">{report.event.title}</p>
+                        <p className="m-0">Signups: {report.totals.totalSignups}</p>
+                        <p className="m-0">Checked in: {report.totals.totalCheckedIn}</p>
+                        <p className="m-0">Attendance rate: {report.totals.attendanceRate}%</p>
+                        <p className="m-0">Total hours: {report.totals.totalHours}</p>
+                        <p className="m-0 text-[11px] text-brand-forest">
+                          CSV downloads include these metrics plus timestamps and attendee details.
+                        </p>
+                      </div>
+                    ) : null}
                   </div>
                 </div>
               </aside>
@@ -1118,7 +1164,9 @@ export default function EventManagerWorkspace() {
                 <section className="rounded-xl border border-brand-forest/10 bg-brand-sand/40 p-4">
                   <header className="flex flex-col gap-1 pb-3">
                     <h4 className="m-0 text-base font-semibold text-brand-forest">Task board</h4>
-                    <p className="m-0 text-xs text-brand-muted">Outline roles so volunteers know how they&apos;ll contribute.</p>
+                    <p className="m-0 text-xs text-brand-muted">
+                      Outline roles so volunteers know how they&apos;ll contribute.
+                    </p>
                   </header>
                   <div className="flex flex-col gap-3">
                     {taskDrafts.map((task) => (
@@ -1129,18 +1177,24 @@ export default function EventManagerWorkspace() {
                             <input
                               className="rounded-md border border-brand-forest/20 bg-white px-3 py-2 text-sm focus:border-brand-green focus:outline-none"
                               value={task.title}
-                              onChange={(event) => handleTaskFieldChange(task.id, 'title', event.target.value)}
+                              onChange={(event) =>
+                                handleTaskFieldChange(task.id, 'title', event.target.value)
+                              }
                               placeholder="Registration desk lead"
                             />
                           </label>
                           <label className="flex flex-col gap-1 text-xs">
-                            <span className="font-semibold text-brand-forest">Needed volunteers</span>
+                            <span className="font-semibold text-brand-forest">
+                              Needed volunteers
+                            </span>
                             <input
                               type="number"
                               min="1"
                               className="rounded-md border border-brand-forest/20 bg-white px-3 py-2 text-sm focus:border-brand-green focus:outline-none"
                               value={task.requiredCount}
-                              onChange={(event) => handleTaskFieldChange(task.id, 'requiredCount', event.target.value)}
+                              onChange={(event) =>
+                                handleTaskFieldChange(task.id, 'requiredCount', event.target.value)
+                              }
                             />
                           </label>
                           <label className="flex flex-col gap-1 text-xs sm:col-span-2">
@@ -1148,7 +1202,9 @@ export default function EventManagerWorkspace() {
                             <textarea
                               className="min-h-[60px] rounded-md border border-brand-forest/20 bg-white px-3 py-2 text-sm focus:border-brand-green focus:outline-none"
                               value={task.description}
-                              onChange={(event) => handleTaskFieldChange(task.id, 'description', event.target.value)}
+                              onChange={(event) =>
+                                handleTaskFieldChange(task.id, 'description', event.target.value)
+                              }
                               placeholder="Outline duties, schedules, or special gear."
                             />
                           </label>
@@ -1172,7 +1228,12 @@ export default function EventManagerWorkspace() {
                       + Add task
                     </button>
                     <div className="flex items-center gap-3">
-                      <button type="button" className="btn-primary" onClick={handleSaveTasks} disabled={taskState.status === 'loading'}>
+                      <button
+                        type="button"
+                        className="btn-primary"
+                        onClick={handleSaveTasks}
+                        disabled={taskState.status === 'loading'}
+                      >
                         {taskState.status === 'loading' ? 'Saving…' : 'Save tasks'}
                       </button>
                       {taskState.message ? (
@@ -1191,16 +1252,27 @@ export default function EventManagerWorkspace() {
                 <section className="rounded-xl border border-brand-forest/10 bg-brand-sand/40 p-4">
                   <header className="flex flex-col gap-1 pb-3">
                     <h4 className="m-0 text-base font-semibold text-brand-forest">Crew roster</h4>
-                    <p className="m-0 text-xs text-brand-muted">See who&apos;s on each task and share quick updates.</p>
+                    <p className="m-0 text-xs text-brand-muted">
+                      See who&apos;s on each task and share quick updates.
+                    </p>
                   </header>
                   {existingAssignments.length ? (
                     <ul className="m-0 space-y-3 p-0">
                       {existingAssignments.map((assignment) => (
-                        <li key={assignment.id} className="list-none rounded-lg bg-white/80 p-3 shadow-sm">
-                          <p className="m-0 text-sm font-semibold text-brand-forest">{assignment.taskTitle}</p>
+                        <li
+                          key={assignment.id}
+                          className="list-none rounded-lg bg-white/80 p-3 shadow-sm"
+                        >
+                          <p className="m-0 text-sm font-semibold text-brand-forest">
+                            {assignment.taskTitle}
+                          </p>
                           <p className="m-0 text-xs text-brand-muted">{assignment.volunteerName}</p>
-                          <p className="m-0 text-xs text-brand-muted">{assignment.volunteerEmail}</p>
-                          <p className="m-0 text-xs text-brand-muted">Status: {assignment.status}</p>
+                          <p className="m-0 text-xs text-brand-muted">
+                            {assignment.volunteerEmail}
+                          </p>
+                          <p className="m-0 text-xs text-brand-muted">
+                            Status: {assignment.status}
+                          </p>
                         </li>
                       ))}
                     </ul>
@@ -1211,27 +1283,40 @@ export default function EventManagerWorkspace() {
 
                 <section className="rounded-xl border border-brand-forest/10 bg-brand-sand/40 p-4">
                   <header className="flex flex-col gap-1 pb-3">
-                    <h4 className="m-0 text-base font-semibold text-brand-forest">Attendance tracker</h4>
-                    <p className="m-0 text-xs text-brand-muted">Check volunteers in as they arrive and close out their hours.</p>
+                    <h4 className="m-0 text-base font-semibold text-brand-forest">
+                      Attendance tracker
+                    </h4>
+                    <p className="m-0 text-xs text-brand-muted">
+                      Check volunteers in as they arrive and close out their hours.
+                    </p>
                   </header>
                   {detail.signups?.length ? (
                     <div className="space-y-3">
                       {detail.signups.map((signup) => {
                         const state = attendanceState[signup.userId] || { status: 'idle' };
                         return (
-                          <article key={signup.userId} className="rounded-lg bg-white/80 p-3 shadow-sm">
+                          <article
+                            key={signup.userId}
+                            className="rounded-lg bg-white/80 p-3 shadow-sm"
+                          >
                             <header className="flex flex-col gap-1">
-                              <h5 className="m-0 text-sm font-semibold text-brand-forest">{signup.name}</h5>
+                              <h5 className="m-0 text-sm font-semibold text-brand-forest">
+                                {signup.name}
+                              </h5>
                               <p className="m-0 text-xs text-brand-muted">{signup.email}</p>
                             </header>
                             <dl className="mt-2 grid gap-2 text-xs text-brand-muted [grid-template-columns:repeat(auto-fit,minmax(140px,1fr))]">
                               <div>
                                 <dt className="font-semibold text-brand-forest">Checked in</dt>
-                                <dd className="m-0">{signup.checkInAt ? formatDate(signup.checkInAt) : 'Not yet'}</dd>
+                                <dd className="m-0">
+                                  {signup.checkInAt ? formatDate(signup.checkInAt) : 'Not yet'}
+                                </dd>
                               </div>
                               <div>
                                 <dt className="font-semibold text-brand-forest">Checked out</dt>
-                                <dd className="m-0">{signup.checkOutAt ? formatDate(signup.checkOutAt) : 'Not yet'}</dd>
+                                <dd className="m-0">
+                                  {signup.checkOutAt ? formatDate(signup.checkOutAt) : 'Not yet'}
+                                </dd>
                               </div>
                               <div>
                                 <dt className="font-semibold text-brand-forest">Minutes</dt>
@@ -1245,15 +1330,27 @@ export default function EventManagerWorkspace() {
                                 onClick={() => handleAttendance(signup, 'check-in')}
                                 disabled={Boolean(signup.checkInAt) || state.status === 'loading'}
                               >
-                                {signup.checkInAt ? 'Checked in' : state.status === 'loading' ? 'Working…' : 'Check in'}
+                                {signup.checkInAt
+                                  ? 'Checked in'
+                                  : state.status === 'loading'
+                                    ? 'Working…'
+                                    : 'Check in'}
                               </button>
                               <button
                                 type="button"
                                 className="btn-primary"
                                 onClick={() => handleAttendance(signup, 'check-out')}
-                                disabled={!signup.checkInAt || Boolean(signup.checkOutAt) || state.status === 'loading'}
+                                disabled={
+                                  !signup.checkInAt ||
+                                  Boolean(signup.checkOutAt) ||
+                                  state.status === 'loading'
+                                }
                               >
-                                {signup.checkOutAt ? 'Completed' : state.status === 'loading' ? 'Working…' : 'Check out'}
+                                {signup.checkOutAt
+                                  ? 'Completed'
+                                  : state.status === 'loading'
+                                    ? 'Working…'
+                                    : 'Check out'}
                               </button>
                               {state.status === 'error' ? (
                                 <span className="text-xs text-red-600">{state.message}</span>

--- a/frontend/src/features/health/HealthCheck.jsx
+++ b/frontend/src/features/health/HealthCheck.jsx
@@ -9,7 +9,7 @@ function HealthCheck() {
 
   useEffect(() => {
     fetch(`${API_BASE}/api/health`)
-      .then(res => res.json())
+      .then((res) => res.json())
       .then(
         (result) => {
           setData(result);

--- a/frontend/src/features/impact/ImpactStoriesList.jsx
+++ b/frontend/src/features/impact/ImpactStoriesList.jsx
@@ -17,7 +17,8 @@ export default function ImpactStoriesList({ stories = [], emptyState }) {
       <div className="flex flex-col gap-3 rounded-3xl border border-dashed border-brand-forest/20 bg-white/80 p-6 text-center">
         <span className="text-4xl">🌱</span>
         <p className="m-0 text-sm text-brand-muted">
-          {emptyState || 'No impact stories yet. Share your experience to inspire future volunteers.'}
+          {emptyState ||
+            'No impact stories yet. Share your experience to inspire future volunteers.'}
         </p>
       </div>
     );
@@ -34,20 +35,24 @@ export default function ImpactStoriesList({ stories = [], emptyState }) {
             <h4 className="m-0 text-base font-semibold text-brand-forest">{story.title}</h4>
             <p className="m-0 text-xs uppercase tracking-[0.2em] text-brand-muted">
               {story.authorName ? `By ${story.authorName}` : 'Community story'}
-              {story.publishedAt ? ` · ${formatDate(story.publishedAt)}` : story.createdAt ? ` · ${formatDate(story.createdAt)}` : ''}
+              {story.publishedAt
+                ? ` · ${formatDate(story.publishedAt)}`
+                : story.createdAt
+                  ? ` · ${formatDate(story.createdAt)}`
+                  : ''}
             </p>
           </header>
           <p className="m-0 text-sm leading-6 text-brand-muted">{story.excerpt || story.body}</p>
           {Array.isArray(story.mediaIds) && story.mediaIds.length ? (
             <div className="flex flex-wrap gap-2 text-xs text-brand-muted">
-            {story.mediaIds.slice(0, 3).map((mediaId, index) => (
-              <span
-                key={mediaId}
-                className="rounded-full bg-brand-sand px-3 py-1 font-semibold uppercase tracking-[0.18em] text-brand-forest"
-              >
-                Highlight {index + 1}
-              </span>
-            ))}
+              {story.mediaIds.slice(0, 3).map((mediaId, index) => (
+                <span
+                  key={mediaId}
+                  className="rounded-full bg-brand-sand px-3 py-1 font-semibold uppercase tracking-[0.18em] text-brand-forest"
+                >
+                  Highlight {index + 1}
+                </span>
+              ))}
               {story.mediaIds.length > 3 ? (
                 <span className="rounded-full bg-brand-sand px-3 py-1 font-semibold uppercase tracking-[0.18em] text-brand-forest">
                   +{story.mediaIds.length - 3}

--- a/frontend/src/features/impact/ImpactStoryComposer.jsx
+++ b/frontend/src/features/impact/ImpactStoryComposer.jsx
@@ -31,7 +31,10 @@ export default function ImpactStoryComposer({ eventId, token, onSubmitted }) {
         setMediaState({ state: 'success', message: '' });
       } catch (error) {
         if (!active) return;
-        setMediaState({ state: 'error', message: error.message || 'Unable to load gallery highlights.' });
+        setMediaState({
+          state: 'error',
+          message: error.message || 'Unable to load gallery highlights.',
+        });
       }
     })();
     return () => {
@@ -46,20 +49,17 @@ export default function ImpactStoryComposer({ eventId, token, onSubmitted }) {
     setStatus({ state: 'idle', message: '' });
   }, [eventId]);
 
-  const toggleMedia = useCallback(
-    (mediaId) => {
-      setSelectedMedia((prev) => {
-        if (prev.includes(mediaId)) {
-          return prev.filter((value) => value !== mediaId);
-        }
-        if (prev.length >= MAX_MEDIA_SELECTION) {
-          return prev;
-        }
-        return [...prev, mediaId];
-      });
-    },
-    [],
-  );
+  const toggleMedia = useCallback((mediaId) => {
+    setSelectedMedia((prev) => {
+      if (prev.includes(mediaId)) {
+        return prev.filter((value) => value !== mediaId);
+      }
+      if (prev.length >= MAX_MEDIA_SELECTION) {
+        return prev;
+      }
+      return [...prev, mediaId];
+    });
+  }, []);
 
   const handleSubmit = useCallback(
     async (event) => {
@@ -76,16 +76,22 @@ export default function ImpactStoryComposer({ eventId, token, onSubmitted }) {
           body: body.trim(),
           mediaIds: selectedMedia,
         });
-        setStatus({ state: 'success', message: 'Thanks for sharing! Your story is now awaiting moderator review.' });
+        setStatus({
+          state: 'success',
+          message: 'Thanks for sharing! Your story is now awaiting moderator review.',
+        });
         setTitle('');
         setBody('');
         setSelectedMedia([]);
         onSubmitted?.(result.story);
       } catch (error) {
-        setStatus({ state: 'error', message: error.message || 'Unable to submit your story right now.' });
+        setStatus({
+          state: 'error',
+          message: error.message || 'Unable to submit your story right now.',
+        });
       }
     },
-    [body, canSubmit, eventId, onSubmitted, selectedMedia, title, token],
+    [body, canSubmit, eventId, onSubmitted, selectedMedia, title, token]
   );
 
   if (!token || !eventId) {
@@ -93,11 +99,15 @@ export default function ImpactStoryComposer({ eventId, token, onSubmitted }) {
   }
 
   return (
-    <form onSubmit={handleSubmit} className="flex flex-col gap-4 rounded-3xl border border-brand-forest/15 bg-white/90 p-5 shadow-sm">
+    <form
+      onSubmit={handleSubmit}
+      className="flex flex-col gap-4 rounded-3xl border border-brand-forest/15 bg-white/90 p-5 shadow-sm"
+    >
       <header className="flex flex-col gap-1 text-left">
         <h3 className="m-0 text-lg font-semibold text-brand-forest">Share an impact story</h3>
         <p className="m-0 text-sm text-brand-muted">
-          Celebrate the community you served. Stories go live after an admin review and appear in the event gallery.
+          Celebrate the community you served. Stories go live after an admin review and appear in
+          the event gallery.
         </p>
       </header>
       <label className="flex flex-col gap-2 text-sm font-medium text-brand-forest">
@@ -120,10 +130,14 @@ export default function ImpactStoryComposer({ eventId, token, onSubmitted }) {
           maxLength={500}
           className="w-full rounded-xl border border-brand-green/40 bg-white px-4 py-3 text-sm text-brand-forest shadow-inner focus:border-brand-forest focus:outline-none focus:ring-2 focus:ring-brand-forest/40"
         />
-        <span className="text-xs font-normal text-brand-muted">{body.trim().length} / 500 characters</span>
+        <span className="text-xs font-normal text-brand-muted">
+          {body.trim().length} / 500 characters
+        </span>
       </label>
       <section className="flex flex-col gap-2">
-        <p className="m-0 text-sm font-semibold text-brand-forest">Highlight up to {MAX_MEDIA_SELECTION} gallery photos</p>
+        <p className="m-0 text-sm font-semibold text-brand-forest">
+          Highlight up to {MAX_MEDIA_SELECTION} gallery photos
+        </p>
         {mediaState.state === 'error' ? (
           <p className="m-0 text-xs text-red-600">{mediaState.message}</p>
         ) : null}
@@ -137,11 +151,15 @@ export default function ImpactStoryComposer({ eventId, token, onSubmitted }) {
                   type="button"
                   onClick={() => toggleMedia(media.id)}
                   className={`flex items-center gap-2 rounded-2xl border px-3 py-2 text-xs font-semibold uppercase tracking-[0.18em] transition ${
-                    checked ? 'border-brand-forest bg-brand-sand text-brand-forest' : 'border-brand-forest/20 bg-white text-brand-forest'
+                    checked
+                      ? 'border-brand-forest bg-brand-sand text-brand-forest'
+                      : 'border-brand-forest/20 bg-white text-brand-forest'
                   }`}
                 >
                   <span className="inline-flex h-2.5 w-2.5 rounded-full border border-brand-forest bg-white">
-                    {checked ? <span className="block h-full w-full rounded-full bg-brand-forest" /> : null}
+                    {checked ? (
+                      <span className="block h-full w-full rounded-full bg-brand-forest" />
+                    ) : null}
                   </span>
                   {media.caption ? media.caption.slice(0, 24) : 'Gallery photo'}
                 </button>
@@ -149,7 +167,9 @@ export default function ImpactStoryComposer({ eventId, token, onSubmitted }) {
             })
           ) : (
             <p className="m-0 text-xs text-brand-muted">
-              {mediaState.state === 'loading' ? 'Loading gallery highlights…' : 'Upload photos to this gallery to link them here.'}
+              {mediaState.state === 'loading'
+                ? 'Loading gallery highlights…'
+                : 'Upload photos to this gallery to link them here.'}
             </p>
           )}
         </div>
@@ -158,7 +178,9 @@ export default function ImpactStoryComposer({ eventId, token, onSubmitted }) {
         <p className="m-0 text-sm font-semibold text-red-600">{status.message}</p>
       ) : null}
       {status.state === 'success' ? (
-        <p className="m-0 rounded-xl bg-brand-sand/80 px-3 py-2 text-sm font-medium text-brand-forest">{status.message}</p>
+        <p className="m-0 rounded-xl bg-brand-sand/80 px-3 py-2 text-sm font-medium text-brand-forest">
+          {status.message}
+        </p>
       ) : null}
       <button
         type="submit"

--- a/frontend/src/features/landing/HomePage.jsx
+++ b/frontend/src/features/landing/HomePage.jsx
@@ -71,9 +71,10 @@ export default function HomePage() {
           <span className="home-hero__eyebrow">Nature · Sustainability · Community</span>
           <h2>Grow local impact with Onkur.</h2>
           <p>
-            Onkur is the mobile-first volunteering platform that brings volunteers, event managers, sponsors, and administrators
-            together to spark lasting environmental and social change. Plan immersive events, capture living galleries, and measure
-            the ripple effects of every action.
+            Onkur is the mobile-first volunteering platform that brings volunteers, event managers,
+            sponsors, and administrators together to spark lasting environmental and social change.
+            Plan immersive events, capture living galleries, and measure the ripple effects of every
+            action.
           </p>
           <div className="home-hero__actions">
             <Link className="btn-primary" to="/signup">
@@ -107,8 +108,9 @@ export default function HomePage() {
       <section className="home-highlight">
         <h3>Designed as a living ecosystem</h3>
         <p>
-          Every workflow, report, and gallery is crafted to feel warm, transparent, and actionable. Onkur keeps teams aligned
-          with responsive tools that work beautifully on mobile and desktop alike.
+          Every workflow, report, and gallery is crafted to feel warm, transparent, and actionable.
+          Onkur keeps teams aligned with responsive tools that work beautifully on mobile and
+          desktop alike.
         </p>
         <div className="home-highlight__grid">
           {HIGHLIGHTS.map((item) => (
@@ -125,8 +127,8 @@ export default function HomePage() {
         <div className="home-roles__intro">
           <h3>Built for every steward of change</h3>
           <p>
-            Purposeful features adapt to each role so every stakeholder—volunteers, organizers, sponsors, and admins—can focus on
-            what matters most: nurturing impact.
+            Purposeful features adapt to each role so every stakeholder—volunteers, organizers,
+            sponsors, and admins—can focus on what matters most: nurturing impact.
           </p>
         </div>
         <div className="home-roles__grid">
@@ -148,15 +150,24 @@ export default function HomePage() {
           <ul>
             <li>
               <strong>Morning check-in</strong>
-              <p>Review upcoming events, confirm volunteers, and highlight new sponsorship opportunities.</p>
+              <p>
+                Review upcoming events, confirm volunteers, and highlight new sponsorship
+                opportunities.
+              </p>
             </li>
             <li>
               <strong>In the field</strong>
-              <p>Capture photos, log attendance, and notify your community—all from a mobile-friendly workspace.</p>
+              <p>
+                Capture photos, log attendance, and notify your community—all from a mobile-friendly
+                workspace.
+              </p>
             </li>
             <li>
               <strong>Evening reflection</strong>
-              <p>Publish gallery stories, unlock eco-badges, and send dashboards that prove your collective impact.</p>
+              <p>
+                Publish gallery stories, unlock eco-badges, and send dashboards that prove your
+                collective impact.
+              </p>
             </li>
           </ul>
         </div>
@@ -183,7 +194,8 @@ export default function HomePage() {
         <div className="home-cta__content">
           <h3>Ready to nurture your next act of care?</h3>
           <p>
-            Join Onkur to connect purpose-driven people, illuminate every story, and measure the change you cultivate together.
+            Join Onkur to connect purpose-driven people, illuminate every story, and measure the
+            change you cultivate together.
           </p>
         </div>
         <div className="home-cta__actions">

--- a/frontend/src/features/sponsors/SponsorImpactSummary.jsx
+++ b/frontend/src/features/sponsors/SponsorImpactSummary.jsx
@@ -6,7 +6,9 @@ function MetricCard({ label, value, icon }) {
       <span className="text-2xl" aria-hidden="true">
         {icon}
       </span>
-      <span className="text-xs font-semibold uppercase tracking-[0.24em] text-brand-muted">{label}</span>
+      <span className="text-xs font-semibold uppercase tracking-[0.24em] text-brand-muted">
+        {label}
+      </span>
       <span className="text-lg font-semibold text-brand-forest">{value}</span>
     </div>
   );

--- a/frontend/src/features/sponsors/SponsorOnboardingForm.jsx
+++ b/frontend/src/features/sponsors/SponsorOnboardingForm.jsx
@@ -10,7 +10,12 @@ const DEFAULT_VALUES = {
   brandGuidelines: '',
 };
 
-export default function SponsorOnboardingForm({ initialValues, onSubmit, isSubmitting, ctaLabel = 'Submit application' }) {
+export default function SponsorOnboardingForm({
+  initialValues,
+  onSubmit,
+  isSubmitting,
+  ctaLabel = 'Submit application',
+}) {
   const [form, setForm] = useState(DEFAULT_VALUES);
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
@@ -150,8 +155,16 @@ export default function SponsorOnboardingForm({ initialValues, onSubmit, isSubmi
           placeholder="Recognition preferences, tone, hero statements"
         />
       </label>
-      {error ? <p className="m-0 rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-700">{error}</p> : null}
-      {success ? <p className="m-0 rounded-xl border border-brand-green/20 bg-brand-sand/70 p-3 text-sm text-brand-forest">{success}</p> : null}
+      {error ? (
+        <p className="m-0 rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+          {error}
+        </p>
+      ) : null}
+      {success ? (
+        <p className="m-0 rounded-xl border border-brand-green/20 bg-brand-sand/70 p-3 text-sm text-brand-forest">
+          {success}
+        </p>
+      ) : null}
       <div className="flex flex-wrap items-center gap-3">
         <button type="submit" className="btn-primary" disabled={isSubmitting}>
           {isSubmitting ? 'Saving…' : ctaLabel}

--- a/frontend/src/features/sponsors/SponsorSponsorshipList.jsx
+++ b/frontend/src/features/sponsors/SponsorSponsorshipList.jsx
@@ -8,10 +8,12 @@ function StatusBadge({ status }) {
     normalized === 'APPROVED'
       ? 'bg-brand-forest/10 text-brand-forest'
       : normalized === 'DECLINED'
-      ? 'bg-red-100 text-red-700'
-      : 'bg-brand-sand text-brand-muted';
+        ? 'bg-red-100 text-red-700'
+        : 'bg-brand-sand text-brand-muted';
   return (
-    <span className={`inline-flex items-center gap-1 rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] ${tone}`}>
+    <span
+      className={`inline-flex items-center gap-1 rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] ${tone}`}
+    >
       {normalized}
     </span>
   );
@@ -26,7 +28,9 @@ function ContributionDetails({ sponsorship }) {
     <div className="flex flex-col gap-3 rounded-3xl border border-brand-forest/10 bg-white/80 p-4">
       <header className="flex flex-col gap-1">
         <div className="flex flex-wrap items-center justify-between gap-2">
-          <h4 className="m-0 text-base font-semibold text-brand-forest">{sponsorship.event?.title || 'Sponsored event'}</h4>
+          <h4 className="m-0 text-base font-semibold text-brand-forest">
+            {sponsorship.event?.title || 'Sponsored event'}
+          </h4>
           <StatusBadge status={sponsorship.status} />
         </div>
         <p className="m-0 text-xs uppercase tracking-[0.22em] text-brand-muted">

--- a/frontend/src/features/sponsors/SponsorSupportForm.jsx
+++ b/frontend/src/features/sponsors/SponsorSupportForm.jsx
@@ -5,7 +5,13 @@ const SUPPORT_TYPES = [
   { value: 'IN_KIND', label: 'In-kind resources' },
 ];
 
-export default function SponsorSupportForm({ event, onSubmit, onCancel, isSubmitting = false, initialSponsorship }) {
+export default function SponsorSupportForm({
+  event,
+  onSubmit,
+  onCancel,
+  isSubmitting = false,
+  initialSponsorship,
+}) {
   const [type, setType] = useState('FUNDS');
   const [amount, setAmount] = useState('');
   const [notes, setNotes] = useState('');
@@ -66,7 +72,10 @@ export default function SponsorSupportForm({ event, onSubmit, onCancel, isSubmit
       </header>
       <div className="flex flex-col gap-3">
         {SUPPORT_TYPES.map((option) => (
-          <label key={option.value} className="flex items-center gap-3 rounded-2xl border border-brand-forest/15 bg-brand-sand/60 px-4 py-3 text-sm font-medium text-brand-forest">
+          <label
+            key={option.value}
+            className="flex items-center gap-3 rounded-2xl border border-brand-forest/15 bg-brand-sand/60 px-4 py-3 text-sm font-medium text-brand-forest"
+          >
             <input
               type="radio"
               name="sponsorType"
@@ -103,8 +112,16 @@ export default function SponsorSupportForm({ event, onSubmit, onCancel, isSubmit
           placeholder="Share how you plan to support or recognition preferences."
         />
       </label>
-      {error ? <p className="m-0 rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-700">{error}</p> : null}
-      {message ? <p className="m-0 rounded-xl border border-brand-green/20 bg-brand-sand/70 p-3 text-sm text-brand-forest">{message}</p> : null}
+      {error ? (
+        <p className="m-0 rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+          {error}
+        </p>
+      ) : null}
+      {message ? (
+        <p className="m-0 rounded-xl border border-brand-green/20 bg-brand-sand/70 p-3 text-sm text-brand-forest">
+          {message}
+        </p>
+      ) : null}
       <div className="flex flex-wrap items-center gap-3">
         <button type="submit" className="btn-primary" disabled={isSubmitting}>
           {isSubmitting ? 'Submitting…' : 'Confirm sponsorship'}

--- a/frontend/src/features/volunteer/EventDiscovery.jsx
+++ b/frontend/src/features/volunteer/EventDiscovery.jsx
@@ -95,14 +95,20 @@ export default function EventDiscovery({
     } catch (error) {
       setActionStates((prev) => ({
         ...prev,
-        [eventId]: { status: 'leave-error', message: error.message || 'Unable to leave this event.' },
+        [eventId]: {
+          status: 'leave-error',
+          message: error.message || 'Unable to leave this event.',
+        },
       }));
     }
   };
 
   return (
     <div className="flex flex-col gap-5">
-      <form className="grid gap-3 rounded-2xl border border-brand-forest/10 bg-brand-sand/60 p-4" onSubmit={handleSubmit}>
+      <form
+        className="grid gap-3 rounded-2xl border border-brand-forest/10 bg-brand-sand/60 p-4"
+        onSubmit={handleSubmit}
+      >
         <div className="grid gap-3 sm:[grid-template-columns:repeat(2,minmax(0,1fr))]">
           <label className="flex flex-col gap-1 text-sm">
             <span className="font-semibold text-brand-forest">Category</span>
@@ -161,15 +167,15 @@ export default function EventDiscovery({
             Reset
           </button>
           <span className="text-xs text-brand-muted">
-            {events.length ? `${events.length} event${events.length === 1 ? '' : 's'} shown` : 'No events to show yet'}
+            {events.length
+              ? `${events.length} event${events.length === 1 ? '' : 's'} shown`
+              : 'No events to show yet'}
           </span>
         </div>
       </form>
 
       <div className="space-y-4">
-        {isLoading ? (
-          <p className="m-0 text-sm text-brand-muted">Loading opportunities…</p>
-        ) : null}
+        {isLoading ? <p className="m-0 text-sm text-brand-muted">Loading opportunities…</p> : null}
         {!events.length && !isLoading ? (
           <p className="m-0 rounded-xl border border-dashed border-brand-forest/30 bg-white p-4 text-sm text-brand-muted">
             No events match these filters yet. Try widening your search or check back soon.
@@ -218,7 +224,11 @@ export default function EventDiscovery({
                       className="inline-flex items-center gap-2 rounded-full bg-brand-sand px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-brand-forest"
                     >
                       {sponsor.logoUrl ? (
-                        <img src={sponsor.logoUrl} alt={sponsor.orgName} className="h-5 w-5 rounded-full object-cover" />
+                        <img
+                          src={sponsor.logoUrl}
+                          alt={sponsor.orgName}
+                          className="h-5 w-5 rounded-full object-cover"
+                        />
                       ) : null}
                       {sponsor.orgName}
                     </span>
@@ -255,12 +265,15 @@ export default function EventDiscovery({
                   </button>
                 )}
                 {!isSponsorMode && alreadyJoined ? (
-                  <span className="text-xs font-semibold text-brand-green">You\u2019re confirmed!</span>
+                  <span className="text-xs font-semibold text-brand-green">
+                    You\u2019re confirmed!
+                  </span>
                 ) : null}
                 {!isSponsorMode && isFull && !alreadyJoined ? (
                   <span className="text-xs text-brand-muted">This event reached capacity.</span>
                 ) : null}
-                {!isSponsorMode && (state.status === 'join-error' || state.status === 'leave-error') ? (
+                {!isSponsorMode &&
+                (state.status === 'join-error' || state.status === 'leave-error') ? (
                   <span className="text-xs text-red-600">{state.message}</span>
                 ) : null}
                 {!isSponsorMode && state.status === 'join-success' && !alreadyJoined ? (
@@ -284,10 +297,10 @@ export default function EventDiscovery({
               ? `${totalAvailable} event${totalAvailable === 1 ? '' : 's'} ready for sponsorship.`
               : 'All listed events are already fully supported.'
             : totalAvailable
-            ? `${totalAvailable} event${totalAvailable === 1 ? '' : 's'} still ${
-                totalAvailable === 1 ? 'has' : 'have'
-              } volunteer spots available.`
-            : 'All listed events are currently full.'}
+              ? `${totalAvailable} event${totalAvailable === 1 ? '' : 's'} still ${
+                  totalAvailable === 1 ? 'has' : 'have'
+                } volunteer spots available.`
+              : 'All listed events are currently full.'}
         </p>
       ) : null}
     </div>

--- a/frontend/src/features/volunteer/HoursTracker.jsx
+++ b/frontend/src/features/volunteer/HoursTracker.jsx
@@ -94,62 +94,63 @@ export default function HoursTracker({ summary, signups, onLogHours }) {
         <h4 className="m-0 text-base font-semibold text-brand-forest">Log new hours</h4>
         {hasEligibleEvents ? (
           <form className="flex flex-col gap-3" onSubmit={handleSubmit}>
-          <label className="flex flex-col gap-1 text-sm">
-            <span className="font-semibold text-brand-forest">Event</span>
-            <select
-              className="rounded-lg border border-brand-forest/20 bg-white px-3 py-2 text-sm shadow-sm focus:border-brand-green focus:outline-none"
-              name="eventId"
-              value={form.eventId}
-              onChange={handleChange}
-            >
-              {upcomingOptions.map((option) => (
-                <option key={option.id} value={option.id}>
-                  {option.title}
-                  {option.isUpcoming ? ' (upcoming)' : ''}
-                </option>
-              ))}
-            </select>
-          </label>
-          <label className="flex flex-col gap-1 text-sm">
-            <span className="font-semibold text-brand-forest">Hours completed</span>
-            <input
-              className="rounded-lg border border-brand-forest/20 bg-white px-3 py-2 text-sm shadow-sm focus:border-brand-green focus:outline-none"
-              type="number"
-              name="hours"
-              min="0"
-              step="0.25"
-              placeholder="e.g. 2"
-              value={form.hours}
-              onChange={handleChange}
-            />
-          </label>
-          <label className="flex flex-col gap-1 text-sm">
-            <span className="font-semibold text-brand-forest">Notes (optional)</span>
-            <textarea
-              className="min-h-[72px] rounded-lg border border-brand-forest/20 bg-white px-3 py-2 text-sm shadow-sm focus:border-brand-green focus:outline-none"
-              name="note"
-              placeholder="What did you work on?"
-              value={form.note}
-              onChange={handleChange}
-            />
-          </label>
-          {status ? (
-            <p
-              className={`m-0 text-sm ${
-                status.type === 'success' ? 'text-brand-green' : 'text-red-600'
-              }`}
-            >
-              {status.message}
-            </p>
-          ) : null}
-          <button type="submit" className="btn-primary" disabled={submitting}>
-            {submitting ? 'Saving…' : 'Log hours'}
-          </button>
-        </form>
+            <label className="flex flex-col gap-1 text-sm">
+              <span className="font-semibold text-brand-forest">Event</span>
+              <select
+                className="rounded-lg border border-brand-forest/20 bg-white px-3 py-2 text-sm shadow-sm focus:border-brand-green focus:outline-none"
+                name="eventId"
+                value={form.eventId}
+                onChange={handleChange}
+              >
+                {upcomingOptions.map((option) => (
+                  <option key={option.id} value={option.id}>
+                    {option.title}
+                    {option.isUpcoming ? ' (upcoming)' : ''}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="flex flex-col gap-1 text-sm">
+              <span className="font-semibold text-brand-forest">Hours completed</span>
+              <input
+                className="rounded-lg border border-brand-forest/20 bg-white px-3 py-2 text-sm shadow-sm focus:border-brand-green focus:outline-none"
+                type="number"
+                name="hours"
+                min="0"
+                step="0.25"
+                placeholder="e.g. 2"
+                value={form.hours}
+                onChange={handleChange}
+              />
+            </label>
+            <label className="flex flex-col gap-1 text-sm">
+              <span className="font-semibold text-brand-forest">Notes (optional)</span>
+              <textarea
+                className="min-h-[72px] rounded-lg border border-brand-forest/20 bg-white px-3 py-2 text-sm shadow-sm focus:border-brand-green focus:outline-none"
+                name="note"
+                placeholder="What did you work on?"
+                value={form.note}
+                onChange={handleChange}
+              />
+            </label>
+            {status ? (
+              <p
+                className={`m-0 text-sm ${
+                  status.type === 'success' ? 'text-brand-green' : 'text-red-600'
+                }`}
+              >
+                {status.message}
+              </p>
+            ) : null}
+            <button type="submit" className="btn-primary" disabled={submitting}>
+              {submitting ? 'Saving…' : 'Log hours'}
+            </button>
+          </form>
         ) : (
           <div className="flex flex-col gap-3 rounded-2xl border border-dashed border-brand-forest/30 bg-brand-ivory p-4 text-sm text-brand-muted">
             <p className="m-0">
-              Join an event to log your time. Head to the events hub to browse opportunities and RSVP.
+              Join an event to log your time. Head to the events hub to browse opportunities and
+              RSVP.
             </p>
             <Link className="btn-primary self-start" to="/app/events">
               Explore events
@@ -173,7 +174,9 @@ export default function HoursTracker({ summary, signups, onLogHours }) {
                   <p className="m-0 font-semibold text-brand-forest">{badge.label}</p>
                   <p className="m-0 text-xs text-brand-muted">{badge.description}</p>
                 </div>
-                <span className="text-xs font-semibold text-brand-muted">{badge.thresholdHours} hrs</span>
+                <span className="text-xs font-semibold text-brand-muted">
+                  {badge.thresholdHours} hrs
+                </span>
               </div>
               {badge.earned ? (
                 <p className="mt-2 text-xs font-semibold text-brand-green">

--- a/frontend/src/features/volunteer/ProfileEditor.jsx
+++ b/frontend/src/features/volunteer/ProfileEditor.jsx
@@ -78,11 +78,11 @@ export default function ProfileEditor({
 
   const skillOptions = useMemo(
     () => mergeSelections(lookups?.skills || [], form.skills),
-    [lookups?.skills, form.skills],
+    [lookups?.skills, form.skills]
   );
   const interestOptions = useMemo(
     () => mergeSelections(lookups?.interests || [], form.interests),
-    [lookups?.interests, form.interests],
+    [lookups?.interests, form.interests]
   );
 
   const hasChanges = useMemo(() => {
@@ -128,7 +128,11 @@ export default function ProfileEditor({
       try {
         const response = await onRequestCities(form.stateCode);
         if (cancelled) return;
-        const options = Array.isArray(response) ? response : Array.isArray(response?.cities) ? response.cities : [];
+        const options = Array.isArray(response)
+          ? response
+          : Array.isArray(response?.cities)
+            ? response.cities
+            : [];
         setCityOptions(options);
         if (!options.some((option) => option.value === form.citySlug)) {
           setForm((prev) => ({ ...prev, citySlug: '' }));
@@ -217,11 +221,11 @@ export default function ProfileEditor({
 
   const selectedSkills = useMemo(
     () => form.skills.map((value) => ({ value, label: resolveLabel(skillOptions, value) })),
-    [form.skills, skillOptions],
+    [form.skills, skillOptions]
   );
   const selectedInterests = useMemo(
     () => form.interests.map((value) => ({ value, label: resolveLabel(interestOptions, value) })),
-    [form.interests, interestOptions],
+    [form.interests, interestOptions]
   );
 
   return (
@@ -269,7 +273,10 @@ export default function ProfileEditor({
           {selectedSkills.length ? (
             <div className="flex flex-wrap gap-2 text-xs">
               {selectedSkills.map((item) => (
-                <span key={item.value} className="rounded-full bg-brand-mint/40 px-3 py-1 text-brand-forest">
+                <span
+                  key={item.value}
+                  className="rounded-full bg-brand-mint/40 px-3 py-1 text-brand-forest"
+                >
                   {item.label}
                 </span>
               ))}
@@ -319,7 +326,10 @@ export default function ProfileEditor({
           {selectedInterests.length ? (
             <div className="flex flex-wrap gap-2 text-xs">
               {selectedInterests.map((item) => (
-                <span key={item.value} className="rounded-full bg-brand-sand px-3 py-1 text-brand-forest">
+                <span
+                  key={item.value}
+                  className="rounded-full bg-brand-sand px-3 py-1 text-brand-forest"
+                >
                   {item.label}
                 </span>
               ))}
@@ -370,7 +380,9 @@ export default function ProfileEditor({
               onChange={handleSelectChange}
               disabled={!form.stateCode || !cityOptions.length}
             >
-              <option value="">{form.stateCode ? 'Select your city' : 'Choose a state first'}</option>
+              <option value="">
+                {form.stateCode ? 'Select your city' : 'Choose a state first'}
+              </option>
               {cityOptions.map((city) => (
                 <option key={city.value} value={city.value}>
                   {city.label}

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -12,12 +12,8 @@ const renderTree = () =>
     React.createElement(
       BrowserRouter,
       null,
-      React.createElement(
-        AuthProvider,
-        null,
-        React.createElement(App),
-      ),
-    ),
+      React.createElement(AuthProvider, null, React.createElement(App))
+    )
   );
 
 ReactDOM.createRoot(document.getElementById('root')).render(renderTree());

--- a/frontend/src/test/setupTests.js
+++ b/frontend/src/test/setupTests.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -23,8 +23,7 @@ const ensureCrossoriginPlugin = {
   transformIndexHtml: {
     enforce: 'post',
     transform(html) {
-      const escapeForRegex = (value) =>
-        value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      const escapeForRegex = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
       const addCrossoriginBefore = (tag, attribute) => {
         if (/\bcrossorigin\b/.test(tag)) {
@@ -37,16 +36,14 @@ const ensureCrossoriginPlugin = {
         }
 
         return (
-          tag.slice(0, attributeIndex) +
-          'crossorigin="anonymous" ' +
-          tag.slice(attributeIndex)
+          tag.slice(0, attributeIndex) + 'crossorigin="anonymous" ' + tag.slice(attributeIndex)
         );
       };
 
       const addCrossoriginToScript = (source, scriptSrc) => {
         const pattern = new RegExp(
           `<script\\s+type="module"[^>]*src="${escapeForRegex(scriptSrc)}"[^>]*>\\s*</script>`,
-          'g',
+          'g'
         );
 
         return source.replace(pattern, (tag) => addCrossoriginBefore(tag, 'src='));
@@ -55,7 +52,7 @@ const ensureCrossoriginPlugin = {
       const addCrossoriginToLink = (source, linkHref) => {
         const pattern = new RegExp(
           `<link\\s+rel="modulepreload"[^>]*href="${escapeForRegex(linkHref)}"[^>]*>`,
-          'g',
+          'g'
         );
 
         return source.replace(pattern, (tag) => addCrossoriginBefore(tag, 'href='));
@@ -120,5 +117,11 @@ export default defineConfig({
         },
       },
     },
+  },
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: './src/test/setupTests.js',
+    mockReset: true,
   },
 });


### PR DESCRIPTION
## Summary
- add repo hygiene assets including gitignore, Prettier config, environment templates, contribution docs, and README/wiki updates
- pin and script backend/frontend toolchains with ESLint + Prettier configs and wire up a CI workflow that runs format, lint, test, and build
- add a frontend Vitest smoke test and related config changes while resolving lint issues uncovered by the new tooling

## Testing
- `cd backend && npm run format:check`
- `cd backend && npm run lint`
- `cd backend && npm test`
- `cd frontend && npm run format:check`
- `cd frontend && npm run lint`
- `cd frontend && npm run test`
- `cd frontend && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68cdd176278083338ab2753b22d59a4e